### PR TITLE
fix: return address with BFC type

### DIFF
--- a/packages/connect-examples/electron-example/package.json
+++ b/packages/connect-examples/electron-example/package.json
@@ -2,7 +2,7 @@
   "name": "hardware-example",
   "productName": "HardwareExample",
   "executableName": "onekey-hardware-example",
-  "version": "1.0.15-alpha.0",
+  "version": "1.0.15-alpha.1",
   "author": "OneKey",
   "description": "End-to-end encrypted workspaces for teams",
   "main": "dist/index.js",

--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.0.15-alpha.0",
+  "version": "1.0.15-alpha.1",
   "scripts": {
     "start": "CONNECT_SRC=https://localhost:8087/ yarn expo start --dev-client",
     "android": "yarn expo run:android",
@@ -19,10 +19,10 @@
     "@noble/ed25519": "^2.1.0",
     "@noble/hashes": "^1.3.3",
     "@noble/secp256k1": "^1.7.1",
-    "@onekeyfe/hd-ble-sdk": "^1.0.15-alpha.0",
-    "@onekeyfe/hd-common-connect-sdk": "^1.0.15-alpha.0",
-    "@onekeyfe/hd-core": "^1.0.15-alpha.0",
-    "@onekeyfe/hd-web-sdk": "^1.0.15-alpha.0",
+    "@onekeyfe/hd-ble-sdk": "^1.0.15-alpha.1",
+    "@onekeyfe/hd-common-connect-sdk": "^1.0.15-alpha.1",
+    "@onekeyfe/hd-core": "^1.0.15-alpha.1",
+    "@onekeyfe/hd-web-sdk": "^1.0.15-alpha.1",
     "@onekeyfe/react-native-ble-plx": "3.0.0",
     "@polkadot/util-crypto": "13.1.1",
     "@react-native-async-storage/async-storage": "1.21.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.0.15-alpha.0",
+  "version": "1.0.15-alpha.1",
   "description": "> TODO: description",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.15-alpha.0",
-    "@onekeyfe/hd-transport": "^1.0.15-alpha.0",
+    "@onekeyfe/hd-shared": "^1.0.15-alpha.1",
+    "@onekeyfe/hd-transport": "^1.0.15-alpha.1",
     "axios": "^0.27.2",
     "bignumber.js": "^9.0.2",
     "bytebuffer": "^5.0.1",

--- a/packages/core/src/api/benfen/BenfenGetAddress.ts
+++ b/packages/core/src/api/benfen/BenfenGetAddress.ts
@@ -77,7 +77,7 @@ export default class BenfenGetAddress extends BaseMethod<HardwareBenfenGetAddres
             'Address',
             param
           );
-          address = addressRes.message.address?.toLowerCase();
+          address = addressRes.message.address;
         } else {
           address = publicKeyToAddress(publicKey);
         }

--- a/packages/core/src/api/benfen/BenfenGetAddress.ts
+++ b/packages/core/src/api/benfen/BenfenGetAddress.ts
@@ -101,7 +101,7 @@ export default class BenfenGetAddress extends BaseMethod<HardwareBenfenGetAddres
           const res = await this.device.commands.typedCall('BenfenGetAddress', 'Address', param);
           const result = {
             path: serializedPath(param.address_n),
-            address: hex2BfcAddress(res.message.address?.toLowerCase()),
+            address: hex2BfcAddress(res.message.address),
           };
           if (this.shouldConfirm) {
             this.postPreviousAddressMessage(result);

--- a/packages/core/src/api/benfen/BenfenGetAddress.ts
+++ b/packages/core/src/api/benfen/BenfenGetAddress.ts
@@ -101,7 +101,7 @@ export default class BenfenGetAddress extends BaseMethod<HardwareBenfenGetAddres
           const res = await this.device.commands.typedCall('BenfenGetAddress', 'Address', param);
           const result = {
             path: serializedPath(param.address_n),
-            address: res.message.address?.toLowerCase() ?? '',
+            address: hex2BfcAddress(res.message.address?.toLowerCase()),
           };
           if (this.shouldConfirm) {
             this.postPreviousAddressMessage(result);

--- a/packages/core/src/api/benfen/BenfenGetAddress.ts
+++ b/packages/core/src/api/benfen/BenfenGetAddress.ts
@@ -4,7 +4,7 @@ import { BaseMethod } from '../BaseMethod';
 import { validateParams, validateResult } from '../helpers/paramsValidator';
 import { serializedPath, validatePath } from '../helpers/pathUtils';
 import { UI_REQUEST } from '../../constants/ui-request';
-import { publicKeyToAddress } from './normalize';
+import { hex2BfcAddress, publicKeyToAddress } from './normalize';
 import { BenfenAddress, BenfenGetAddressParams } from '../../types';
 import { supportBatchPublicKey } from '../../utils/deviceFeaturesUtils';
 
@@ -77,14 +77,15 @@ export default class BenfenGetAddress extends BaseMethod<HardwareBenfenGetAddres
             'Address',
             param
           );
-          address = addressRes.message.address?.toLowerCase() ?? '';
+          address = addressRes.message.address?.toLowerCase();
         } else {
           address = publicKeyToAddress(publicKey);
         }
 
         const result = {
           path: serializedPath(param.address_n),
-          address,
+          // 将 address 转为BFC格式
+          address: hex2BfcAddress(address),
           pub: publicKey,
         };
 

