### PR TITLE
Optimize: release the device when an error is encountered

### DIFF
--- a/packages/connect-examples/electron-example/package.json
+++ b/packages/connect-examples/electron-example/package.json
@@ -2,7 +2,7 @@
   "name": "hardware-example",
   "productName": "HardwareExample",
   "executableName": "onekey-hardware-example",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "author": "OneKey",
   "description": "End-to-end encrypted workspaces for teams",
   "main": "dist/index.js",

--- a/packages/connect-examples/expo-example/locale/en-US.json
+++ b/packages/connect-examples/expo-example/locale/en-US.json
@@ -67,6 +67,7 @@
   "label__retry_interval_time": "Retry Interval Time",
   "label__connection_timeout": "Connection Timeout Time",
   "label__init_session": "Init Session",
+  "label__use_empty_passphrase": "Use Empty Passphrase",
   "label__default_parameters": "Default Parameters",
   "label__parameters": "Parameters",
   "label__enter_parameters_tip": "Enter your parameters here...",

--- a/packages/connect-examples/expo-example/locale/zh-CN.json
+++ b/packages/connect-examples/expo-example/locale/zh-CN.json
@@ -67,6 +67,7 @@
   "label__retry_interval_time": "重试间隔时间",
   "label__connection_timeout": "连接超时时间",
   "label__init_session": "初始化 Session",
+  "label__use_empty_passphrase": "使用空 Passphrase",
   "label__default_parameters": "预设参数",
   "label__parameters": "参数",
   "label__enter_parameters_tip": "在此输入您的参数...",

