### PR TITLE
fix: homescreen blur example

### DIFF
--- a/packages/connect-examples/expo-example/src/components/UploadScreen/index.tsx
+++ b/packages/connect-examples/expo-example/src/components/UploadScreen/index.tsx
@@ -30,7 +30,7 @@ interface UploadResourceParams {
   nftMetaData?: string;
   fileNameNoExt?: string;
   blurRadius?: number;
-  blurOverlayOpacity?: number;
+  blurOverlayOpacity?: string;
 }
 
 function getUrlExtension(url: string) {
@@ -233,7 +233,7 @@ function UploadScreenComponent() {
           homeScreenSize: HomeScreenSize,
           homeScreenThumbnailSize: HomeScreenThumbnailSize,
           blurRadius: uploadScreenParams?.blurRadius ?? 100,
-          blurOverlayOpacity: uploadScreenParams?.blurOverlayOpacity ?? 0.2,
+          blurOverlayOpacity: parseFloat(uploadScreenParams?.blurOverlayOpacity ?? '0.2'),
           cb: data => {
             setImage({ uri: base64 } as any);
             setPreviewData(data?.base64 ? `data:image/png;base64,${data.base64}` : null);
@@ -296,7 +296,7 @@ function UploadScreenComponent() {
             homeScreenSize: HomeScreenSize,
             homeScreenThumbnailSize: HomeScreenThumbnailSize,
             blurRadius: uploadScreenParams?.blurRadius ?? 100,
-            blurOverlayOpacity: uploadScreenParams?.blurOverlayOpacity ?? 0.2,
+            blurOverlayOpacity: parseFloat(uploadScreenParams?.blurOverlayOpacity ?? '0.2'),
             cb: data => {
               setPreviewData(data?.base64 ? `data:image/png;base64,${data.base64}` : null);
             },
@@ -426,19 +426,13 @@ function UploadScreenComponent() {
           }}
         />
         <CommonInput
-          type="number"
+          type="text"
           label="Blur Overlay Opacity"
-          value={uploadScreenParams?.blurOverlayOpacity?.toString() ?? '0.2'}
-          placeholder="100"
+          value={uploadScreenParams?.blurOverlayOpacity ?? '0.2'}
+          placeholder="0.2"
           onChange={v => {
             if (!isInputDisabled) {
-              try {
-                parseInt(v);
-              } catch (e) {
-                alert('Blur Overlay Opacity must be a number');
-                return;
-              }
-              setUploadScreenParams({ ...uploadScreenParams, blurOverlayOpacity: parseInt(v) });
+              setUploadScreenParams({ ...uploadScreenParams, blurOverlayOpacity: v });
             }
           }}
         />
@@ -495,19 +489,13 @@ function UploadScreenComponent() {
           }}
         />
         <CommonInput
-          type="number"
+          type="text"
           label="Blur Overlay Opacity"
-          value={uploadScreenParams?.blurOverlayOpacity?.toString() ?? '0.2'}
-          placeholder="100"
+          value={uploadScreenParams?.blurOverlayOpacity ?? '0.2'}
+          placeholder="0.2"
           onChange={v => {
             if (!isInputDisabled) {
-              try {
-                parseInt(v);
-              } catch (e) {
-                alert('Blur Overlay Opacity must be a number');
-                return;
-              }
-              setUploadScreenParams({ ...uploadScreenParams, blurOverlayOpacity: parseInt(v) });
+              setUploadScreenParams({ ...uploadScreenParams, blurOverlayOpacity: v });
             }
           }}
         />

--- a/packages/connect-examples/expo-example/src/components/UploadScreen/nftUtils.ts
+++ b/packages/connect-examples/expo-example/src/components/UploadScreen/nftUtils.ts
@@ -86,7 +86,7 @@ export async function processImageBlur({
     // 3. apply blur effect
     if (blurRadius > 0) {
       try {
-        blurCanvasRGBA(canvas, 0, 0, canvas.width, canvas.height, Math.min(blurRadius, 300));
+        blurCanvasRGBA(canvas, 0, 0, canvas.width, canvas.height, Math.min(blurRadius, 400));
       } catch (blurError) {
         console.warn('blur processing failed, skip blur effect:', blurError);
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Increased maximum blur strength, allowing higher blur levels before capping (from 300 to 400).
  - Updated Blur Overlay Opacity input to accept text (e.g., “0.2”) with a new default/placeholder of “0.2”; values are automatically converted when applying settings, enabling more flexible entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->