--- a/packages/core/src/api/benfen/BenfenSignTransaction.ts
+++ b/packages/core/src/api/benfen/BenfenSignTransaction.ts
@@ -16,16 +16,19 @@ export default class BenfenSignTransaction extends BaseMethod<BenfenSignTx> {
     validateParams(this.payload, [
       { name: 'path', required: true },
       { name: 'rawTx', type: 'hexString', required: true },
-      { name: 'coinType', type: 'hexString', required: true },
+      { name: 'coinType', type: 'string', required: true },
     ]);
 
     const { path, rawTx, coinType } = this.payload;
     const addressN = validatePath(path, 3);
+    const coinTypeHex = coinType.startsWith('0x')
+      ? coinType.slice(2)
+      : Buffer.from(coinType).toString('hex');
 
     this.params = {
       address_n: addressN,
       raw_tx: formatAnyHex(rawTx),
-      coin_type: formatAnyHex(coinType),
+      coin_type: formatAnyHex(coinTypeHex),
     };
   }
 

--- a/packages/core/src/api/benfen/normalize.ts
+++ b/packages/core/src/api/benfen/normalize.ts
@@ -1,5 +1,6 @@
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import { blake2b } from '@noble/hashes/blake2b';
+import { sha256 } from '@noble/hashes/sha256';
 
 export const BENFEN_ADDRESS_LENGTH = 32;
 export const PUBLIC_KEY_SIZE = 32;
@@ -24,4 +25,21 @@ export function publicKeyToAddress(publicKey: string) {
   return normalizeBenfenAddress(
     bytesToHex(blake2b(tmp, { dkLen: 32 })).slice(0, BENFEN_ADDRESS_LENGTH * 2)
   );
+}
+
+export function hex2BfcAddress(hexAddress: string): string {
+  // 如果已经是BFC格式，直接返回
+  if (/^BFC/i.test(hexAddress)) {
+    return hexAddress;
+  }
+
+  // 移除0x前缀，补齐64位，转小写
+  const hex = hexAddress.replace(/^0x/, '').padStart(64, '0').toLowerCase();
+
+  // 使用SHA-256计算校验和
+  const hash = sha256(new TextEncoder().encode(hex));
+  const checksumHex = bytesToHex(hash).slice(0, 4);
+
+  // 返回BFC格式地址
+  return `BFC${hex}${checksumHex}`;
 }

--- a/packages/core/src/api/sui/SuiGetAddress.ts
+++ b/packages/core/src/api/sui/SuiGetAddress.ts
@@ -80,7 +80,7 @@ export default class SuiGetAddress extends BaseMethod<HardwareSuiGetAddress[]> {
             'SuiAddress',
             param
           );
-          address = addressRes.message.address?.toLowerCase() ?? '';
+          address = addressRes.message.address?.toLowerCase();
         } else {
           address = publicKeyToAddress(publicKey);
         }

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.0.15-alpha.0",
+  "version": "1.0.15-alpha.1",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "^1.0.15-alpha.0",
-    "@onekeyfe/hd-shared": "^1.0.15-alpha.0",
-    "@onekeyfe/hd-transport-react-native": "^1.0.15-alpha.0"
+    "@onekeyfe/hd-core": "^1.0.15-alpha.1",
+    "@onekeyfe/hd-shared": "^1.0.15-alpha.1",
+    "@onekeyfe/hd-transport-react-native": "^1.0.15-alpha.1"
   }
 }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.0.15-alpha.0",
