### PR TITLE
fix: skip validate in classic and mini device

### DIFF
--- a/packages/connect-examples/electron-example/package.json
+++ b/packages/connect-examples/electron-example/package.json
@@ -2,7 +2,7 @@
   "name": "hardware-example",
   "productName": "HardwareExample",
   "executableName": "onekey-hardware-example",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "author": "OneKey",
   "description": "End-to-end encrypted workspaces for teams",
   "main": "dist/index.js",

--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "scripts": {
     "start": "yarn expo start --dev-client",
     "android": "yarn expo run:android",
@@ -16,10 +16,10 @@
     "@noble/ed25519": "^2.1.0",
     "@noble/hashes": "^1.3.3",
     "@noble/secp256k1": "^1.7.1",
-    "@onekeyfe/hd-ble-sdk": "^1.0.10",
-    "@onekeyfe/hd-common-connect-sdk": "^1.0.10",
-    "@onekeyfe/hd-core": "^1.0.10",
-    "@onekeyfe/hd-web-sdk": "^1.0.10",
+    "@onekeyfe/hd-ble-sdk": "^1.0.11",
+    "@onekeyfe/hd-common-connect-sdk": "^1.0.11",
+    "@onekeyfe/hd-core": "^1.0.11",
+    "@onekeyfe/hd-web-sdk": "^1.0.11",
     "@onekeyfe/react-native-ble-plx": "3.0.0",
     "@react-native-async-storage/async-storage": "1.21.0",
     "@react-native-picker/picker": "2.6.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "> TODO: description",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.10",
-    "@onekeyfe/hd-transport": "^1.0.10",
+    "@onekeyfe/hd-shared": "^1.0.11",
+    "@onekeyfe/hd-transport": "^1.0.11",
     "axios": "^0.27.2",
     "bignumber.js": "^9.0.2",
     "bytebuffer": "^5.0.1",

--- a/packages/core/src/api/ton/TonSignMessage.ts
+++ b/packages/core/src/api/ton/TonSignMessage.ts
@@ -5,7 +5,6 @@ import { validatePath } from '../helpers/pathUtils';
 import { BaseMethod } from '../BaseMethod';
 import { validateParams } from '../helpers/paramsValidator';
 import { DeviceModelToTypes, TonSignMessageParams } from '../../types';
-s;
 import { getDeviceType } from '../../utils';
 
 export default class TonSignMessage extends BaseMethod<HardwareTonSignMessage> {

--- a/packages/core/src/api/ton/TonSignMessage.ts
+++ b/packages/core/src/api/ton/TonSignMessage.ts
@@ -76,10 +76,9 @@ export default class TonSignMessage extends BaseMethod<HardwareTonSignMessage> {
     const res = await this.device.commands.typedCall('TonSignMessage', 'TonSignedMessage', {
       ...this.params,
     });
-
     return Promise.resolve({
-      skip_validate: DeviceModelToTypes.model_mini.includes(deviceType),
       ...res.message,
+      skip_validate: DeviceModelToTypes.model_mini.includes(deviceType),
     });
   }
 }

--- a/packages/core/src/api/ton/TonSignMessage.ts
+++ b/packages/core/src/api/ton/TonSignMessage.ts
@@ -4,7 +4,9 @@ import { UI_REQUEST } from '../../constants/ui-request';
 import { validatePath } from '../helpers/pathUtils';
 import { BaseMethod } from '../BaseMethod';
 import { validateParams } from '../helpers/paramsValidator';
-import { TonSignMessageParams } from '../../types';
+import { DeviceModelToTypes, TonSignMessageParams } from '../../types';
+s;
+import { getDeviceType } from '../../utils';
 
 export default class TonSignMessage extends BaseMethod<HardwareTonSignMessage> {
   init() {
@@ -71,10 +73,16 @@ export default class TonSignMessage extends BaseMethod<HardwareTonSignMessage> {
   }
 
   async run() {
+    const deviceType = getDeviceType(this.device.features);
     const res = await this.device.commands.typedCall('TonSignMessage', 'TonSignedMessage', {
       ...this.params,
     });
 
-    return Promise.resolve(res.message);
+    return Promise.resolve({
+      skip_validate:
+        DeviceModelToTypes.model_mini.includes(deviceType) ||
+        DeviceModelToTypes.model_classic.includes(deviceType),
+      ...res.message,
+    });
   }
 }

--- a/packages/core/src/api/ton/TonSignMessage.ts
+++ b/packages/core/src/api/ton/TonSignMessage.ts
@@ -78,9 +78,7 @@ export default class TonSignMessage extends BaseMethod<HardwareTonSignMessage> {
     });
 
     return Promise.resolve({
-      skip_validate:
-        DeviceModelToTypes.model_mini.includes(deviceType) ||
-        DeviceModelToTypes.model_classic.includes(deviceType),
+      skip_validate: DeviceModelToTypes.model_mini.includes(deviceType),
       ...res.message,
     });
   }

