### PR TITLE
refactor: extract transport to sdk

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,8 +23,6 @@
   },
   "dependencies": {
     "@onekeyfe/hd-transport": "*",
-    "@onekeyfe/hd-transport-http": "*",
-    "@onekeyfe/hd-transport-react-native": "*",
     "@onekeyfe/rollout": "1.0.6",
     "axios": "^0.27.2",
     "parse-uri": "^1.0.7",

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -221,11 +221,15 @@ export const initConnector = () => {
   return _connector;
 };
 
-export const init = async (settings: ConnectSettings) => {
-  console.log('init');
+const initTransport = (Transport: any) => {
+  TransportManager.setTransport(Transport);
+};
+
+export const init = async (settings: ConnectSettings, Transport: any) => {
   try {
     try {
       await DataManager.load(settings);
+      initTransport(Transport);
     } catch {
       Log.error('DataManager.load error');
     }

--- a/packages/core/src/data-manager/TransportManager.ts
+++ b/packages/core/src/data-manager/TransportManager.ts
@@ -1,6 +1,4 @@
 import { Transport } from '@onekeyfe/hd-transport';
-import HttpBridge from '@onekeyfe/hd-transport-http';
-import ReactNativeTransport from '@onekeyfe/hd-transport-react-native';
 import { ERRORS } from '../constants';
 import { initLog } from '../utils';
 import DataManager from './DataManager';
@@ -21,13 +19,7 @@ export default class TransportManager {
   static reactNativeInit = false;
 
   static load() {
-    const env = DataManager.getSettings('env');
     console.log('transport manager load');
-    if (env === 'react-native') {
-      this.transport = new ReactNativeTransport({ scanTimeout: 1500 }) as any;
-    } else {
-      this.transport = new HttpBridge() as any;
-    }
     this.defaultMessages = DataManager.getProtobufMessages();
     this.currentMessages = this.defaultMessages;
   }
@@ -67,6 +59,18 @@ export default class TransportManager {
     } catch (error) {
       throw ERRORS.TypedError('Transport_InvalidProtobuf', error.message);
     }
+  }
+
+  static setTransport(TransportConstructor: any) {
+    const env = DataManager.getSettings('env');
+    if (env === 'react-native') {
+      /** Actually initializes the ReactNativeTransport */
+      this.transport = new TransportConstructor({ scanTimeout: 1500 }) as unknown as Transport;
+    } else {
+      /** Actually initializes the HttpTransport */
+      this.transport = new TransportConstructor() as unknown as Transport;
+    }
+    console.log('set transport: ', this.transport);
   }
 
   static getTransport() {

--- a/packages/core/src/device/Device.ts
+++ b/packages/core/src/device/Device.ts
@@ -95,9 +95,12 @@ export class Device extends EventEmitter {
   toMessageObject(): DeviceTyped | null {
     if (this.isUnacquired() || !this.features) return null;
 
+    const env = DataManager.getSettings('env');
+
     return {
       /** Android uses Mac address, iOS uses uuid, USB uses path  */
-      connectId: this.mainId || null,
+      connectId:
+        env === 'react-native' ? this.mainId || null : this.originalDescriptor.path || null,
       /** Hardware ID, will not change at any time */
       uuid: getDeviceUUID(this.features),
       deviceType: getDeviceType(this.features),

--- a/packages/core/src/device/DeviceConnector.ts
+++ b/packages/core/src/device/DeviceConnector.ts
@@ -87,9 +87,7 @@ export default class DeviceConnector {
   listening = false;
 
   constructor() {
-    if (!TransportManager.getTransport()) {
-      TransportManager.load();
-    }
+    TransportManager.load();
     this.transport = TransportManager.getTransport();
   }
 

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -17,6 +17,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "*"
+    "@onekeyfe/hd-core": "*",
+    "@onekeyfe/hd-transport-react-native": "*"
   }
 }

--- a/packages/hd-ble-sdk/src/index.ts
+++ b/packages/hd-ble-sdk/src/index.ts
@@ -14,6 +14,7 @@ import HardwareSdk, {
   create as createDeferred,
   IFRAME,
 } from '@onekeyfe/hd-core';
+import ReactNativeTransport from '@onekeyfe/hd-transport-react-native';
 
 const eventEmitter = new EventEmitter();
 const Log = initLog('@onekey/hd-ble-sdk');
@@ -55,7 +56,7 @@ const init = async (settings: Partial<ConnectSettings>) => {
   Log.debug('init');
 
   try {
-    _core = await initCore(_settings);
+    _core = await initCore(_settings, ReactNativeTransport);
     _core?.on(CORE_EVENT, handleMessage);
   } catch (error) {
     Log.error(createErrorMessage(error));

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@onekeyfe/hd-core": "*",
+    "@onekeyfe/hd-transport-http": "*",
     "@onekeyfe/cross-inpage-provider-core": "^0.0.14"
   },
   "devDependencies": {

--- a/packages/hd-web-sdk/src/iframe/index.ts
+++ b/packages/hd-web-sdk/src/iframe/index.ts
@@ -1,3 +1,4 @@
+import HttpTransport from '@onekeyfe/hd-transport-http';
 import {
   PostMessageEvent,
   IFRAME,
@@ -42,7 +43,7 @@ export async function init(payload: IFrameInit['payload']) {
   Log.enabled = !!settings.debug;
 
   try {
-    _core = await initCore(settings);
+    _core = await initCore(settings, HttpTransport);
   } catch (error) {
     return createErrorMessage(error);
   }


### PR DESCRIPTION
- 将 transport 放置在 sdk 的 package 里，避免放在 core 中由于依赖关系导致不同平台的打包失败