### PR TITLE
fix: use example with 1.0.11

### DIFF
--- a/packages/connect-examples/expo-example/src/constants/connect.ts
+++ b/packages/connect-examples/expo-example/src/constants/connect.ts
@@ -1,3 +1,1 @@
-import { version } from '../../package.json';
-
-export const CONNECT_SRC = process.env.CONNECT_SRC || `https://jssdk.onekey.so/${version}`;
+export const CONNECT_SRC = process.env.CONNECT_SRC || `https://jssdk.onekey.so/1.0.11`;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了 `CONNECT_SRC` 常量的构建方式，使用固定版本 `1.0.11`，移除了对包版本的依赖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->