--- a/packages/core/src/types/api/tonSignMessage.ts
+++ b/packages/core/src/types/api/tonSignMessage.ts
@@ -1,4 +1,8 @@
-import { TonSignedMessage, TonWalletVersion, TonWorkChain } from '@onekeyfe/hd-transport';
+import {
+  TonSignedMessage as HardwareTonSignedMessage,
+  TonWalletVersion,
+  TonWorkChain,
+} from '@onekeyfe/hd-transport';
 import type { CommonParams, Response } from '../params';
 
 export type TonSignMessageParams = {
@@ -23,6 +27,10 @@ export type TonSignMessageParams = {
   extTonAmount?: number[];
   extPayload?: string[];
 };
+
+export type TonSignedMessage = {
+  skip_validate: boolean;
+} & HardwareTonSignedMessage;
 
 export declare function tonSignMessage(
   connectId: string,

--- a/packages/core/src/types/api/tonSignMessage.ts
+++ b/packages/core/src/types/api/tonSignMessage.ts
@@ -1,8 +1,4 @@
-import {
-  TonSignedMessage as HardwareTonSignedMessage,
-  TonWalletVersion,
-  TonWorkChain,
-} from '@onekeyfe/hd-transport';
+import { TonSignedMessage, TonWalletVersion, TonWorkChain } from '@onekeyfe/hd-transport';
 import type { CommonParams, Response } from '../params';
 
 export type TonSignMessageParams = {
@@ -28,12 +24,12 @@ export type TonSignMessageParams = {
   extPayload?: string[];
 };
 
-export type TonSignedMessage = {
+export type TonSignedMessageResponse = {
   skip_validate: boolean;
-} & HardwareTonSignedMessage;
+} & TonSignedMessage;
 
 export declare function tonSignMessage(
   connectId: string,
   deviceId: string,
   params: CommonParams & TonSignMessageParams
-): Response<TonSignedMessage>;
+): Response<TonSignedMessageResponse>;

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "^1.0.10",
-    "@onekeyfe/hd-shared": "^1.0.10",
-    "@onekeyfe/hd-transport-react-native": "^1.0.10"
+    "@onekeyfe/hd-core": "^1.0.11",
+    "@onekeyfe/hd-shared": "^1.0.11",
+    "@onekeyfe/hd-transport-react-native": "^1.0.11"
   }
 }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,10 +20,10 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "^1.0.10",
-    "@onekeyfe/hd-shared": "^1.0.10",
-    "@onekeyfe/hd-transport-http": "^1.0.10",
-    "@onekeyfe/hd-transport-lowlevel": "^1.0.10",
-    "@onekeyfe/hd-transport-webusb": "^1.0.10"
+    "@onekeyfe/hd-core": "^1.0.11",
+    "@onekeyfe/hd-shared": "^1.0.11",
+    "@onekeyfe/hd-transport-http": "^1.0.11",
+    "@onekeyfe/hd-transport-lowlevel": "^1.0.11",
+    "@onekeyfe/hd-transport-webusb": "^1.0.11"
   }
 }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.10",