+  "version": "1.0.15-alpha.1",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,10 +20,10 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "^1.0.15-alpha.0",
-    "@onekeyfe/hd-shared": "^1.0.15-alpha.0",
-    "@onekeyfe/hd-transport-http": "^1.0.15-alpha.0",
-    "@onekeyfe/hd-transport-lowlevel": "^1.0.15-alpha.0",
-    "@onekeyfe/hd-transport-webusb": "^1.0.15-alpha.0"
+    "@onekeyfe/hd-core": "^1.0.15-alpha.1",
+    "@onekeyfe/hd-shared": "^1.0.15-alpha.1",
+    "@onekeyfe/hd-transport-http": "^1.0.15-alpha.1",
+    "@onekeyfe/hd-transport-lowlevel": "^1.0.15-alpha.1",
+    "@onekeyfe/hd-transport-webusb": "^1.0.15-alpha.1"
   }
 }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.0.15-alpha.0",
+  "version": "1.0.15-alpha.1",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.15-alpha.0",
-    "@onekeyfe/hd-transport": "^1.0.15-alpha.0",
+    "@onekeyfe/hd-shared": "^1.0.15-alpha.1",
+    "@onekeyfe/hd-transport": "^1.0.15-alpha.1",
     "axios": "^0.27.2"
   }
 }

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.0.15-alpha.0",
+  "version": "1.0.15-alpha.1",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.15-alpha.0",
-    "@onekeyfe/hd-transport": "^1.0.15-alpha.0"
+    "@onekeyfe/hd-shared": "^1.0.15-alpha.1",
+    "@onekeyfe/hd-transport": "^1.0.15-alpha.1"
   }
 }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.0.15-alpha.0",
+  "version": "1.0.15-alpha.1",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,8 +19,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.15-alpha.0",
-    "@onekeyfe/hd-transport": "^1.0.15-alpha.0",
+    "@onekeyfe/hd-shared": "^1.0.15-alpha.1",
+    "@onekeyfe/hd-transport": "^1.0.15-alpha.1",
     "@onekeyfe/react-native-ble-plx": "3.0.1",
     "react-native-ble-manager": "^8.1.0"
   }

--- a/packages/hd-transport-webusb/package.json
+++ b/packages/hd-transport-webusb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-webusb",
-  "version": "1.0.15-alpha.0",
+  "version": "1.0.15-alpha.1",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.15-alpha.0",
-    "@onekeyfe/hd-transport": "^1.0.15-alpha.0"
+    "@onekeyfe/hd-shared": "^1.0.15-alpha.1",
+    "@onekeyfe/hd-transport": "^1.0.15-alpha.1"
   },
   "devDependencies": {
     "@types/w3c-web-usb": "^1.0.6"

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.0.15-alpha.0",
+  "version": "1.0.15-alpha.1",
   "description": "> TODO: description",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-transport/src/types/messages.ts
+++ b/packages/hd-transport/src/types/messages.ts
@@ -141,7 +141,7 @@ export type BenfenGetAddress = {
 
 // BenfenAddress
 export type BenfenAddress = {
-  address?: string;
+  address: string;
 };
 
 // BenfenSignTx
@@ -3720,7 +3720,7 @@ export type SuiGetAddress = {
 
 // SuiAddress
 export type SuiAddress = {
-  address?: string;
+  address: string;
 };
 
 // SuiSignTx

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.0.15-alpha.0",
+  "version": "1.0.15-alpha.1",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "^0.0.17",
-    "@onekeyfe/hd-core": "^1.0.15-alpha.0",
-    "@onekeyfe/hd-shared": "^1.0.15-alpha.0",
-    "@onekeyfe/hd-transport-http": "^1.0.15-alpha.0",
-    "@onekeyfe/hd-transport-webusb": "^1.0.15-alpha.0"
+    "@onekeyfe/hd-core": "^1.0.15-alpha.1",
+    "@onekeyfe/hd-shared": "^1.0.15-alpha.1",
+    "@onekeyfe/hd-transport-http": "^1.0.15-alpha.1",
+    "@onekeyfe/hd-transport-webusb": "^1.0.15-alpha.1"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.0.15-alpha.0",
+  "version": "1.0.15-alpha.1",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 引入了 `hex2BfcAddress` 函数，用于将十六进制地址转换为 BFC 格式。
- **版本更新**
	- 所有相关包的版本号已更新至 `1.0.15-alpha.1`。
	- 更新了多个依赖项，以确保与新版本的兼容性。
- **类型定义更改**
	- `BenfenAddress` 和 `SuiAddress` 类型的 `address` 属性已更改为必需字段。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->