### PR TITLE
feat: support tron signmessage on classic1s

### DIFF
--- a/packages/core/src/api/tron/TronSignMessage.ts
+++ b/packages/core/src/api/tron/TronSignMessage.ts
@@ -54,6 +54,9 @@ export default class TronSignMessage extends BaseMethod<HardwareTronSignMessage>
       pro: {
         min: '4.16.0',
       },
+      classic1s: {
+        min: '3.13.0',
+      },
     };
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Tron message signing on Classic1s devices (requires firmware 3.13.0 or later).
  * Existing support for Pro devices remains unchanged.

* **Bug Fixes**
  * None.

* **Documentation**
  * None.

* **Refactor**
  * None.

* **Tests**
  * None.

* **Chores**
  * None.

* **Revert**
  * None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->