### PR TITLE
Fix/response-pub

### DIFF
--- a/packages/connect-examples/expo-example/webpack.config.js
+++ b/packages/connect-examples/expo-example/webpack.config.js
@@ -28,5 +28,14 @@ module.exports = async function (env, argv) {
     config.devtool = false;
   }
 
+  const definePlugin = config.plugins.find(plugin => plugin.constructor.name === 'DefinePlugin');
+  if (definePlugin) {
+    const processEnv = {};
+    Object.keys(process.env).forEach(key => {
+      processEnv[key] = JSON.stringify(process.env[key]);
+    });
+
+    definePlugin.definitions['process.env'] = processEnv;
+  }
   return config;
 };

--- a/packages/core/src/api/alephium/AlephiumGetAddress.ts
+++ b/packages/core/src/api/alephium/AlephiumGetAddress.ts
@@ -62,10 +62,11 @@ export default class AlephiumGetAddress extends BaseMethod<HardwareAlephiumGetAd
 
       const { address } = res.message;
 
-      const result = {
+      const result: AlephiumAddress = {
         path: serializedPath(param.address_n),
         address,
         publicKey: param.include_public_key ? res.message.public_key : undefined,
+        pub: param.include_public_key ? res.message.public_key : undefined,
         derivedPath: serializedPath(res.message.derived_path),
       };
       responses.push(result);

--- a/packages/core/src/api/allnetwork/AllNetworkGetAddress.ts
+++ b/packages/core/src/api/allnetwork/AllNetworkGetAddress.ts
@@ -141,14 +141,6 @@ const networkConfigMap: NetworkConfigMap = {
   },
   sui: {
     methodName: 'suiGetAddress',
-    dependOnMethodName: ['suiGetPublicKey'],
-    getParams: (baseParams: AllNetworkAddressParams) => {
-      const { path, showOnOneKey } = baseParams;
-      return {
-        path,
-        showOnOneKey,
-      };
-    },
   },
   fil: {
     methodName: 'filecoinGetAddress',
@@ -325,14 +317,22 @@ export default class AllNetworkGetAddress extends BaseMethod<
         payload: response,
       };
     } catch (e: any) {
-      const errorMessage =
-        e instanceof Error ? handleHardwareError(e, this.device, method) : 'Unknown error';
-
-      result = {
-        ...baseParams,
-        success: false,
-        error: errorMessage,
-      };
+      if (e instanceof Error) {
+        const errorMessage = handleHardwareError(e, this.device, method);
+        result = {
+          ...baseParams,
+          success: false,
+          errorCode: e.message,
+          error: errorMessage,
+        };
+      } else {
+        result = {
+          ...baseParams,
+          success: false,
+          errorCode: 'Unknown error',
+          error: 'Unknown error',
+        };
+      }
     }
 
     return result;

