### PR TITLE
Feat/aptos sign in

### DIFF
--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.1.9",
+  "version": "1.1.10-alpha.3",
   "scripts": {
     "start": "cross-env CONNECT_SRC=https://localhost:8087/ yarn expo start --dev-client",
     "android": "yarn expo run:android",
@@ -19,10 +19,10 @@
     "@noble/ed25519": "^2.1.0",
     "@noble/hashes": "^1.3.3",
     "@noble/secp256k1": "^1.7.1",
-    "@onekeyfe/hd-ble-sdk": "1.1.9",
-    "@onekeyfe/hd-common-connect-sdk": "1.1.9",
-    "@onekeyfe/hd-core": "1.1.9",
-    "@onekeyfe/hd-web-sdk": "1.1.9",
+    "@onekeyfe/hd-ble-sdk": "1.1.10-alpha.3",
+    "@onekeyfe/hd-common-connect-sdk": "1.1.10-alpha.3",
+    "@onekeyfe/hd-core": "1.1.10-alpha.3",
+    "@onekeyfe/hd-web-sdk": "1.1.10-alpha.3",
     "@onekeyfe/react-native-ble-utils": "^0.1.3",
     "@polkadot/util-crypto": "13.1.1",
     "@react-native-async-storage/async-storage": "1.21.0",

--- a/packages/connect-examples/expo-example/src/data/aptos.ts
+++ b/packages/connect-examples/expo-example/src/data/aptos.ts
@@ -85,6 +85,19 @@ const api: PlaygroundProps[] = [
     ],
   },
   {
+    method: 'aptosSignInMessage',
+    presupposes: [
+      {
+        title: 'Sign message',
+        value: {
+          path: "m/44'/637'/0'/0'/0'",
+          payload:
+            'localhost:3000 wants you to sign in with your Aptos account:\\n0xeb2d1d9bbfca9d892e124e858f1dc449935a3f785f8860892e03fb9820db1839\\n\\nSigning into demo application\\n\\nURI: https://dapp-example.onekeytest.com\\nVersion: 1.0.0\\nNonce: 0.72024fabf0bbd\\nIssued At: 2025-08-20T08:58:22.851Z\\nExpiration Time: 2025-08-21T08:58:22.851Z\\nNot Before: 2025-08-20T08:58:22.851Z\\nRequest ID: abc\\nChain ID: aptos--1\\nResources:\\n- resource.1\\n- resource.2',
+        },
+      },
+    ],
+  },
+  {
     method: 'aptosSignTransaction',
 
     presupposes: [

--- a/packages/connect-examples/expo-example/src/data/tron.ts
+++ b/packages/connect-examples/expo-example/src/data/tron.ts
@@ -38,10 +38,19 @@ const api: PlaygroundProps[] = [
 
     presupposes: [
       {
-        title: 'Sign Message',
+        title: 'Sign Message V2',
         value: {
           path: "m/44'/195'/0'/0/0",
           messageHex: '0x6578616d706c65206d657373616765',
+          messageType: 'V2',
+        },
+      },
+      {
+        title: 'Sign Message V1 not support',
+        value: {
+          path: "m/44'/195'/0'/0/0",
+          messageHex: '0x6578616d706c65206d657373616765',
+          messageType: 'V1',
         },
       },
     ],

--- a/packages/connect-examples/expo-playground/package.json
+++ b/packages/connect-examples/expo-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onekey-hardware-playground",
-  "version": "1.1.9",
+  "version": "1.1.10-alpha.3",
   "private": true,
   "sideEffects": [
     "app/utils/shim.js",
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0",
-    "@onekeyfe/hd-core": "1.1.9",
-    "@onekeyfe/hd-shared": "1.1.9",
-    "@onekeyfe/hd-web-sdk": "1.1.9",
+    "@onekeyfe/hd-core": "1.1.10-alpha.3",
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-web-sdk": "1.1.10-alpha.3",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.1.9",
+  "version": "1.1.10-alpha.3",
   "description": "> TODO: description",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.9",
-    "@onekeyfe/hd-transport": "1.1.9",
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport": "1.1.10-alpha.3",
     "axios": "^0.27.2",
     "bignumber.js": "^9.0.2",
     "bytebuffer": "^5.0.1",

--- a/packages/core/src/api/aptos/AptosSignInMessage.ts
+++ b/packages/core/src/api/aptos/AptosSignInMessage.ts
@@ -1,0 +1,54 @@
+import { AptosSignSIWAMessage } from '@onekeyfe/hd-transport';
+import { UI_REQUEST } from '../../constants/ui-request';
+import { serializedPath, validatePath } from '../helpers/pathUtils';
+import { BaseMethod } from '../BaseMethod';
+import { validateParams } from '../helpers/paramsValidator';
+import { AptosSignInMessageParams, AptosSignInMessageSignature } from '../../types';
+
+export default class AptosSignInMessage extends BaseMethod<AptosSignSIWAMessage> {
+  init() {
+    this.checkDeviceId = true;
+    this.allowDeviceMode = [...this.allowDeviceMode, UI_REQUEST.NOT_INITIALIZE];
+
+    // check payload
+    validateParams(this.payload, [
+      { name: 'path', required: true },
+      { name: 'payload', type: 'string', required: true },
+    ]);
+
+    const { path, payload } = this.payload as AptosSignInMessageParams;
+    const addressN = validatePath(path, 3);
+
+    // init params
+    this.params = {
+      address_n: addressN,
+      siwa_payload: payload,
+    };
+  }
+
+  getVersionRange() {
+    return {
+      pro: {
+        min: '4.15.0',
+      },
+    };
+  }
+
+  async run() {
+    const res = await this.device.commands.typedCall(
+      'AptosSignSIWAMessage',
+      'AptosMessageSignature',
+      {
+        ...this.params,
+      }
+    );
+
+    const { address, signature } = res.message;
+
+    return Promise.resolve<AptosSignInMessageSignature>({
+      path: serializedPath(this.params.address_n),
+      address,
+      signature,
+    });
+  }
+}

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -91,6 +91,7 @@ export { default as aptosGetAddress } from './aptos/AptosGetAddress';
 export { default as aptosGetPublicKey } from './aptos/AptosGetPublicKey';
 export { default as aptosSignTransaction } from './aptos/AptosSignTransaction';
 export { default as aptosSignMessage } from './aptos/AptosSignMessage';
+export { default as aptosSignInMessage } from './aptos/AptosSignInMessage';
 
 export { default as algoGetAddress } from './algo/AlgoGetAddress';
 export { default as algoSignTransaction } from './algo/AlgoSignTransaction';

--- a/packages/core/src/api/tron/TronSignMessage.ts
+++ b/packages/core/src/api/tron/TronSignMessage.ts
@@ -1,4 +1,8 @@
-import { TronSignMessage as HardwareTronSignMessage } from '@onekeyfe/hd-transport';
+import {
+  TronSignMessage as HardwareTronSignMessage,
+  TronMessageType,
+} from '@onekeyfe/hd-transport';
+import { ERRORS, HardwareErrorCode } from '@onekeyfe/hd-shared';
 import { UI_REQUEST } from '../../constants/ui-request';
 import { validatePath } from '../helpers/pathUtils';
 import { BaseMethod } from '../BaseMethod';
@@ -14,15 +18,26 @@ export default class TronSignMessage extends BaseMethod<HardwareTronSignMessage>
     validateParams(this.payload, [
       { name: 'path', required: true },
       { name: 'messageHex', type: 'hexString', required: true },
+      { name: 'messageType', type: 'string' },
     ]);
 
     const { path, messageHex } = this.payload;
     const addressN = validatePath(path, 3);
 
+    if (this.payload.messageType === 'V1' || this.payload.messageType == null) {
+      throw ERRORS.TypedError(
+        HardwareErrorCode.DeviceNotSupportMethod,
+        'not support tron message v1'
+      );
+    }
+
+    const messageType = TronMessageType.V2;
+
     // init params
     this.params = {
       address_n: addressN,
       message: stripHexPrefix(messageHex),
+      message_type: messageType,
     };
   }
 
@@ -34,7 +49,23 @@ export default class TronSignMessage extends BaseMethod<HardwareTronSignMessage>
     };
   }
 
+  getMessageV2VersionRange() {
+    return {
+      pro: {
+        min: '4.15.0',
+      },
+    };
+  }
+
   async run() {
+    this.checkFeatureVersionLimit(
+      () => this.params.message_type === TronMessageType.V2,
+      () => this.getMessageV2VersionRange(),
+      {
+        strictCheckDeviceSupport: true,
+      }
+    );
+
     const response = await this.device.commands.typedCall(
       'TronSignMessage',
       'TronMessageSignature',

--- a/packages/core/src/data/messages/messages.json
+++ b/packages/core/src/data/messages/messages.json
@@ -11722,6 +11722,12 @@
         }
       }
     },
