### PR TITLE
refactor: update platform type 'webEmbed' to 'web-embed'

### DIFF
--- a/packages/connect-examples/electron-example/package.json
+++ b/packages/connect-examples/electron-example/package.json
@@ -2,7 +2,7 @@
   "name": "hardware-example",
   "productName": "HardwareExample",
   "executableName": "onekey-hardware-example",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "author": "OneKey",
   "description": "End-to-end encrypted workspaces for teams",
   "main": "dist/index.js",

--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "scripts": {
     "start": "CONNECT_SRC=https://localhost:8087/ yarn expo start --dev-client",
     "android": "yarn expo run:android",
@@ -19,10 +19,10 @@
     "@noble/ed25519": "^2.1.0",
     "@noble/hashes": "^1.3.3",
     "@noble/secp256k1": "^1.7.1",
-    "@onekeyfe/hd-ble-sdk": "^1.0.33",
-    "@onekeyfe/hd-common-connect-sdk": "^1.0.33",
-    "@onekeyfe/hd-core": "^1.0.33",
-    "@onekeyfe/hd-web-sdk": "^1.0.33",
+    "@onekeyfe/hd-ble-sdk": "^1.0.34",
+    "@onekeyfe/hd-common-connect-sdk": "^1.0.34",
+    "@onekeyfe/hd-core": "^1.0.34",
+    "@onekeyfe/hd-web-sdk": "^1.0.34",
     "@onekeyfe/react-native-ble-utils": "^0.1.3",
     "@polkadot/util-crypto": "13.1.1",
     "@react-native-async-storage/async-storage": "1.21.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "> TODO: description",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.33",
-    "@onekeyfe/hd-transport": "^1.0.33",
+    "@onekeyfe/hd-shared": "^1.0.34",
+    "@onekeyfe/hd-transport": "^1.0.34",
     "axios": "^0.27.2",
     "bignumber.js": "^9.0.2",
     "bytebuffer": "^5.0.1",

--- a/packages/core/src/types/api/firmwareUpdate.ts
+++ b/packages/core/src/types/api/firmwareUpdate.ts
@@ -25,7 +25,7 @@ export declare function firmwareUpdate(
   params: Params<FirmwareUpdateBinaryParams> & { rebootOnSuccess?: boolean }
 ): Response<PROTO.Success>;
 
-type IPlatform = 'native' | 'desktop' | 'ext' | 'web' | 'webEmbed';
+type IPlatform = 'native' | 'desktop' | 'ext' | 'web' | 'web-embed';
 type Platform = { platform: IPlatform };
 
 export declare function firmwareUpdateV2(

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "^1.0.33",
-    "@onekeyfe/hd-shared": "^1.0.33",
-    "@onekeyfe/hd-transport-react-native": "^1.0.33"
+    "@onekeyfe/hd-core": "^1.0.34",
+    "@onekeyfe/hd-shared": "^1.0.34",
+    "@onekeyfe/hd-transport-react-native": "^1.0.34"
   }
 }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,10 +20,10 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "^1.0.33",
-    "@onekeyfe/hd-shared": "^1.0.33",
-    "@onekeyfe/hd-transport-http": "^1.0.33",
-    "@onekeyfe/hd-transport-lowlevel": "^1.0.33",
-    "@onekeyfe/hd-transport-webusb": "^1.0.33"
+    "@onekeyfe/hd-core": "^1.0.34",
+    "@onekeyfe/hd-shared": "^1.0.34",
+    "@onekeyfe/hd-transport-http": "^1.0.34",
+    "@onekeyfe/hd-transport-lowlevel": "^1.0.34",
+    "@onekeyfe/hd-transport-webusb": "^1.0.34"
   }
 }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.33",
-    "@onekeyfe/hd-transport": "^1.0.33",
+    "@onekeyfe/hd-shared": "^1.0.34",
+    "@onekeyfe/hd-transport": "^1.0.34",
     "axios": "^0.27.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.33",
-    "@onekeyfe/hd-transport": "^1.0.33"
+    "@onekeyfe/hd-shared": "^1.0.34",
+    "@onekeyfe/hd-transport": "^1.0.34"
   }
 }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,8 +19,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.33",
-    "@onekeyfe/hd-transport": "^1.0.33",
+    "@onekeyfe/hd-shared": "^1.0.34",
+    "@onekeyfe/hd-transport": "^1.0.34",
     "@onekeyfe/react-native-ble-utils": "^0.1.4",
     "react-native-ble-plx": "3.5.0"
   }

--- a/packages/hd-transport-webusb/package.json
+++ b/packages/hd-transport-webusb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-webusb",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "^1.0.33",
-    "@onekeyfe/hd-transport": "^1.0.33"
+    "@onekeyfe/hd-shared": "^1.0.34",
+    "@onekeyfe/hd-transport": "^1.0.34"
   },
   "devDependencies": {
     "@types/w3c-web-usb": "^1.0.6",

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "> TODO: description",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "^0.0.17",
-    "@onekeyfe/hd-core": "^1.0.33",
-    "@onekeyfe/hd-shared": "^1.0.33",
-    "@onekeyfe/hd-transport-http": "^1.0.33",
-    "@onekeyfe/hd-transport-webusb": "^1.0.33"
+    "@onekeyfe/hd-core": "^1.0.34",
+    "@onekeyfe/hd-shared": "^1.0.34",
+    "@onekeyfe/hd-transport-http": "^1.0.34",
+    "@onekeyfe/hd-transport-webusb": "^1.0.34"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package versions across multiple components from 1.0.33 to 1.0.34.
  - Synchronized dependency versions to 1.0.34 for improved consistency and compatibility.

- **Refactor**
  - Standardized a platform identifier to use kebab-case ("web-embed" instead of "webEmbed") for improved naming consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->