### PR TITLE
feat: alph chain set "group" with optional

### DIFF
--- a/packages/connect-examples/expo-example/src/data/alephium.ts
+++ b/packages/connect-examples/expo-example/src/data/alephium.ts
@@ -9,6 +9,7 @@ const api: PlaygroundProps[] = [
         title: 'Get address',
         value: {
           path: "m/44'/1234'/0'/0/0",
+          includePublicKey: true,
           showOnOneKey: false,
           group: 0,
         },
@@ -19,11 +20,13 @@ const api: PlaygroundProps[] = [
           bundle: [
             {
               path: "m/44'/1234'/0'/0/0",
+              includePublicKey: true,
               showOnOneKey: false,
               group: 0,
             },
             {
               path: "m/44'/1234'/0'/0/1",
+              includePublicKey: true,
               showOnOneKey: false,
               group: 0,
             },

--- a/packages/connect-examples/expo-example/src/data/allnetwork.ts
+++ b/packages/connect-examples/expo-example/src/data/allnetwork.ts
@@ -208,7 +208,9 @@ const api: PlaygroundProps[] = [
             {
               network: 'alph',
               path: "m/44'/1234'/0'/0/0",
+              includePublicKey: true,
               showOnOneKey: false,
+              group: 0,
             },
             {
               network: 'nostr',

--- a/packages/core/src/api/alephium/AlephiumGetAddress.ts
+++ b/packages/core/src/api/alephium/AlephiumGetAddress.ts
@@ -36,7 +36,8 @@ export default class AlephiumGetAddress extends BaseMethod<HardwareAlephiumGetAd
         address_n: addressN,
         show_display: showOnOneKey,
         include_public_key: batch.includePublicKey ?? false,
-        target_group: batch.group ?? 0,
+        // When group is 'null', the 'group' parameter will not be sent
+        ...(batch.group !== null && { target_group: batch.group ?? 0 }),
       });
     });
   }

--- a/packages/core/src/api/alephium/AlephiumGetAddress.ts
+++ b/packages/core/src/api/alephium/AlephiumGetAddress.ts
@@ -36,7 +36,7 @@ export default class AlephiumGetAddress extends BaseMethod<HardwareAlephiumGetAd
         address_n: addressN,
         show_display: showOnOneKey,
         include_public_key: batch.includePublicKey ?? false,
-        target_group: batch.group,
+        target_group: batch.group || 0,
       });
     });
   }

--- a/packages/core/src/api/alephium/AlephiumGetAddress.ts
+++ b/packages/core/src/api/alephium/AlephiumGetAddress.ts
@@ -36,7 +36,7 @@ export default class AlephiumGetAddress extends BaseMethod<HardwareAlephiumGetAd
         address_n: addressN,
         show_display: showOnOneKey,
         include_public_key: batch.includePublicKey ?? false,
-        target_group: batch.group || 0,
+        target_group: batch.group ?? 0,
       });
     });
   }

--- a/packages/core/src/types/api/alephiumGetAddress.ts
+++ b/packages/core/src/types/api/alephiumGetAddress.ts
@@ -11,7 +11,7 @@ export type AlephiumGetAddressParams = {
   path: string | number[];
   showOnOneKey?: boolean;
   includePublicKey?: boolean;
-  group?: number;
+  group: number | undefined | null;
 };
 
 export declare function alephiumGetAddress(

--- a/packages/core/src/types/api/alephiumGetAddress.ts
+++ b/packages/core/src/types/api/alephiumGetAddress.ts
@@ -11,7 +11,7 @@ export type AlephiumGetAddressParams = {
   path: string | number[];
   showOnOneKey?: boolean;
   includePublicKey?: boolean;
-  group: number;
+  group?: number;
 };
 
 export declare function alephiumGetAddress(

--- a/packages/hd-web-sdk/src/iframe/builder.ts
+++ b/packages/hd-web-sdk/src/iframe/builder.ts
@@ -29,8 +29,8 @@ export const init = async (settings: any) => {
     }
   }
 
-  const manifest = `version=${settings.version as string}`;
-  const src = `${settings.iframeSrc as string}?${manifest}`;
+  // const manifest = `version=${settings.version as string}`;
+  const src = `${settings.iframeSrc as string}`;
 
   instance.setAttribute('src', src);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 在 `alephiumGetAddress` 和 `allNetworkGetAddress` 方法中添加了 `includePublicKey` 属性，增强了对网络 `alph` 的支持。
- **改进**
	- `target_group` 属性的初始化逻辑进行了调整，确保其默认值为 `0`。
	- `AlephiumGetAddressParams` 类型中的 `group` 属性已更改为可选，允许在创建对象时省略此属性。
- **简化**
	- 移除了 iframe 源 URL 中的版本查询参数，简化了 iframe 源的构建过程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->