+    "TronMessageType": {
+      "values": {
+        "V1": 1,
+        "V2": 2
+      }
+    },
     "TronSignMessage": {
       "fields": {
         "address_n": {
@@ -11736,6 +11742,13 @@
           "rule": "required",
           "type": "bytes",
           "id": 2
+        },
+        "message_type": {
+          "type": "TronMessageType",
+          "id": 3,
+          "options": {
+            "default": "V1"
+          }
         }
       }
     },

--- a/packages/core/src/data/messages/messages.json
+++ b/packages/core/src/data/messages/messages.json
@@ -341,6 +341,23 @@
         }
       }
     },
+    "AptosSignSIWAMessage": {
+      "fields": {
+        "address_n": {
+          "rule": "repeated",
+          "type": "uint32",
+          "id": 1,
+          "options": {
+            "packed": false
+          }
+        },
+        "siwa_payload": {
+          "rule": "required",
+          "type": "string",
+          "id": 2
+        }
+      }
+    },
     "BenfenGetAddress": {
       "fields": {
         "address_n": {
@@ -5241,6 +5258,20 @@
         }
       }
     },
+    "EthereumAccessListOneKey": {
+      "fields": {
+        "address": {
+          "rule": "required",
+          "type": "string",
+          "id": 1
+        },
+        "storage_keys": {
+          "rule": "repeated",
+          "type": "bytes",
+          "id": 2
+        }
+      }
+    },
     "EthereumSignTxEIP1559OneKey": {
       "fields": {
         "address_n": {
@@ -5305,19 +5336,124 @@
           "type": "EthereumAccessListOneKey",
           "id": 11
         }
+      }
+    },
+    "EthereumAuthorizationSignature": {
+      "fields": {
+        "y_parity": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 1
+        },
+        "r": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 2
+        },
+        "s": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 3
+        }
+      }
+    },
+    "EthereumSignTxEIP7702OneKey": {
+      "fields": {
+        "address_n": {
+          "rule": "repeated",
+          "type": "uint32",
+          "id": 1,
+          "options": {
+            "packed": false
+          }
+        },
+        "nonce": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 2
+        },
+        "max_gas_fee": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 3
+        },
+        "max_priority_fee": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 4
+        },
+        "gas_limit": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 5
+        },
+        "to": {
+          "rule": "required",
+          "type": "string",
+          "id": 6
+        },
+        "value": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 7
+        },
+        "data_initial_chunk": {
+          "type": "bytes",
+          "id": 8,
+          "options": {
+            "default": ""
+          }
+        },
+        "data_length": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 9
+        },
+        "chain_id": {
+          "rule": "required",
+          "type": "uint64",
+          "id": 10
+        },
+        "access_list": {
+          "rule": "repeated",
+          "type": "EthereumAccessListOneKey",
+          "id": 11
+        },
+        "authorization_list": {
+          "rule": "repeated",
+          "type": "EthereumAuthorizationOneKey",
+          "id": 12
+        }
       },
       "nested": {
-        "EthereumAccessListOneKey": {
+        "EthereumAuthorizationOneKey": {
           "fields": {
+            "address_n": {
+              "rule": "repeated",
+              "type": "uint32",
+              "id": 1,
+              "options": {
+                "packed": false
+              }
+            },
+            "chain_id": {
+              "rule": "required",
+              "type": "uint64",
+              "id": 2
+            },
             "address": {
               "rule": "required",
               "type": "string",
-              "id": 1
+              "id": 3
             },
-            "storage_keys": {
-              "rule": "repeated",
+            "nonce": {
+              "rule": "required",
               "type": "bytes",
-              "id": 2
+              "id": 4
+            },
+            "signature": {
+              "type": "EthereumAuthorizationSignature",
+              "id": 5
             }
           }
         }
@@ -5340,6 +5476,11 @@
         "signature_s": {
           "type": "bytes",
           "id": 4
+        },
+        "authorization_signatures": {
+          "rule": "repeated",
+          "type": "EthereumAuthorizationSignature",
+          "id": 10
         }
       }
     },
@@ -11914,6 +12055,7 @@
         "MessageType_EthereumSignTypedHashOneKey": 20117,
         "MessageType_EthereumGnosisSafeTxAck": 20118,
         "MessageType_EthereumGnosisSafeTxRequest": 20119,
+        "MessageType_EthereumSignTxEIP7702OneKey": 20120,
         "MessageType_NEMGetAddress": 67,
         "MessageType_NEMAddress": 68,
         "MessageType_NEMSignTx": 69,
@@ -12055,6 +12197,7 @@
         "MessageType_AptosSignedTx": 10603,
         "MessageType_AptosSignMessage": 10604,
         "MessageType_AptosMessageSignature": 10605,
+        "MessageType_AptosSignSIWAMessage": 10606,
         "MessageType_WebAuthnListResidentCredentials": 800,
         "MessageType_WebAuthnCredentials": 801,
         "MessageType_WebAuthnAddResidentCredential": 802,

--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -288,6 +288,8 @@ export const createCoreApi = (
     call({ ...params, connectId, deviceId, method: 'aptosGetPublicKey' }),
   aptosSignMessage: (connectId, deviceId, params) =>
     call({ ...params, connectId, deviceId, method: 'aptosSignMessage' }),
+  aptosSignInMessage: (connectId, deviceId, params) =>
+    call({ ...params, connectId, deviceId, method: 'aptosSignInMessage' }),
   aptosSignTransaction: (connectId, deviceId, params) =>
     call({ ...params, connectId, deviceId, method: 'aptosSignTransaction' }),
 

--- a/packages/core/src/types/api/aptosSignInMessage.ts
+++ b/packages/core/src/types/api/aptosSignInMessage.ts
@@ -1,0 +1,17 @@
+import { AptosMessageSignature as HardwareAptosMessageSignature } from '@onekeyfe/hd-transport';
+import type { CommonParams, Response } from '../params';
+
+export type AptosSignInMessageSignature = {
+  path: string;
+} & HardwareAptosMessageSignature;
+
+export type AptosSignInMessageParams = {
+  path: string | number[];
+  payload: string;
+};
+
+export declare function aptosSignInMessage(
+  connectId: string,
+  deviceId: string,
+  params: CommonParams & AptosSignInMessageParams
+): Response<AptosSignInMessageSignature>;

--- a/packages/core/src/types/api/export.ts
+++ b/packages/core/src/types/api/export.ts
@@ -115,6 +115,7 @@ export type { NearSignTransactionParams } from './nearSignTransaction';
 export type { AptosAddress, AptosGetAddressParams } from './aptosGetAddress';
 export type { AptosPublicKey, AptosGetPublicKeyParams } from './aptosGetPublicKey';
 export type { AptosMessageSignature, AptosSignMessageParams } from './aptosSignMessage';
+export type { AptosSignInMessageSignature, AptosSignInMessageParams } from './aptosSignInMessage';
 export type { AptosSignedTx, AptosSignTransactionParams } from './aptosSignTransaction';
 
 export type { AlgoAddress, AlgoGetAddressParams } from './algoGetAddress';
@@ -134,6 +135,10 @@ export type {
   CardanoAddress,
   CardanoGetAddressParams,
 } from './cardanoGetAddress';
+export type {
+  CardanoSignMessageMethodParams,
+  CardanoSignMessageParams,
+} from './cardanoSignMessage';
 export type { CardanoSignTransaction, CardanoSignedTxData } from './cardano';
 
 export type { FilecoinAddress, FilecoinGetAddressParams } from './filecoinGetAddress';

--- a/packages/core/src/types/api/index.ts
+++ b/packages/core/src/types/api/index.ts
@@ -92,6 +92,7 @@ import { nearSignTransaction } from './nearSignTransaction';
 import { aptosGetAddress } from './aptosGetAddress';
 import { aptosGetPublicKey } from './aptosGetPublicKey';
 import { aptosSignMessage } from './aptosSignMessage';
+import { aptosSignInMessage } from './aptosSignInMessage';
 import { aptosSignTransaction } from './aptosSignTransaction';
 
 import { algoGetAddress } from './algoGetAddress';
@@ -309,6 +310,7 @@ export type CoreApi = {
   aptosGetAddress: typeof aptosGetAddress;
   aptosGetPublicKey: typeof aptosGetPublicKey;
   aptosSignMessage: typeof aptosSignMessage;
+  aptosSignInMessage: typeof aptosSignInMessage;
   aptosSignTransaction: typeof aptosSignTransaction;
 
   /**

--- a/packages/core/src/types/api/tronSignMessage.ts
+++ b/packages/core/src/types/api/tronSignMessage.ts
@@ -4,6 +4,7 @@ import type { CommonParams, Response } from '../params';
 export type TronSignMessageParams = {
   path: string | number[];
   messageHex: string;
+  messageType?: 'V1' | 'V2';
 };
 
 export declare function tronSignMessage(

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.1.9",
+  "version": "1.1.10-alpha.3",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.9",
-    "@onekeyfe/hd-shared": "1.1.9",
-    "@onekeyfe/hd-transport-react-native": "1.1.9"
+    "@onekeyfe/hd-core": "1.1.10-alpha.3",
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport-react-native": "1.1.10-alpha.3"
   }
 }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.1.9",
+  "version": "1.1.10-alpha.3",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.9",
-    "@onekeyfe/hd-shared": "1.1.9",
-    "@onekeyfe/hd-transport-emulator": "1.1.9",
-    "@onekeyfe/hd-transport-http": "1.1.9",
-    "@onekeyfe/hd-transport-lowlevel": "1.1.9",
-    "@onekeyfe/hd-transport-web-device": "1.1.9"
+    "@onekeyfe/hd-core": "1.1.10-alpha.3",
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport-emulator": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport-http": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport-lowlevel": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport-web-device": "1.1.10-alpha.3"
   }
 }

--- a/packages/hd-transport-electron/package.json
+++ b/packages/hd-transport-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-electron",
-  "version": "1.1.9",
+  "version": "1.1.10-alpha.3",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -25,7 +25,7 @@
     "electron-log": ">=4.0.0"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.9"
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3"
   },
   "devDependencies": {
     "@types/web-bluetooth": "^0.0.17",

--- a/packages/hd-transport-emulator/package.json
+++ b/packages/hd-transport-emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-emulator",
-  "version": "1.1.9",
+  "version": "1.1.10-alpha.3",
   "description": "hardware emulator transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.9",
-    "@onekeyfe/hd-transport": "1.1.9",
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport": "1.1.10-alpha.3",
     "axios": "^0.27.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.1.9",
+  "version": "1.1.10-alpha.3",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.9",
-    "@onekeyfe/hd-transport": "1.1.9",
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport": "1.1.10-alpha.3",
     "axios": "^0.27.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.1.9",
+  "version": "1.1.10-alpha.3",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.9",
-    "@onekeyfe/hd-transport": "1.1.9"
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport": "1.1.10-alpha.3"
   }
 }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.1.9",
+  "version": "1.1.10-alpha.3",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,8 +19,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.9",
-    "@onekeyfe/hd-transport": "1.1.9",
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport": "1.1.10-alpha.3",
     "@onekeyfe/react-native-ble-utils": "^0.1.4",
     "react-native-ble-plx": "3.5.0"
   }

--- a/packages/hd-transport-web-device/package.json
+++ b/packages/hd-transport-web-device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-web-device",
-  "version": "1.1.9",
+  "version": "1.1.10-alpha.3",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.9",
-    "@onekeyfe/hd-transport": "1.1.9"
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport": "1.1.10-alpha.3"
   },
   "devDependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.9",
+    "@onekeyfe/hd-transport-electron": "1.1.10-alpha.3",
     "@types/w3c-web-usb": "^1.0.6",
     "@types/web-bluetooth": "^0.0.17"
   }

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.1.9",
+  "version": "1.1.10-alpha.3",
   "description": "> TODO: description",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-transport/src/types/messages.ts
+++ b/packages/hd-transport/src/types/messages.ts
@@ -139,6 +139,12 @@ export type AptosMessageSignature = {
   address: string;
 };
 
+// AptosSignSIWAMessage
+export type AptosSignSIWAMessage = {
+  address_n: number[];
+  siwa_payload: string;
+};
+
 // BenfenGetAddress
 export type BenfenGetAddress = {
   address_n: number[];
@@ -1919,6 +1925,7 @@ export type EthereumSignTxOneKey = {
   tx_type?: number;
 };
 
+// EthereumAccessListOneKey
 export type EthereumAccessListOneKey = {
   address: string;
   storage_keys: string[];
@@ -1939,12 +1946,44 @@ export type EthereumSignTxEIP1559OneKey = {
   access_list: EthereumAccessListOneKey[];
 };
 
+// EthereumAuthorizationSignature
+export type EthereumAuthorizationSignature = {
+  y_parity: number;
+  r: string;
+  s: string;
+};
+
+export type EthereumAuthorizationOneKey = {
+  address_n: number[];
+  chain_id: number;
+  address: string;
+  nonce: string;
+  signature?: EthereumAuthorizationSignature;
+};
+
+// EthereumSignTxEIP7702OneKey
+export type EthereumSignTxEIP7702OneKey = {
+  address_n: number[];
+  nonce: string;
+  max_gas_fee: string;
+  max_priority_fee: string;
+  gas_limit: string;
+  to: string;
+  value: string;
+  data_initial_chunk?: string;
+  data_length: number;
+  chain_id: number;
+  access_list: EthereumAccessListOneKey[];
+  authorization_list: EthereumAuthorizationOneKey[];
+};
+
 // EthereumTxRequestOneKey
 export type EthereumTxRequestOneKey = {
   data_length?: number;
   signature_v?: number;
   signature_r?: string;
   signature_s?: string;
+  authorization_signatures: EthereumAuthorizationSignature[];
 };
 
 // EthereumTxAckOneKey
@@ -4276,6 +4315,7 @@ export type MessageType = {
   AptosMessagePayload: AptosMessagePayload;
   AptosSignMessage: AptosSignMessage;
   AptosMessageSignature: AptosMessageSignature;
+  AptosSignSIWAMessage: AptosSignSIWAMessage;
   BenfenGetAddress: BenfenGetAddress;
   BenfenAddress: BenfenAddress;
   BenfenSignTx: BenfenSignTx;
@@ -4491,6 +4531,9 @@ export type MessageType = {
   EthereumSignTxOneKey: EthereumSignTxOneKey;
   EthereumAccessListOneKey: EthereumAccessListOneKey;
   EthereumSignTxEIP1559OneKey: EthereumSignTxEIP1559OneKey;
+  EthereumAuthorizationSignature: EthereumAuthorizationSignature;
+  EthereumAuthorizationOneKey: EthereumAuthorizationOneKey;
+  EthereumSignTxEIP7702OneKey: EthereumSignTxEIP7702OneKey;
   EthereumTxRequestOneKey: EthereumTxRequestOneKey;
   EthereumTxAckOneKey: EthereumTxAckOneKey;
   EthereumSignMessageOneKey: EthereumSignMessageOneKey;

--- a/packages/hd-transport/src/types/messages.ts
+++ b/packages/hd-transport/src/types/messages.ts
@@ -4272,10 +4272,16 @@ export type TronSignedTx = {
   serialized_tx?: string;
 };
 
+export enum TronMessageType {
+  V1 = 1,
+  V2 = 2,
+}
+
 // TronSignMessage
 export type TronSignMessage = {
   address_n: number[];
   message: string;
+  message_type?: TronMessageType;
 };
 
 // TronMessageSignature

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.1.9",
+  "version": "1.1.10-alpha.3",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "^0.0.17",
-    "@onekeyfe/hd-core": "1.1.9",
-    "@onekeyfe/hd-shared": "1.1.9",
-    "@onekeyfe/hd-transport-http": "1.1.9",
-    "@onekeyfe/hd-transport-web-device": "1.1.9"
+    "@onekeyfe/hd-core": "1.1.10-alpha.3",
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport-http": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport-web-device": "1.1.10-alpha.3"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.1.9",
+  "version": "1.1.10-alpha.3",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Aptos Sign-In Message support (may require latest firmware).
  - Introduced Ethereum EIP-7702 signing with authorization lists and signatures.
  - Enabled Tron message signing V2 with device compatibility checks.

- Breaking Changes
  - Tron message signing V1 is no longer supported; use V2.

- Examples
  - Playground updated with Aptos sign-in sample and Tron V2/V1-not-supported presets.

- Chores
  - Bumped packages to 1.1.10-alpha.3 and aligned dependencies across SDKs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->