-    "@onekeyfe/hd-transport": "^1.0.10",
+    "@onekeyfe/hd-shared": "^1.0.11",
+    "@onekeyfe/hd-transport": "^1.0.11",
     "axios": "^0.27.2"
   }
 }

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.10",
-    "@onekeyfe/hd-transport": "^1.0.10"
+    "@onekeyfe/hd-shared": "^1.0.11",
+    "@onekeyfe/hd-transport": "^1.0.11"
   }
 }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,8 +19,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.10",
-    "@onekeyfe/hd-transport": "^1.0.10",
+    "@onekeyfe/hd-shared": "^1.0.11",
+    "@onekeyfe/hd-transport": "^1.0.11",
     "@onekeyfe/react-native-ble-plx": "3.0.1",
     "react-native-ble-manager": "^8.1.0"
   }

--- a/packages/hd-transport-webusb/package.json
+++ b/packages/hd-transport-webusb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-webusb",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.10",
-    "@onekeyfe/hd-transport": "^1.0.10"
+    "@onekeyfe/hd-shared": "^1.0.11",
+    "@onekeyfe/hd-transport": "^1.0.11"
   },
   "devDependencies": {
     "@types/w3c-web-usb": "^1.0.6"

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "> TODO: description",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-transport/src/types/messages.ts
+++ b/packages/hd-transport/src/types/messages.ts
@@ -4561,5 +4561,5 @@ export type MessageResponse<T extends MessageKey> = {
 export type TypedCall = <T extends MessageKey, R extends MessageKey>(
   type: T,
   resType: R,
-  message?: MessageType[T],
+  message?: MessageType[T]
 ) => Promise<MessageResponse<R>>;

--- a/packages/hd-transport/src/types/messages.ts
+++ b/packages/hd-transport/src/types/messages.ts
@@ -3890,7 +3890,6 @@ export type TonSignMessage = {
 export type TonSignedMessage = {
   signature?: string;
   signning_message?: string;
-  skip_validate: boolean;
 };
 
 // TonSignProof

--- a/packages/hd-transport/src/types/messages.ts
+++ b/packages/hd-transport/src/types/messages.ts
@@ -3890,6 +3890,7 @@ export type TonSignMessage = {
 export type TonSignedMessage = {
   signature?: string;
   signning_message?: string;
+  skip_validate: boolean;
 };
 
 // TonSignProof
@@ -4560,5 +4561,5 @@ export type MessageResponse<T extends MessageKey> = {
 export type TypedCall = <T extends MessageKey, R extends MessageKey>(
   type: T,
   resType: R,
-  message?: MessageType[T]
+  message?: MessageType[T],
 ) => Promise<MessageResponse<R>>;

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "^0.0.17",
-    "@onekeyfe/hd-core": "^1.0.10",
-    "@onekeyfe/hd-shared": "^1.0.10",
-    "@onekeyfe/hd-transport-http": "^1.0.10",
-    "@onekeyfe/hd-transport-webusb": "^1.0.10"
+    "@onekeyfe/hd-core": "^1.0.11",
+    "@onekeyfe/hd-shared": "^1.0.11",
+    "@onekeyfe/hd-transport-http": "^1.0.11",
+    "@onekeyfe/hd-transport-webusb": "^1.0.11"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 更新了消息签名功能以支持设备类型处理，返回结果中新增了 `skip_validate` 属性。
- **Bug 修复**
	- 保持了原有响应结构的同时，确保新属性与现有消息一起返回。
- **版本更新**
	- 多个包的版本已从 `1.0.10` 更新至 `1.0.11`，包括 `@onekeyfe/hd-core`、`@onekeyfe/hd-shared`、`@onekeyfe/hd-transport` 等。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->