--- a/packages/core/src/api/aptos/AptosGetAddress.ts
+++ b/packages/core/src/api/aptos/AptosGetAddress.ts
@@ -23,7 +23,8 @@ export default class AptosGetAddress extends BaseMethod<HardwareAptosGetAddress[
     const payload = this.hasBundle ? this.payload : { bundle: [this.payload] };
 
     this.shouldConfirm =
-      this.payload.showOnOneKey || this.payload.bundle?.some((i: any) => !!i.showOnOneKey);
+      this.payload.showOnOneKey ||
+      this.payload.bundle?.some((i: AptosGetAddressParams) => !!i.showOnOneKey);
 
     // check payload
     validateParams(payload, [{ name: 'bundle', type: 'array' }]);

--- a/packages/core/src/api/aptos/AptosGetPublicKey.ts
+++ b/packages/core/src/api/aptos/AptosGetPublicKey.ts
@@ -2,7 +2,7 @@ import { UI_REQUEST } from '../../constants/ui-request';
 import { serializedPath, validatePath } from '../helpers/pathUtils';
 import { BaseMethod } from '../BaseMethod';
 import { validateParams, validateResult } from '../helpers/paramsValidator';
-import { AptosGetAddressParams } from '../../types';
+import { AptosGetAddressParams, AptosPublicKey } from '../../types';
 
 export default class AptosGetPublicKey extends BaseMethod<any> {
   hasBundle = false;
@@ -50,12 +50,15 @@ export default class AptosGetPublicKey extends BaseMethod<any> {
       ecdsa_curve_name: 'ed25519',
     });
 
-    const responses = res.message.public_keys.map((publicKey: string, index: number) => ({
-      path: serializedPath((this.params as unknown as any[])[index].address_n),
-      publicKey,
-    }));
+    const responses: AptosPublicKey[] = res.message.public_keys.map(
+      (publicKey: string, index: number) => ({
+        path: serializedPath((this.params as unknown as any[])[index].address_n),
+        pub: publicKey,
+        publicKey,
+      })
+    );
 
-    validateResult(responses, ['publicKey'], {
+    validateResult(responses, ['pub'], {
       expectedLength: this.params.length,
     });
 

--- a/packages/core/src/api/cardano/CardanoGetPublicKey.ts
+++ b/packages/core/src/api/cardano/CardanoGetPublicKey.ts
@@ -57,8 +57,7 @@ export default class CardanoGetPublicKey extends BaseMethod<CardanoPublicKeyPara
       responses.push({
         path: batch.address_n,
         serializedPath: serializedPath(batch.address_n),
-        pub: message.xpub,
-        publicKey: message.xpub,
+        xpub: message.xpub,
         node: message.node,
       });
     }

--- a/packages/core/src/api/cardano/CardanoGetPublicKey.ts
+++ b/packages/core/src/api/cardano/CardanoGetPublicKey.ts
@@ -57,12 +57,13 @@ export default class CardanoGetPublicKey extends BaseMethod<CardanoPublicKeyPara
       responses.push({
         path: batch.address_n,
         serializedPath: serializedPath(batch.address_n),
+        pub: message.xpub,
         publicKey: message.xpub,
         node: message.node,
       });
     }
 
-    validateResult(responses, ['publicKey'], {
+    validateResult(responses, ['pub'], {
       expectedLength: this.params.length,
     });
 

--- a/packages/core/src/api/cardano/CardanoGetPublicKey.ts
+++ b/packages/core/src/api/cardano/CardanoGetPublicKey.ts
@@ -62,7 +62,7 @@ export default class CardanoGetPublicKey extends BaseMethod<CardanoPublicKeyPara
       });
     }
 
