### PR TITLE
chore: release 1.1.10-alpha.3

### DIFF
--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.1.10-alpha.2",
+  "version": "1.1.10-alpha.3",
   "scripts": {
     "start": "cross-env CONNECT_SRC=https://localhost:8087/ yarn expo start --dev-client",
     "android": "yarn expo run:android",
@@ -19,10 +19,10 @@
     "@noble/ed25519": "^2.1.0",
     "@noble/hashes": "^1.3.3",
     "@noble/secp256k1": "^1.7.1",
-    "@onekeyfe/hd-ble-sdk": "1.1.10-alpha.2",
-    "@onekeyfe/hd-common-connect-sdk": "1.1.10-alpha.2",
-    "@onekeyfe/hd-core": "1.1.10-alpha.2",
-    "@onekeyfe/hd-web-sdk": "1.1.10-alpha.2",
+    "@onekeyfe/hd-ble-sdk": "1.1.10-alpha.3",
+    "@onekeyfe/hd-common-connect-sdk": "1.1.10-alpha.3",
+    "@onekeyfe/hd-core": "1.1.10-alpha.3",
+    "@onekeyfe/hd-web-sdk": "1.1.10-alpha.3",
     "@onekeyfe/react-native-ble-utils": "^0.1.3",
     "@polkadot/util-crypto": "13.1.1",
     "@react-native-async-storage/async-storage": "1.21.0",

--- a/packages/connect-examples/expo-playground/package.json
+++ b/packages/connect-examples/expo-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onekey-hardware-playground",
-  "version": "1.1.10-alpha.2",
+  "version": "1.1.10-alpha.3",
   "private": true,
   "sideEffects": [
     "app/utils/shim.js",
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0",
-    "@onekeyfe/hd-core": "1.1.10-alpha.2",
-    "@onekeyfe/hd-shared": "1.1.10-alpha.2",
-    "@onekeyfe/hd-web-sdk": "1.1.10-alpha.2",
+    "@onekeyfe/hd-core": "1.1.10-alpha.3",
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-web-sdk": "1.1.10-alpha.3",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.1.10-alpha.2",
+  "version": "1.1.10-alpha.3",
   "description": "> TODO: description",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.10-alpha.2",
-    "@onekeyfe/hd-transport": "1.1.10-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport": "1.1.10-alpha.3",
     "axios": "^0.27.2",
     "bignumber.js": "^9.0.2",
     "bytebuffer": "^5.0.1",

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.1.10-alpha.2",
+  "version": "1.1.10-alpha.3",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.10-alpha.2",
-    "@onekeyfe/hd-shared": "1.1.10-alpha.2",
-    "@onekeyfe/hd-transport-react-native": "1.1.10-alpha.2"
+    "@onekeyfe/hd-core": "1.1.10-alpha.3",
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport-react-native": "1.1.10-alpha.3"
   }
 }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.1.10-alpha.2",
+  "version": "1.1.10-alpha.3",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.10-alpha.2",
-    "@onekeyfe/hd-shared": "1.1.10-alpha.2",
-    "@onekeyfe/hd-transport-emulator": "1.1.10-alpha.2",
-    "@onekeyfe/hd-transport-http": "1.1.10-alpha.2",
-    "@onekeyfe/hd-transport-lowlevel": "1.1.10-alpha.2",
-    "@onekeyfe/hd-transport-web-device": "1.1.10-alpha.2"
+    "@onekeyfe/hd-core": "1.1.10-alpha.3",
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport-emulator": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport-http": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport-lowlevel": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport-web-device": "1.1.10-alpha.3"
   }
 }

--- a/packages/hd-transport-electron/package.json
+++ b/packages/hd-transport-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-electron",
-  "version": "1.1.10-alpha.2",
+  "version": "1.1.10-alpha.3",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -25,7 +25,7 @@
     "electron-log": ">=4.0.0"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.10-alpha.2"
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3"
   },
   "devDependencies": {
     "@types/web-bluetooth": "^0.0.17",

--- a/packages/hd-transport-emulator/package.json
+++ b/packages/hd-transport-emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-emulator",
-  "version": "1.1.10-alpha.2",
+  "version": "1.1.10-alpha.3",
   "description": "hardware emulator transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.10-alpha.2",
-    "@onekeyfe/hd-transport": "1.1.10-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport": "1.1.10-alpha.3",
     "axios": "^0.27.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.1.10-alpha.2",
+  "version": "1.1.10-alpha.3",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.10-alpha.2",
-    "@onekeyfe/hd-transport": "1.1.10-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport": "1.1.10-alpha.3",
     "axios": "^0.27.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.1.10-alpha.2",
+  "version": "1.1.10-alpha.3",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.10-alpha.2",
-    "@onekeyfe/hd-transport": "1.1.10-alpha.2"
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport": "1.1.10-alpha.3"
   }
 }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.1.10-alpha.2",
+  "version": "1.1.10-alpha.3",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,8 +19,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.10-alpha.2",
-    "@onekeyfe/hd-transport": "1.1.10-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport": "1.1.10-alpha.3",
     "@onekeyfe/react-native-ble-utils": "^0.1.4",
     "react-native-ble-plx": "3.5.0"
   }

--- a/packages/hd-transport-web-device/package.json
+++ b/packages/hd-transport-web-device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-web-device",
-  "version": "1.1.10-alpha.2",
+  "version": "1.1.10-alpha.3",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.10-alpha.2",
-    "@onekeyfe/hd-transport": "1.1.10-alpha.2"
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport": "1.1.10-alpha.3"
   },
   "devDependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.10-alpha.2",
+    "@onekeyfe/hd-transport-electron": "1.1.10-alpha.3",
     "@types/w3c-web-usb": "^1.0.6",
     "@types/web-bluetooth": "^0.0.17"
   }

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.1.10-alpha.2",
+  "version": "1.1.10-alpha.3",
   "description": "> TODO: description",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.1.10-alpha.2",
+  "version": "1.1.10-alpha.3",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "^0.0.17",
-    "@onekeyfe/hd-core": "1.1.10-alpha.2",
-    "@onekeyfe/hd-shared": "1.1.10-alpha.2",
-    "@onekeyfe/hd-transport-http": "1.1.10-alpha.2",
-    "@onekeyfe/hd-transport-web-device": "1.1.10-alpha.2"
+    "@onekeyfe/hd-core": "1.1.10-alpha.3",
+    "@onekeyfe/hd-shared": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport-http": "1.1.10-alpha.3",
+    "@onekeyfe/hd-transport-web-device": "1.1.10-alpha.3"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.1.10-alpha.2",
+  "version": "1.1.10-alpha.3",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Aligned versions across the SDK suite to 1.1.10-alpha.3, updating dependencies consistently (core, shared, transport variants, web, BLE, React Native, Electron, HTTP, emulator, web-device).
  - Ensures improved consistency and compatibility across example apps and SDK packages.
  - No user-facing functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->