--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "scripts": {
     "start": "CONNECT_SRC=https://localhost:8087/ yarn expo start --dev-client",
     "android": "yarn expo run:android",
@@ -19,10 +19,10 @@
     "@noble/ed25519": "^2.1.0",
     "@noble/hashes": "^1.3.3",
     "@noble/secp256k1": "^1.7.1",
-    "@onekeyfe/hd-ble-sdk": "^1.0.13",
-    "@onekeyfe/hd-common-connect-sdk": "^1.0.13",
-    "@onekeyfe/hd-core": "^1.0.13",
-    "@onekeyfe/hd-web-sdk": "^1.0.13",
+    "@onekeyfe/hd-ble-sdk": "^1.0.14",
+    "@onekeyfe/hd-common-connect-sdk": "^1.0.14",
+    "@onekeyfe/hd-core": "^1.0.14",
+    "@onekeyfe/hd-web-sdk": "^1.0.14",
     "@onekeyfe/react-native-ble-plx": "3.0.0",
     "@polkadot/util-crypto": "13.1.1",
     "@react-native-async-storage/async-storage": "1.21.0",

--- a/packages/connect-examples/expo-example/src/components/CommonParamsView.tsx
+++ b/packages/connect-examples/expo-example/src/components/CommonParamsView.tsx
@@ -51,6 +51,11 @@ export default function CommonParamsView() {
           onToggle={value => handleSetParam('initSession', value)}
         />
         <SwitchInput
+          label={intl.formatMessage({ id: 'label__use_empty_passphrase' })}
+          value={!!commonParams.useEmptyPassphrase}
+          onToggle={value => handleSetParam('useEmptyPassphrase', value)}
+        />
+        <SwitchInput
           // TODO: i18n
           label="detectBootloaderDevice"
           value={!!commonParams.detectBootloaderDevice}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "> TODO: description",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.13",
-    "@onekeyfe/hd-transport": "^1.0.13",
+    "@onekeyfe/hd-shared": "^1.0.14",
+    "@onekeyfe/hd-transport": "^1.0.14",
     "axios": "^0.27.2",
     "bignumber.js": "^9.0.2",
     "bytebuffer": "^5.0.1",

--- a/packages/core/src/api/allnetwork/AllNetworkGetAddress.ts
+++ b/packages/core/src/api/allnetwork/AllNetworkGetAddress.ts
@@ -1,8 +1,7 @@
 import semver from 'semver';
-import { ERRORS, HardwareErrorCode } from '@onekeyfe/hd-shared';
+import { ERRORS, HardwareError, HardwareErrorCode } from '@onekeyfe/hd-shared';
 
 import { get } from 'lodash';
-import { UI_REQUEST } from '../../constants/ui-request';
 import { serializedPath } from '../helpers/pathUtils';
 import { BaseMethod } from '../BaseMethod';
 import { validateParams } from '../helpers/paramsValidator';
@@ -19,8 +18,7 @@ import { createUiMessage, IFRAME } from '../../events';
 import { getDeviceFirmwareVersion, getMethodVersionRange } from '../../utils';
 import { Device } from '../../device/Device';
 import { PROTO } from '../../constants';
-
-import { HardwareError } from '@onekeyfe/hd-shared';
+import { UI_REQUEST } from '../../constants/ui-request';
 
 const Mainnet = 'mainnet';
 
@@ -388,7 +386,7 @@ export default class AllNetworkGetAddress extends BaseMethod<
       };
       responses.push(result);
       if (this.payload?.bundle?.length > 1) {
-        const progress = Math.round(((i + 1) / this.payload?.bundle?.length) * 100);
+        const progress = Math.round(((i + 1) / this.payload.bundle.length) * 100);
         this.postMessage(createUiMessage(UI_REQUEST.DEVICE_PROGRESS, { progress }));
       }
       this.postPreviousAddressMessage(result);
@@ -403,9 +401,9 @@ function handleSkippableHardwareError(
   device: Device,
   method: BaseMethod,
 ): HardwareError | undefined {
-  let error: HardwareError | undefined = undefined;
+  let error: HardwareError | undefined;
 
-  if (e.message.includes('Failure_UnexpectedMessage')) {
+  if (e.message?.includes('Failure_UnexpectedMessage')) {
     const versionRange = getMethodVersionRange(
       device.features,
       type => method.getVersionRange()[type],
@@ -425,12 +423,12 @@ function handleSkippableHardwareError(
     } else {
       error = ERRORS.TypedError(HardwareErrorCode.CallMethodNotResponse, e.message);
     }
-  } else if (e.message.includes('Forbidden key path')) {
+  } else if (e.message?.includes('Forbidden key path')) {
     error = ERRORS.TypedError(HardwareErrorCode.CallMethodInvalidParameter, e.message);
   } else if (e.message.includes('DeviceCheckPassphraseStateError')) {
     error = ERRORS.TypedError(HardwareErrorCode.DeviceCheckPassphraseStateError, e.message);
   } else if (e instanceof HardwareError) {
-    const errorCode = e.errorCode;
+    const { errorCode } = e;
     if (errorCode === HardwareErrorCode.CallMethodInvalidParameter) {
       error = e;
     }

--- a/packages/core/src/api/allnetwork/AllNetworkGetAddress.ts
+++ b/packages/core/src/api/allnetwork/AllNetworkGetAddress.ts
@@ -305,23 +305,23 @@ export default class AllNetworkGetAddress extends BaseMethod<
 
     method.connector = this.connector;
     method.postMessage = this.postMessage;
-    method.init();
-    method.setDevice?.(this.device);
 
     let result: AllNetworkAddress;
     try {
+      method.init();
+      method.setDevice?.(this.device);
+
       const response = await method.run();
       result = {
         ...baseParams,
         success: true,
-        payload: {
-          ...response,
-          error: response.payload?.error,
-          errorCode: response.payload?.errorCode,
-        },
+        payload: response,
       };
     } catch (e: any) {
+      console.log('=====>>>>>>> error', e, JSON.stringify(e));
+
       const error = handleSkippableHardwareError(e, this.device, method);
+
       if (error) {
         result = {
           ...baseParams,
@@ -403,7 +403,14 @@ function handleSkippableHardwareError(
 ): HardwareError | undefined {
   let error: HardwareError | undefined;
 
-  if (e.message?.includes('Failure_UnexpectedMessage')) {
+  if (e instanceof HardwareError && e.errorCode !== HardwareErrorCode.RuntimeError) {
+    const { errorCode } = e;
+    if (errorCode === HardwareErrorCode.CallMethodInvalidParameter) {
+      error = e;
+    } else if (errorCode === HardwareErrorCode.CallMethodNeedUpgradeFirmware) {
+      error = e;
+    }
+  } else if (e.message?.includes('Failure_UnexpectedMessage')) {
     const versionRange = getMethodVersionRange(
       device.features,
       type => method.getVersionRange()[type],
@@ -423,15 +430,11 @@ function handleSkippableHardwareError(
     } else {
       error = ERRORS.TypedError(HardwareErrorCode.CallMethodNotResponse, e.message);
     }
-  } else if (e.message?.includes('Forbidden key path')) {
+  } else if (
+    e.message?.toLowerCase()?.includes('forbidden key path') ||
+    e.message?.toLowerCase()?.includes('invalid path')
+  ) {
     error = ERRORS.TypedError(HardwareErrorCode.CallMethodInvalidParameter, e.message);
-  } else if (e.message.includes('DeviceCheckPassphraseStateError')) {
-    error = ERRORS.TypedError(HardwareErrorCode.DeviceCheckPassphraseStateError, e.message);
-  } else if (e instanceof HardwareError) {
-    const { errorCode } = e;
-    if (errorCode === HardwareErrorCode.CallMethodInvalidParameter) {
-      error = e;
-    }
   }
 
   return error;

--- a/packages/core/src/api/allnetwork/AllNetworkGetAddress.ts
+++ b/packages/core/src/api/allnetwork/AllNetworkGetAddress.ts
@@ -1,5 +1,5 @@
 import semver from 'semver';
-import { ERRORS, HardwareError, HardwareErrorCode } from '@onekeyfe/hd-shared';
+import { ERRORS, HardwareError, HardwareErrorCode, serializeError } from '@onekeyfe/hd-shared';
 
 import { get } from 'lodash';
 import { serializedPath } from '../helpers/pathUtils';
@@ -318,8 +318,6 @@ export default class AllNetworkGetAddress extends BaseMethod<
         payload: response,
       };
     } catch (e: any) {
-      console.log('=====>>>>>>> error', e, JSON.stringify(e));
-
       const error = handleSkippableHardwareError(e, this.device, method);
 
       if (error) {
@@ -329,8 +327,9 @@ export default class AllNetworkGetAddress extends BaseMethod<
           payload: {
             error: error.message,
             code: error.errorCode,
-            connectId: this.payload.connectId,
-            deviceId: this.payload.deviceId,
+            params: error.params,
+            connectId: method.connectId,
+            deviceId: method.deviceId,
           },
         };
       } else {
@@ -356,7 +355,7 @@ export default class AllNetworkGetAddress extends BaseMethod<
         const response = await this.callMethod(
           dependOnMethod.methodName,
           dependOnMethod.params,
-          param,
+          param
         );
         dependOnMethodResults.push(response);
       }
@@ -376,7 +375,7 @@ export default class AllNetworkGetAddress extends BaseMethod<
 
       const dependOnPayloads = dependOnMethodResults.reduce(
         (acc, cur) => Object.assign(acc, get(cur, 'payload', {})),
-        {},
+        {}
       );
 
       const result: AllNetworkAddress = {
@@ -399,7 +398,7 @@ export default class AllNetworkGetAddress extends BaseMethod<
 function handleSkippableHardwareError(
   e: any,
   device: Device,
-  method: BaseMethod,
+  method: BaseMethod
 ): HardwareError | undefined {
   let error: HardwareError | undefined;
 
@@ -413,7 +412,7 @@ function handleSkippableHardwareError(
   } else if (e.message?.includes('Failure_UnexpectedMessage')) {
     const versionRange = getMethodVersionRange(
       device.features,
-      type => method.getVersionRange()[type],
+      type => method.getVersionRange()[type]
     );
     const currentVersion = getDeviceFirmwareVersion(device.features).join('.');
 
@@ -422,11 +421,7 @@ function handleSkippableHardwareError(
       semver.valid(versionRange.min) &&
       semver.lt(currentVersion, versionRange.min)
     ) {
-      error = ERRORS.TypedError(
-        HardwareErrorCode.CallMethodNeedUpgradeFirmware,
-        `Device firmware version is too low, please update to ${versionRange.min}`,
-        { current: currentVersion, require: versionRange.min },
-      );
+      error = ERRORS.createNeedUpgradeFirmwareHardwareError(currentVersion, versionRange.min);
     } else {
       error = ERRORS.TypedError(HardwareErrorCode.CallMethodNotResponse, e.message);
     }

--- a/packages/core/src/api/dynex/DnxGetAddress.ts
+++ b/packages/core/src/api/dynex/DnxGetAddress.ts
@@ -43,6 +43,9 @@ export default class DnxGetAddress extends BaseMethod<HardwareDnxGetAddress[]> {
       classic: {
         min: '3.8.0',
       },
+      model_touch: {
+        min: '6.0.0',
+      },
     };
   }
 

--- a/packages/core/src/api/dynex/DnxGetAddress.ts
+++ b/packages/core/src/api/dynex/DnxGetAddress.ts
@@ -43,9 +43,6 @@ export default class DnxGetAddress extends BaseMethod<HardwareDnxGetAddress[]> {
       classic: {
         min: '3.8.0',
       },
-      model_touch: {
-        min: '6.0.0',
-      },
     };
   }
 

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -3,6 +3,10 @@ import EventEmitter from 'events';
 import { Features, LowlevelTransportSharedPlugin, OneKeyDeviceInfo } from '@onekeyfe/hd-transport';
 import {
   createDeferred,
+  createDeprecatedHardwareError,
+  createNeedUpgradeFirmwareHardwareError,
+  createNewFirmwareForceUpdateHardwareError,
+  createNewFirmwareUnReleaseHardwareError,
   Deferred,
   ERRORS,
   HardwareError,
@@ -175,26 +179,18 @@ export const callAPI = async (message: CoreMessage) => {
           (newVersionStatus === 'required' || bleVersionStatus === 'required') &&
           method.skipForceUpdateCheck === false
         ) {
-          throw ERRORS.TypedError(
-            HardwareErrorCode.NewFirmwareForceUpdate,
-            'Device firmware version is too low, please update to the latest version',
-            { connectId: method.connectId, deviceId: method.deviceId }
-          );
+          throw createNewFirmwareForceUpdateHardwareError(method.connectId, method.deviceId);
         }
 
         if (versionRange) {
           const currentVersion = getDeviceFirmwareVersion(device.features).join('.');
           if (semver.valid(versionRange.min) && semver.lt(currentVersion, versionRange.min)) {
             if (newVersionStatus === 'none' || newVersionStatus === 'valid') {
-              throw ERRORS.TypedError(HardwareErrorCode.NewFirmwareUnRelease);
+              throw createNewFirmwareUnReleaseHardwareError(currentVersion, versionRange.min);
             }
 
             return Promise.reject(
-              ERRORS.TypedError(
-                HardwareErrorCode.CallMethodNeedUpgradeFirmware,
-                `Device firmware version is too low, please update to ${versionRange.min}`,
-                { current: currentVersion, require: versionRange.min }
-              )
+              createNeedUpgradeFirmwareHardwareError(currentVersion, versionRange.min)
             );
           }
           if (
@@ -202,13 +198,7 @@ export const callAPI = async (message: CoreMessage) => {
             semver.valid(versionRange.max) &&
             semver.gte(currentVersion, versionRange.max)
           ) {
-            return Promise.reject(
-              ERRORS.TypedError(
-                HardwareErrorCode.CallMethodDeprecated,
-                `Device firmware version is too high, this method has been deprecated in ${versionRange.max}`,
-                { current: currentVersion, deprecated: versionRange.max }
-              )
-            );
+            return Promise.reject(createDeprecatedHardwareError(currentVersion, versionRange.max));
           }
         }
       }

--- a/packages/core/src/device/Device.ts
+++ b/packages/core/src/device/Device.ts
@@ -492,6 +492,21 @@ export class Device extends EventEmitter {
           this.runPromise.reject(e);
         }
 
+        if (
+          e instanceof HardwareError &&
+          (e.errorCode === HardwareErrorCode.DeviceInitializeFailed ||
+            e.errorCode === HardwareErrorCode.DeviceInterruptedFromOutside ||
+            e.errorCode === HardwareErrorCode.DeviceInterruptedFromUser ||
+            e.errorCode === HardwareErrorCode.DeviceCheckPassphraseStateError ||
+            e.errorCode === HardwareErrorCode.ResponseUnexpectTypeError ||
+            e.errorCode === HardwareErrorCode.PinInvalid ||
+            e.errorCode === HardwareErrorCode.PinCancelled ||
+            e.errorCode === HardwareErrorCode.UnexpectPassphrase)
+        ) {
+          await this.release();
+          Log.debug(`error code ${e.errorCode} release device, mainId: ${this.mainId}`);
+        }
+
         this.runPromise = null;
         return;
       }

--- a/packages/core/src/types/api/allNetworkGetAddress.ts
+++ b/packages/core/src/types/api/allNetworkGetAddress.ts
@@ -95,8 +95,9 @@ export type AllNetworkAddress = CommonResponseParams & {
     | {
         error: string;
         code: number;
-        connectId: string;
-        deviceId: string;
+        connectId?: string;
+        deviceId?: string;
+        params: any;
       };
 };
 

--- a/packages/core/src/types/api/allNetworkGetAddress.ts
+++ b/packages/core/src/types/api/allNetworkGetAddress.ts
@@ -107,5 +107,5 @@ export type AllNetworkGetAddressParams = {
 export declare function allNetworkGetAddress(
   connectId: string,
   deviceId: string,
-  params: CommonParams & AllNetworkGetAddressParams,
+  params: CommonParams & AllNetworkGetAddressParams
 ): Response<AllNetworkAddress[]>;

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "^1.0.13",
-    "@onekeyfe/hd-shared": "^1.0.13",
-    "@onekeyfe/hd-transport-react-native": "^1.0.13"
+    "@onekeyfe/hd-core": "^1.0.14",
+    "@onekeyfe/hd-shared": "^1.0.14",
+    "@onekeyfe/hd-transport-react-native": "^1.0.14"
   }
 }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,10 +20,10 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "^1.0.13",
-    "@onekeyfe/hd-shared": "^1.0.13",
-    "@onekeyfe/hd-transport-http": "^1.0.13",
-    "@onekeyfe/hd-transport-lowlevel": "^1.0.13",
-    "@onekeyfe/hd-transport-webusb": "^1.0.13"
+    "@onekeyfe/hd-core": "^1.0.14",
+    "@onekeyfe/hd-shared": "^1.0.14",
+    "@onekeyfe/hd-transport-http": "^1.0.14",
+    "@onekeyfe/hd-transport-lowlevel": "^1.0.14",
+    "@onekeyfe/hd-transport-webusb": "^1.0.14"
   }
 }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.13",
-    "@onekeyfe/hd-transport": "^1.0.13",
+    "@onekeyfe/hd-shared": "^1.0.14",
+    "@onekeyfe/hd-transport": "^1.0.14",
     "axios": "^0.27.2"
   }
 }

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.13",
-    "@onekeyfe/hd-transport": "^1.0.13"
+    "@onekeyfe/hd-shared": "^1.0.14",
+    "@onekeyfe/hd-transport": "^1.0.14"
   }
 }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,8 +19,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.13",
-    "@onekeyfe/hd-transport": "^1.0.13",
+    "@onekeyfe/hd-shared": "^1.0.14",
+    "@onekeyfe/hd-transport": "^1.0.14",
     "@onekeyfe/react-native-ble-plx": "3.0.1",
     "react-native-ble-manager": "^8.1.0"
   }

--- a/packages/hd-transport-webusb/package.json
+++ b/packages/hd-transport-webusb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-webusb",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.13",
-    "@onekeyfe/hd-transport": "^1.0.13"
+    "@onekeyfe/hd-shared": "^1.0.14",
+    "@onekeyfe/hd-transport": "^1.0.14"
   },
   "devDependencies": {
     "@types/w3c-web-usb": "^1.0.6"

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "> TODO: description",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "^0.0.17",
-    "@onekeyfe/hd-core": "^1.0.13",
-    "@onekeyfe/hd-shared": "^1.0.13",
-    "@onekeyfe/hd-transport-http": "^1.0.13",
-    "@onekeyfe/hd-transport-webusb": "^1.0.13"
+    "@onekeyfe/hd-core": "^1.0.14",
+    "@onekeyfe/hd-shared": "^1.0.14",
+    "@onekeyfe/hd-transport-http": "^1.0.14",
+    "@onekeyfe/hd-transport-webusb": "^1.0.14"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",

--- a/packages/shared/src/HardwareError.ts
+++ b/packages/shared/src/HardwareError.ts
@@ -523,3 +523,41 @@ export const CreateErrorByMessage = (message: string): HardwareError => {
   }
   return new HardwareError(message);
 };
+
+const createNewFirmwareUnReleaseHardwareError = (currentVersion: string, requireVersion: string) =>
+  TypedError(
+    HardwareErrorCode.NewFirmwareUnRelease,
+    'Device firmware version is too low, please update to the latest version',
+    { current: currentVersion, require: requireVersion }
+  );
+
+const createNeedUpgradeFirmwareHardwareError = (currentVersion: string, requireVersion: string) =>
+  TypedError(
+    HardwareErrorCode.CallMethodNeedUpgradeFirmware,
+    `Device firmware version is too low, please update to ${requireVersion}`,
+    { current: currentVersion, require: requireVersion }
+  );
+
+const createNewFirmwareForceUpdateHardwareError = (
+  connectId: string | undefined,
+  deviceId: string | undefined
+) =>
+  TypedError(
+    HardwareErrorCode.NewFirmwareForceUpdate,
+    'Device firmware version is too low, please update to the latest version',
+    { connectId, deviceId }
+  );
+
+const createDeprecatedHardwareError = (currentVersion: string, deprecatedVersion: string) =>
+  TypedError(
+    HardwareErrorCode.CallMethodDeprecated,
+    `Device firmware version is too high, this method has been deprecated in ${deprecatedVersion}`,
+    { current: currentVersion, deprecated: deprecatedVersion }
+  );
+
+export {
+  createNewFirmwareUnReleaseHardwareError,
+  createNeedUpgradeFirmwareHardwareError,
+  createNewFirmwareForceUpdateHardwareError,
+  createDeprecatedHardwareError,
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 在Expo示例中添加了“使用空密码短语”的本地化标签。
  - 在设备参数视图中新增了切换输入选项，允许用户配置“使用空密码短语”。
  
- **版本更新**
  - 多个包的版本号已从`1.0.13`更新至`1.0.14`，包括`@onekeyfe/hd-ble-sdk`、`@onekeyfe/hd-common-connect-sdk`、`@onekeyfe/hd-transport`等。

- **错误处理增强**
  - 新增了多个与硬件错误相关的函数，改善了固件更新和过时方法的错误处理能力。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->