-    validateResult(responses, ['pub'], {
+    validateResult(responses, ['xpub'], {
       expectedLength: this.params.length,
     });
 

--- a/packages/core/src/api/cosmos/CosmosGetPublicKey.ts
+++ b/packages/core/src/api/cosmos/CosmosGetPublicKey.ts
@@ -2,7 +2,7 @@ import { UI_REQUEST } from '../../constants/ui-request';
 import { serializedPath, validatePath } from '../helpers/pathUtils';
 import { BaseMethod } from '../BaseMethod';
 import { validateParams, validateResult } from '../helpers/paramsValidator';
-import { CosmosGetPublicKeyParams } from '../../types';
+import { CosmosAddress, CosmosGetPublicKeyParams } from '../../types';
 
 export default class CosmosGetPublicKey extends BaseMethod<any> {
   hasBundle = false;
@@ -64,12 +64,15 @@ export default class CosmosGetPublicKey extends BaseMethod<any> {
       ecdsa_curve_name: this.params[0].curve,
     });
 
-    const responses = res.message.public_keys.map((publicKey: string, index: number) => ({
-      path: serializedPath((this.params as unknown as any[])[index].address_n),
-      publicKey,
-    }));
+    const responses: CosmosAddress[] = res.message.public_keys.map(
+      (publicKey: string, index: number) => ({
+        path: serializedPath((this.params as unknown as any[])[index].address_n),
+        pub: publicKey,
+        publicKey,
+      })
+    );
 
-    validateResult(responses, ['publicKey'], {
+    validateResult(responses, ['pub'], {
       expectedLength: this.params.length,
     });
 

--- a/packages/core/src/api/evm/EVMGetPublicKey.ts
+++ b/packages/core/src/api/evm/EVMGetPublicKey.ts
@@ -70,10 +70,11 @@ export default class EVMGetPublicKey extends BaseMethod<EthereumGetPublicKeyOneK
       });
       const result = res.message.public_keys.map((publicKey: string, index: number) => ({
         path: serializedPath((this.params as unknown as any[])[index].address_n),
+        pub: publicKey,
         publicKey,
       }));
 
-      validateResult(responses, ['publicKey'], {
+      validateResult(responses, ['pub'], {
         expectedLength: this.params.length,
       });
       return Promise.resolve(result);
@@ -86,12 +87,13 @@ export default class EVMGetPublicKey extends BaseMethod<EthereumGetPublicKeyOneK
 
       responses.push({
         path: serializedPath(param.address_n),
+        pub: res.message.node.public_key,
         publicKey: res.message.node.public_key,
         ...res.message,
       });
     }
 
-    validateResult(responses, ['publicKey'], {
+    validateResult(responses, ['pub'], {
       expectedLength: this.params.length,
     });
 

--- a/packages/core/src/api/lightning/LnurlAuth.ts
+++ b/packages/core/src/api/lightning/LnurlAuth.ts
@@ -43,6 +43,9 @@ export default class LnurlAuth1 extends BaseMethod<ILnurlAuth> {
 
     validateResult(message, ['publickey', 'path']);
 
-    return message;
+    return {
+      ...message,
+      pub: message.publickey,
+    };
   }
 }

--- a/packages/core/src/api/nostr/NostrGetPublicKey.ts
+++ b/packages/core/src/api/nostr/NostrGetPublicKey.ts
@@ -60,7 +60,9 @@ export default class NostrGetPublicKey extends BaseMethod<GetPublicKey[]> {
 
       const response = {
         path: serializedPath(param.address_n),
-        ...res.message,
+        npub: res.message.npub,
+        pub: res.message.publickey,
+        publickey: res.message.publickey,
       };
 
       responses.push(response);

--- a/packages/core/src/api/polkadot/PolkadotGetAddress.ts
+++ b/packages/core/src/api/polkadot/PolkadotGetAddress.ts
@@ -64,6 +64,7 @@ export default class PolkadotGetAddress extends BaseMethod<HardwarePolkadotGetAd
       responses.push({
         path,
         address,
+        pub: public_key ?? '',
         publicKey: public_key ?? '',
       });
 
@@ -73,7 +74,7 @@ export default class PolkadotGetAddress extends BaseMethod<HardwarePolkadotGetAd
       });
     }
 
-    validateResult(responses, ['address', 'publicKey'], {
+    validateResult(responses, ['address', 'pub'], {
       expectedLength: this.params.length,
     });
 

--- a/packages/core/src/api/sui/SuiGetAddress.ts
+++ b/packages/core/src/api/sui/SuiGetAddress.ts
@@ -20,9 +20,8 @@ export default class SuiGetAddress extends BaseMethod<HardwareSuiGetAddress[]> {
     this.hasBundle = !!this.payload?.bundle;
     const payload = this.hasBundle ? this.payload : { bundle: [this.payload] };
 
-    this.shouldConfirm = this.hasBundle
-      ? this.payload.bundle.some((i: any) => !!i.showOnOneKey)
-      : false;
+    this.shouldConfirm =
+      this.payload.showOnOneKey || this.payload.bundle?.some((i: any) => !!i.showOnOneKey);
 
     // check payload
     validateParams(payload, [{ name: 'bundle', type: 'array' }]);
@@ -58,46 +57,66 @@ export default class SuiGetAddress extends BaseMethod<HardwareSuiGetAddress[]> {
   }
 
   async run() {
-    if (this.hasBundle && supportBatchPublicKey(this.device?.features) && !this.shouldConfirm) {
-      const res = await this.device.commands.typedCall('BatchGetPublickeys', 'EcdsaPublicKeys', {
-        paths: this.params,
-        ecdsa_curve_name: 'ed25519',
-      });
-      const result = res.message.public_keys.map((publicKey: string, index: number) => ({
-        path: serializedPath((this.params as unknown as any[])[index].address_n),
-        publicKey,
-        address: publicKeyToAddress(publicKey),
-      }));
+    const supportsBatchPublicKey = supportBatchPublicKey(this.device?.features);
+    let responses: SuiAddress[] = [];
+    if (supportsBatchPublicKey) {
+      const publicKeyRes = await this.device.commands.typedCall(
+        'BatchGetPublickeys',
+        'EcdsaPublicKeys',
+        {
+          paths: this.params,
+          ecdsa_curve_name: 'ed25519',
+        }
+      );
+      for (let i = 0; i < this.params.length; i++) {
+        const param = this.params[i];
+        const publicKey = publicKeyRes.message.public_keys[i];
+        let address: string;
 
-      validateResult(result, ['address'], {
-        expectedLength: this.params.length,
-      });
+        if (this.shouldConfirm) {
+          const addressRes = await this.device.commands.typedCall(
+            'SuiGetAddress',
+            'SuiAddress',
+            param
+          );
+          address = addressRes.message.address?.toLowerCase() ?? '';
+        } else {
+          address = publicKeyToAddress(publicKey);
+        }
 
-      return Promise.resolve(result);
-    }
+        const result: SuiAddress = {
+          path: serializedPath(param.address_n),
+          address,
+          publicKey,
+          pub: publicKey,
+        };
 
-    const responses: SuiAddress[] = [];
-    for (let i = 0; i < this.params.length; i++) {
-      const param = this.params[i];
+        if (this.shouldConfirm) {
+          this.postPreviousAddressMessage(result);
+        }
 
-      const res = await this.device.commands.typedCall('SuiGetAddress', 'SuiAddress', {
-        ...param,
-      });
-
-      const { address } = res.message;
-
-      const result = {
-        path: serializedPath(param.address_n),
-        address: address?.toLowerCase(),
-      };
-      responses.push(result);
-      this.postPreviousAddressMessage(result);
+        responses.push(result);
+      }
+    } else {
+      responses = await Promise.all(
+        this.params.map(async param => {
+          const res = await this.device.commands.typedCall('SuiGetAddress', 'SuiAddress', param);
+          const result = {
+            path: serializedPath(param.address_n),
+            address: res.message.address?.toLowerCase() ?? '',
+          };
+          if (this.shouldConfirm) {
+            this.postPreviousAddressMessage(result);
+          }
+          return result;
+        })
+      );
     }
 
     validateResult(responses, ['address'], {
       expectedLength: this.params.length,
     });
 
-    return Promise.resolve(this.hasBundle ? responses : responses[0]);
+    return this.hasBundle ? responses : responses[0];
   }
 }

--- a/packages/core/src/api/sui/SuiGetAddress.ts
+++ b/packages/core/src/api/sui/SuiGetAddress.ts
@@ -21,7 +21,8 @@ export default class SuiGetAddress extends BaseMethod<HardwareSuiGetAddress[]> {
     const payload = this.hasBundle ? this.payload : { bundle: [this.payload] };
 
     this.shouldConfirm =
-      this.payload.showOnOneKey || this.payload.bundle?.some((i: any) => !!i.showOnOneKey);
+      this.payload.showOnOneKey ||
+      this.payload.bundle?.some((i: SuiGetAddressParams) => !!i.showOnOneKey);
 
     // check payload
     validateParams(payload, [{ name: 'bundle', type: 'array' }]);

--- a/packages/core/src/api/sui/SuiGetPublicKey.ts
+++ b/packages/core/src/api/sui/SuiGetPublicKey.ts
@@ -2,7 +2,7 @@ import { UI_REQUEST } from '../../constants/ui-request';
 import { serializedPath, validatePath } from '../helpers/pathUtils';
 import { BaseMethod } from '../BaseMethod';
 import { validateParams, validateResult } from '../helpers/paramsValidator';
-import { SuiGetAddressParams } from '../../types';
+import { SuiGetAddressParams, SuiPublicKey } from '../../types';
 
 export default class SuiGetPublicKey extends BaseMethod<any> {
   hasBundle = false;
@@ -53,12 +53,15 @@ export default class SuiGetPublicKey extends BaseMethod<any> {
       ecdsa_curve_name: 'ed25519',
     });
 
-    const responses = res.message.public_keys.map((publicKey: string, index: number) => ({
-      path: serializedPath((this.params as unknown as any[])[index].address_n),
-      publicKey,
-    }));
+    const responses: SuiPublicKey[] = res.message.public_keys.map(
+      (publicKey: string, index: number) => ({
+        path: serializedPath((this.params as unknown as any[])[index].address_n),
+        publicKey,
+        pub: publicKey,
+      })
+    );
 
-    validateResult(responses, ['publicKey'], {
+    validateResult(responses, ['pub'], {
       expectedLength: this.params.length,
     });
 

--- a/packages/core/src/api/ton/TonGetAddress.ts
+++ b/packages/core/src/api/ton/TonGetAddress.ts
@@ -76,13 +76,14 @@ export default class TonGetAddress extends BaseMethod<HardwareTonGetAddress[]> {
       const result = {
         path: serializedPath(param.address_n),
         publicKey: public_key,
+        pub: public_key,
         address,
       };
       responses.push(result);
       this.postPreviousAddressMessage(result);
     }
 
-    validateResult(responses, ['address', 'publicKey'], {
+    validateResult(responses, ['address', 'pub'], {
       expectedLength: this.params.length,
     });
 

--- a/packages/core/src/api/xrp/XrpGetAddress.ts
+++ b/packages/core/src/api/xrp/XrpGetAddress.ts
@@ -97,6 +97,7 @@ export default class XrpGetAddress extends BaseMethod<
         path,
         address,
         publicKey: publicKey.message?.public_keys?.[0],
+        pub: publicKey.message?.public_keys?.[0],
       });
 
       this.postPreviousAddressMessage({
@@ -105,7 +106,7 @@ export default class XrpGetAddress extends BaseMethod<
       });
     }
 
-    validateResult(responses, ['address', 'publicKey'], {
+    validateResult(responses, ['address', 'pub'], {
       expectedLength: this.params.length,
     });
 

--- a/packages/core/src/types/api/alephiumGetAddress.ts
+++ b/packages/core/src/types/api/alephiumGetAddress.ts
@@ -3,6 +3,7 @@ import type { CommonParams, Response } from '../params';
 export type AlephiumAddress = {
   path: string;
   publicKey?: string;
+  pub?: string;
   address: string;
   derivedPath: string;
 };

--- a/packages/core/src/types/api/alephiumGetAddress.ts
+++ b/packages/core/src/types/api/alephiumGetAddress.ts
@@ -2,6 +2,9 @@ import type { CommonParams, Response } from '../params';
 
 export type AlephiumAddress = {
   path: string;
+  /**
+   * @deprecated Use `pub` instead.
+   */
   publicKey?: string;
   pub?: string;
   address: string;

--- a/packages/core/src/types/api/allNetworkGetAddress.ts
+++ b/packages/core/src/types/api/allNetworkGetAddress.ts
@@ -55,6 +55,9 @@ type AllNetworkAddressPayload =
   | {
       address: string;
       pub?: string;
+      /**
+       * @deprecated Use `pub` instead.
+       */
       publicKey?: string;
       // Nostr public key (bech32)
       npub?: string;

--- a/packages/core/src/types/api/allNetworkGetAddress.ts
+++ b/packages/core/src/types/api/allNetworkGetAddress.ts
@@ -46,13 +46,16 @@ export type AllNetworkAddressParams = {
   chainName?: string;
   prefix?: string;
   showOnOneKey?: boolean;
+
+  includePublicKey?: boolean;
+  group?: string;
 };
 
 type AllNetworkAddressPayload =
   | {
       address: string;
-      publicKey?: string;
       pub?: string;
+      publicKey?: string;
       // Nostr public key (bech32)
       npub?: string;
     }
@@ -84,7 +87,10 @@ type AllNetworkAddressPayload =
 
 export type AllNetworkAddress = CommonResponseParams & {
   success: boolean;
+  // custom error message
   error?: string;
+  // native error message
+  errorCode?: string;
   payload?: AllNetworkAddressPayload;
 };
 

--- a/packages/core/src/types/api/aptosGetAddress.ts
+++ b/packages/core/src/types/api/aptosGetAddress.ts
@@ -4,6 +4,9 @@ import type { CommonParams, Response } from '../params';
 export type AptosAddress = {
   path: string;
   pub?: string;
+  /**
+   * @deprecated Use `pub` instead.
+   */
   publicKey?: string;
 } & HardwareAptosAddress;
 

--- a/packages/core/src/types/api/aptosGetAddress.ts
+++ b/packages/core/src/types/api/aptosGetAddress.ts
@@ -3,6 +3,7 @@ import type { CommonParams, Response } from '../params';
 
 export type AptosAddress = {
   path: string;
+  pub?: string;
   publicKey?: string;
 } & HardwareAptosAddress;
 

--- a/packages/core/src/types/api/aptosGetPublicKey.ts
+++ b/packages/core/src/types/api/aptosGetPublicKey.ts
@@ -3,6 +3,9 @@ import type { CommonParams, Response } from '../params';
 export type AptosPublicKey = {
   path: string;
   pub: string;
+  /**
+   * @deprecated Use `pub` instead.
+   */
   publicKey?: string;
 };
 

--- a/packages/core/src/types/api/aptosGetPublicKey.ts
+++ b/packages/core/src/types/api/aptosGetPublicKey.ts
@@ -2,7 +2,8 @@ import type { CommonParams, Response } from '../params';
 
 export type AptosPublicKey = {
   path: string;
-  publicKey: string;
+  pub: string;
+  publicKey?: string;
 };
 
 export type AptosGetPublicKeyParams = {

--- a/packages/core/src/types/api/cardanoGetPublicKey.ts
+++ b/packages/core/src/types/api/cardanoGetPublicKey.ts
@@ -5,6 +5,9 @@ export type CardanoPublicKey = {
   path: number[];
   serializedPath: string;
   pub: string;
+  /**
+   * @deprecated Use `pub` instead.
+   */
   publicKey?: string;
   node: PROTO.HDNodeType;
 };

--- a/packages/core/src/types/api/cardanoGetPublicKey.ts
+++ b/packages/core/src/types/api/cardanoGetPublicKey.ts
@@ -4,11 +4,7 @@ import { PROTO } from '../../constants';
 export type CardanoPublicKey = {
   path: number[];
   serializedPath: string;
-  pub: string;
-  /**
-   * @deprecated Use `pub` instead.
-   */
-  publicKey?: string;
+  xpub: string;
   node: PROTO.HDNodeType;
 };
 

--- a/packages/core/src/types/api/cardanoGetPublicKey.ts
+++ b/packages/core/src/types/api/cardanoGetPublicKey.ts
@@ -4,7 +4,8 @@ import { PROTO } from '../../constants';
 export type CardanoPublicKey = {
   path: number[];
   serializedPath: string;
-  publicKey: string;
+  pub: string;
+  publicKey?: string;
   node: PROTO.HDNodeType;
 };
 

--- a/packages/core/src/types/api/cosmosGetPublicKey.ts
+++ b/packages/core/src/types/api/cosmosGetPublicKey.ts
@@ -2,7 +2,8 @@ import type { CommonParams, Response } from '../params';
 
 export type CosmosPublicKey = {
   path: string;
-  publicKey: string;
+  pub: string;
+  publicKey?: string;
 };
 
 export type CosmosGetPublicKeyParams = {

--- a/packages/core/src/types/api/cosmosGetPublicKey.ts
+++ b/packages/core/src/types/api/cosmosGetPublicKey.ts
@@ -3,6 +3,9 @@ import type { CommonParams, Response } from '../params';
 export type CosmosPublicKey = {
   path: string;
   pub: string;
+  /**
+   * @deprecated Use `pub` instead.
+   */
   publicKey?: string;
 };
 

--- a/packages/core/src/types/api/evmGetPublicKey.ts
+++ b/packages/core/src/types/api/evmGetPublicKey.ts
@@ -4,6 +4,9 @@ import type { CommonParams, Response } from '../params';
 export type EVMPublicKey = {
   path: string;
   pub: string;
+  /**
+   * @deprecated Use `pub` instead.
+   */
   publicKey?: string;
 } & EthereumPublicKey;
 

--- a/packages/core/src/types/api/evmGetPublicKey.ts
+++ b/packages/core/src/types/api/evmGetPublicKey.ts
@@ -3,7 +3,8 @@ import type { CommonParams, Response } from '../params';
 
 export type EVMPublicKey = {
   path: string;
-  publicKey: string;
+  pub: string;
+  publicKey?: string;
 } & EthereumPublicKey;
 
 export type EVMGetPublicKeyParams = {

--- a/packages/core/src/types/api/lnurlAuth.ts
+++ b/packages/core/src/types/api/lnurlAuth.ts
@@ -1,6 +1,7 @@
 import type { CommonParams, Response } from '../params';
 
 export interface LnurlAuth {
+  pub?: string;
   publickey?: string;
   path?: string;
   signature?: string;

--- a/packages/core/src/types/api/lnurlAuth.ts
+++ b/packages/core/src/types/api/lnurlAuth.ts
@@ -2,6 +2,9 @@ import type { CommonParams, Response } from '../params';
 
 export interface LnurlAuth {
   pub?: string;
+  /**
+   * @deprecated Use `pub` instead.
+   */
   publickey?: string;
   path?: string;
   signature?: string;

--- a/packages/core/src/types/api/nostrGetPublicKey.ts
+++ b/packages/core/src/types/api/nostrGetPublicKey.ts
@@ -2,7 +2,8 @@ import type { CommonParams, Response } from '../params';
 
 export type NostrPublicKey = {
   npub?: string;
-  publickey?: string;
+  pub?: string;
+  publicKey?: string;
   path: string;
 };
 

--- a/packages/core/src/types/api/nostrGetPublicKey.ts
+++ b/packages/core/src/types/api/nostrGetPublicKey.ts
@@ -3,6 +3,9 @@ import type { CommonParams, Response } from '../params';
 export type NostrPublicKey = {
   npub?: string;
   pub?: string;
+  /**
+   * @deprecated Use `pub` instead.
+   */
   publicKey?: string;
   path: string;
 };

--- a/packages/core/src/types/api/polkadotGetAddress.ts
+++ b/packages/core/src/types/api/polkadotGetAddress.ts
@@ -3,7 +3,8 @@ import type { CommonParams, Response } from '../params';
 
 export type PolkadotAddress = {
   path: string;
-  publicKey: string;
+  pub: string;
+  publicKey?: string;
 } & HardwarePolkadotAddress;
 
 export type PolkadotGetAddressParams = {

--- a/packages/core/src/types/api/polkadotGetAddress.ts
+++ b/packages/core/src/types/api/polkadotGetAddress.ts
@@ -4,6 +4,9 @@ import type { CommonParams, Response } from '../params';
 export type PolkadotAddress = {
   path: string;
   pub: string;
+  /**
+   * @deprecated Use `pub` instead.
+   */
   publicKey?: string;
 } & HardwarePolkadotAddress;
 

--- a/packages/core/src/types/api/suiGetAddress.ts
+++ b/packages/core/src/types/api/suiGetAddress.ts
@@ -3,6 +3,7 @@ import type { CommonParams, Response } from '../params';
 
 export type SuiAddress = {
   path: string;
+  pub?: string;
   publicKey?: string;
 } & HardwareSuiAddress;
 

--- a/packages/core/src/types/api/suiGetAddress.ts
+++ b/packages/core/src/types/api/suiGetAddress.ts
@@ -4,6 +4,9 @@ import type { CommonParams, Response } from '../params';
 export type SuiAddress = {
   path: string;
   pub?: string;
+  /**
+   * @deprecated Use `pub` instead.
+   */
   publicKey?: string;
 } & HardwareSuiAddress;
 

--- a/packages/core/src/types/api/suiGetPublicKey.ts
+++ b/packages/core/src/types/api/suiGetPublicKey.ts
@@ -3,6 +3,9 @@ import type { CommonParams, Response } from '../params';
 export type SuiPublicKey = {
   path: string;
   pub: string;
+  /**
+   * @deprecated Use `pub` instead.
+   */
   publicKey?: string;
 };
 

--- a/packages/core/src/types/api/suiGetPublicKey.ts
+++ b/packages/core/src/types/api/suiGetPublicKey.ts
@@ -2,7 +2,8 @@ import type { CommonParams, Response } from '../params';
 
 export type SuiPublicKey = {
   path: string;
-  publicKey: string;
+  pub: string;
+  publicKey?: string;
 };
 
 export type SuiGetPublicKeyParams = {

--- a/packages/core/src/types/api/tonGetAddress.ts
+++ b/packages/core/src/types/api/tonGetAddress.ts
@@ -3,7 +3,8 @@ import type { CommonParams, Response } from '../params';
 
 export type TonAddress = {
   path: string;
-  publicKey: string;
+  pub: string;
+  publicKey?: string;
   address: string;
 };
 

--- a/packages/core/src/types/api/tonGetAddress.ts
+++ b/packages/core/src/types/api/tonGetAddress.ts
@@ -4,6 +4,9 @@ import type { CommonParams, Response } from '../params';
 export type TonAddress = {
   path: string;
   pub: string;
+  /**
+   * @deprecated Use `pub` instead.
+   */
   publicKey?: string;
   address: string;
 };

--- a/packages/core/src/types/api/xrpGetAddress.ts
+++ b/packages/core/src/types/api/xrpGetAddress.ts
@@ -2,6 +2,7 @@ import type { CommonParams, Response } from '../params';
 
 export type XrpAddress = {
   path: string;
+  pub?: string;
   publicKey?: string;
   address: string;
 };

--- a/packages/core/src/types/api/xrpGetAddress.ts
+++ b/packages/core/src/types/api/xrpGetAddress.ts
@@ -3,6 +3,9 @@ import type { CommonParams, Response } from '../params';
 export type XrpAddress = {
   path: string;
   pub?: string;
+  /**
+   * @deprecated Use `pub` instead.
+   */
   publicKey?: string;
   address: string;
 };


### PR DESCRIPTION
改动点：
1. webpack.config.js 中添加环境变量配置

2. 增加 pub 字段，标识原有的字段为deprecated

3. 需要重点关注接口 suiGetAddress, aptosGetAddress, InurlAuth, 

4. 原有接口通过Promise.resolve 返回，但是因为已经标识了async 这里应该不需要再包一层

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 更新了公钥响应中的属性名称，从 `publicKey` 更改为 `xpub`，增强了返回数据结构的清晰度。

- **文档**
	- 标记 `publicKey` 属性为弃用，建议用户使用新的 `xpub` 属性。

- **修复**
	- 改进了参数验证逻辑，确保响应的有效性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->