### PR TITLE
fix: clear testcase while chagne

### DIFF
--- a/packages/connect-examples/expo-example/src/components/BaseTestRunner/useRunnerTest.ts
+++ b/packages/connect-examples/expo-example/src/components/BaseTestRunner/useRunnerTest.ts
@@ -442,10 +442,19 @@ export function useRunnerTest<T>(config: RunnerConfig<T>) {
     beginTest(true);
   }, [beginTest]);
 
+  const clearTestResults = useCallback(() => {
+    // Clear all test results and state
+    clearItemVerifyState?.();
+    stableContext.setItemValues?.([]);
+    setFailedTasks?.([]);
+    stableContext.setRunnerLogs?.([]);
+  }, [clearItemVerifyState, stableContext, setFailedTasks]);
+
   return {
     beginTest,
     stopTest,
     retryFailedTasks,
+    clearTestResults,
   };
 }
 

--- a/packages/connect-examples/expo-example/src/testTools/addressTest/TestBatchAddress.tsx
+++ b/packages/connect-examples/expo-example/src/testTools/addressTest/TestBatchAddress.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, useContext } from 'react';
 
 import { CoreMessage, UI_EVENT, UI_REQUEST, UI_RESPONSE } from '@onekeyfe/hd-core';
 import { Picker } from '@react-native-picker/picker';
@@ -16,6 +16,7 @@ import useExportReport from '../../components/BaseTestRunner/useExportReport';
 import { Button } from '../../components/ui/Button';
 import TestRunnerOptionButtons from '../../components/BaseTestRunner/TestRunnerOptionButtons';
 import { useHardwareInputPinDialog } from '../../provider/HardwareInputPinProvider';
+import { TestRunnerContext } from '../../components/BaseTestRunner/Context/TestRunnerProvider';
 
 type TestCaseDataType = AddressBatchTestCase['data'][0];
 type ResultViewProps = { item: TestCaseDataWithKey<TestCaseDataType> };
@@ -64,9 +65,11 @@ function ExportReportView() {
   });
 
   if (showExportReport) {
-    <Button variant="primary" onPress={exportReport}>
-      {intl.formatMessage({ id: 'action__export_report' })}
-    </Button>;
+    return (
+      <Button variant="primary" onPress={exportReport}>
+        {intl.formatMessage({ id: 'action__export_report' })}
+      </Button>
+    );
   }
 
   return null;
@@ -76,6 +79,7 @@ let hardwareUiEventListener: any | undefined;
 function ExecuteView({ batchTestCases }: { batchTestCases: AddressBatchTestCase[] }) {
   const intl = useIntl();
   const { openDialog } = useHardwareInputPinDialog();
+  const { setItemValues } = useContext(TestRunnerContext);
 
   const [testCaseList, setTestCaseList] = useState<string[]>([]);
   const [currentTestCase, setCurrentTestCase] = useState<AddressBatchTestCase>();
@@ -112,155 +116,157 @@ function ExecuteView({ batchTestCases }: { batchTestCases: AddressBatchTestCase[
   const fullOriginDataRef = useRef(passphraseTestCase);
   const originDataRef = useRef(passphraseTestCase);
 
-  const { stopTest, beginTest, retryFailedTasks } = useRunnerTest<TestCaseDataType>({
-    initTestCase: () => {
-      const testCase = currentTestCase;
-      const currentTestCases = testCase?.data?.map((item, index) => {
-        const key = `${item.method}-${index}`;
+  const { stopTest, beginTest, retryFailedTasks, clearTestResults } =
+    useRunnerTest<TestCaseDataType>({
+      initTestCase: () => {
+        const testCase = currentTestCase;
+        const currentTestCases = testCase?.data?.map((item, index) => {
+          const key = `${item.method}-${index}`;
 
-        return {
-          ...item,
-          $key: key,
-        } as unknown as TestCaseDataWithKey<TestCaseDataType>;
-      });
-      if (testCase && currentTestCases) {
-        return Promise.resolve({
-          title: testCase.name,
-          data: currentTestCases,
+          return {
+            ...item,
+            $key: key,
+          } as unknown as TestCaseDataWithKey<TestCaseDataType>;
         });
-      }
-      return Promise.resolve(undefined);
-    },
-    initHardwareListener: sdk => {
-      if (hardwareUiEventListener) {
-        sdk.off(UI_EVENT, hardwareUiEventListener);
-      }
-
-      hardwareUiEventListener = (message: CoreMessage) => {
-        console.log('TopLEVEL EVENT ===>>>>: ', message);
-        if (message.type === UI_REQUEST.REQUEST_PIN) {
-          openDialog(sdk, message.payload.device.features);
+        if (testCase && currentTestCases) {
+          return Promise.resolve({
+            title: testCase.name,
+            data: currentTestCases,
+          });
         }
-        if (message.type === UI_REQUEST.REQUEST_PASSPHRASE) {
-          setTimeout(() => {
-            sdk.uiResponse({
-              type: UI_RESPONSE.RECEIVE_PASSPHRASE,
-              payload: {
-                value: currentPassphrase.current ?? '',
-              },
-            });
-          }, 200);
+        return Promise.resolve(undefined);
+      },
+      initHardwareListener: sdk => {
+        if (hardwareUiEventListener) {
+          sdk.off(UI_EVENT, hardwareUiEventListener);
         }
-      };
-      sdk.on(UI_EVENT, hardwareUiEventListener);
-      return Promise.resolve();
-    },
-    prepareRunner: async (connectId, deviceId, features, sdk) => {
-      const testCase = currentTestCase;
 
-      if (features?.passphrase_protection === true && testCase?.extra?.passphrase == null) {
-        await sdk.deviceSettings(connectId, {
-          usePassphrase: false,
-        });
-      }
-      if (!features?.passphrase_protection && testCase?.extra?.passphrase != null) {
-        await sdk.deviceSettings(connectId, {
-          usePassphrase: true,
-        });
-      }
-
-      currentPassphrase.current = testCase?.extra?.passphrase;
-
-      fullOriginDataRef.current = fullPath(passphraseTestCase);
-      originDataRef.current = passphraseTestCase;
-    },
-    generateRequestParams: item => {
-      const { params } = item;
-      const requestParams = {
-        ...params,
-        passphraseState: currentTestCase?.extra?.passphraseState,
-        useEmptyPassphrase: !currentTestCase?.extra?.passphrase,
-      };
-      return Promise.resolve({
-        method: item.method,
-        params: requestParams,
-      });
-    },
-    processResponse: (res, item, itemIndex) => {
-      const response = res as {
-        path: string;
-        address: string;
-        // ada
-        serializedPath: string;
-      }[];
-
-      let error = '';
-
-      for (const key of Object.keys(item.result)) {
-        const address = response?.find(
-          account => account.path === key || account.serializedPath === key
-        );
-
-        // 测试数据
-        originDataRef.current = {
-          ...originDataRef.current,
-          data: [
-            ...originDataRef.current.data.map((item, index) => {
-              if (index === itemIndex) {
-                const originParams = fullOriginDataRef.current.data[index].params;
-                const template = originParams?.addressParameters?.path || originParams?.path;
-
-                const originKey = Object.keys(item.expectedAddress).find(key => {
-                  const path = replaceTemplate(key, template);
-                  const resultPath = address?.serializedPath || address?.path;
-                  if (path === resultPath) {
-                    return key;
-                  }
-                  return false;
-                });
-
-                const indexKey = originKey || key;
-                return {
-                  ...item,
-                  expectedAddress: {
-                    ...item.expectedAddress,
-                    [indexKey]: address?.address,
-                  },
-                };
-              }
-              return item;
-            }),
-          ],
+        hardwareUiEventListener = (message: CoreMessage) => {
+          console.log('TopLEVEL EVENT ===>>>>: ', message);
+          if (message.type === UI_REQUEST.REQUEST_PIN) {
+            openDialog(sdk, message.payload.device.features);
+          }
+          if (message.type === UI_REQUEST.REQUEST_PASSPHRASE) {
+            setTimeout(() => {
+              sdk.uiResponse({
+                type: UI_RESPONSE.RECEIVE_PASSPHRASE,
+                payload: {
+                  value: currentPassphrase.current ?? '',
+                },
+              });
+            }, 200);
+          }
         };
+        sdk.on(UI_EVENT, hardwareUiEventListener);
+        return Promise.resolve();
+      },
+      prepareRunner: async (connectId, deviceId, features, sdk) => {
+        const testCase = currentTestCase;
 
-        for (const verifyField of Object.keys(item.result[key])) {
-          if (
-            // @ts-expect-error
-            address[verifyField] !== item.result[key][verifyField]
-          ) {
-            // @ts-expect-error
-            error += `(${key}) actual: ${address[verifyField]}, expected: ${item.result[key][verifyField]}\n`;
+        if (features?.passphrase_protection === true && testCase?.extra?.passphrase == null) {
+          await sdk.deviceSettings(connectId, {
+            usePassphrase: false,
+          });
+        }
+        if (!features?.passphrase_protection && testCase?.extra?.passphrase != null) {
+          await sdk.deviceSettings(connectId, {
+            usePassphrase: true,
+          });
+        }
+
+        currentPassphrase.current = testCase?.extra?.passphrase;
+
+        fullOriginDataRef.current = fullPath(passphraseTestCase);
+        originDataRef.current = passphraseTestCase;
+      },
+      generateRequestParams: item => {
+        const { params } = item;
+        const requestParams = {
+          ...params,
+          passphraseState: currentTestCase?.extra?.passphraseState,
+          useEmptyPassphrase: !currentTestCase?.extra?.passphrase,
+        };
+        return Promise.resolve({
+          method: item.method,
+          params: requestParams,
+        });
+      },
+      processResponse: (res, item, itemIndex) => {
+        const response = res as {
+          path: string;
+          address: string;
+          // ada
+          serializedPath: string;
+        }[];
+
+        let error = '';
+
+        for (const key of Object.keys(item.result)) {
+          const address = response?.find(
+            account => account.path === key || account.serializedPath === key
+          );
+
+          // 测试数据
+          originDataRef.current = {
+            ...originDataRef.current,
+            data: [
+              ...originDataRef.current.data.map((item, index) => {
+                if (index === itemIndex) {
+                  const originParams = fullOriginDataRef.current.data[index].params;
+                  const template = originParams?.addressParameters?.path || originParams?.path;
+
+                  const originKey = Object.keys(item.expectedAddress).find(key => {
+                    const path = replaceTemplate(key, template);
+                    const resultPath = address?.serializedPath || address?.path;
+                    if (path === resultPath) {
+                      return key;
+                    }
+                    return false;
+                  });
+
+                  const indexKey = originKey || key;
+                  return {
+                    ...item,
+                    expectedAddress: {
+                      ...item.expectedAddress,
+                      [indexKey]: address?.address,
+                    },
+                  };
+                }
+                return item;
+              }),
+            ],
+          };
+
+          for (const verifyField of Object.keys(item.result[key])) {
+            if (
+              // @ts-expect-error
+              address[verifyField] !== item.result[key][verifyField]
+            ) {
+              // @ts-expect-error
+              error += `(${key}) actual: ${address[verifyField]}, expected: ${item.result[key][verifyField]}\n`;
+            }
           }
         }
-      }
 
-      return Promise.resolve({
-        error,
-      });
-    },
-    removeHardwareListener: sdk => {
-      if (hardwareUiEventListener) {
-        sdk.off(UI_EVENT, hardwareUiEventListener);
-      }
-      return Promise.resolve();
-    },
-    processRunnerDone: () => {
-      console.log('=====>>> Success Data:\n', JSON.stringify(originDataRef.current, null, 2));
-    },
-  });
+        return Promise.resolve({
+          error,
+        });
+      },
+      removeHardwareListener: sdk => {
+        if (hardwareUiEventListener) {
+          sdk.off(UI_EVENT, hardwareUiEventListener);
+        }
+        return Promise.resolve();
+      },
+      processRunnerDone: () => {
+        console.log('=====>>> Success Data:\n', JSON.stringify(originDataRef.current, null, 2));
+      },
+    });
 
   // Additional effect to handle test case switching
   // This ensures that when users switch test cases, any running tests are properly stopped
+  // and all previous test results are cleared for a clean state
   const prevTestCaseRef = useRef<AddressBatchTestCase | undefined>();
   useEffect(() => {
     if (
@@ -268,11 +274,12 @@ function ExecuteView({ batchTestCases }: { batchTestCases: AddressBatchTestCase[
       currentTestCase &&
       prevTestCaseRef.current.name !== currentTestCase.name
     ) {
-      // Test case changed - stop any running tests to ensure clean state
+      // Test case changed - stop any running tests and clear all results
       stopTest();
+      clearTestResults();
     }
     prevTestCaseRef.current = currentTestCase;
-  }, [currentTestCase, stopTest]);
+  }, [currentTestCase, stopTest, clearTestResults]);
 
   const contentMemo = useMemo(
     () => (

--- a/packages/connect-examples/expo-example/src/testTools/addressTest/TestSingleAddress.tsx
+++ b/packages/connect-examples/expo-example/src/testTools/addressTest/TestSingleAddress.tsx
@@ -14,6 +14,7 @@ import useExportReport from '../../components/BaseTestRunner/useExportReport';
 import { Button } from '../../components/ui/Button';
 import TestRunnerOptionButtons from '../../components/BaseTestRunner/TestRunnerOptionButtons';
 import { useHardwareInputPinDialog } from '../../provider/HardwareInputPinProvider';
+import { TestRunnerContext } from '../../components/BaseTestRunner/Context/TestRunnerProvider';
 
 type TestCaseDataType = AddressTestCase['data'][0];
 type ResultViewProps = { item: TestCaseDataWithKey<TestCaseDataType> };
@@ -76,6 +77,7 @@ let hardwareUiEventListener: any | undefined;
 function ExecuteView({ testCases }: { testCases: AddressTestCase[] }) {
   const intl = useIntl();
   const { openDialog } = useHardwareInputPinDialog();
+  const { setItemValues } = useContext(TestRunnerContext);
 
   const [showOnOneKey, setShowOnOneKey] = useState<boolean>(false);
   const [testCaseList, setTestCaseList] = useState<string[]>([]);
@@ -110,100 +112,118 @@ function ExecuteView({ testCases }: { testCases: AddressTestCase[] }) {
 
   const currentPassphrase = useRef<string | undefined>('');
 
-  const { stopTest, beginTest, retryFailedTasks } = useRunnerTest<TestCaseDataType>({
-    initTestCase: () => {
-      const testCase = currentTestCase;
-      const currentTestCases = testCase?.data?.map((item, index) => {
-        const key = `${item.method}-${index}`;
+  const { stopTest, beginTest, retryFailedTasks, clearTestResults } =
+    useRunnerTest<TestCaseDataType>({
+      initTestCase: () => {
+        const testCase = currentTestCase;
+        const currentTestCases = testCase?.data?.map((item, index) => {
+          const key = `${item.method}-${index}`;
 
-        return {
-          ...item,
-          $key: key,
-        } as unknown as TestCaseDataWithKey<TestCaseDataType>;
-      });
-      if (testCase && currentTestCases) {
+          return {
+            ...item,
+            $key: key,
+          } as unknown as TestCaseDataWithKey<TestCaseDataType>;
+        });
+        if (testCase && currentTestCases) {
+          return Promise.resolve({
+            title: testCase.name,
+            data: currentTestCases,
+          });
+        }
+        return Promise.resolve(undefined);
+      },
+      initHardwareListener: sdk => {
+        if (hardwareUiEventListener) {
+          sdk.off(UI_EVENT, hardwareUiEventListener);
+        }
+        hardwareUiEventListener = (message: CoreMessage) => {
+          console.log('TopLEVEL EVENT ===>>>>: ', message);
+          if (message.type === UI_REQUEST.REQUEST_PIN) {
+            openDialog(sdk, message.payload.device.features);
+          }
+          if (message.type === UI_REQUEST.REQUEST_PASSPHRASE) {
+            setTimeout(() => {
+              sdk.uiResponse({
+                type: UI_RESPONSE.RECEIVE_PASSPHRASE,
+                payload: {
+                  value: currentPassphrase.current ?? '',
+                },
+              });
+            }, 200);
+          }
+        };
+        sdk.on(UI_EVENT, hardwareUiEventListener);
+        return Promise.resolve();
+      },
+      prepareRunner: async (connectId, deviceId, features, sdk) => {
+        const testCase = currentTestCase;
+
+        if (features?.passphrase_protection === true && testCase?.extra?.passphrase == null) {
+          await sdk.deviceSettings(connectId, {
+            usePassphrase: false,
+          });
+        }
+        if (!features?.passphrase_protection && testCase?.extra?.passphrase != null) {
+          await sdk.deviceSettings(connectId, {
+            usePassphrase: true,
+          });
+        }
+
+        currentPassphrase.current = testCase?.extra?.passphrase;
+      },
+      generateRequestParams: item => {
+        const { params } = item;
+        const requestParams = {
+          ...params,
+          showOnOneKey,
+          passphraseState: currentTestCase?.extra?.passphraseState,
+          useEmptyPassphrase: !currentTestCase?.extra?.passphrase,
+        };
         return Promise.resolve({
-          title: testCase.name,
-          data: currentTestCases,
+          method: item.method,
+          params: requestParams,
         });
-      }
-      return Promise.resolve(undefined);
-    },
-    initHardwareListener: sdk => {
-      if (hardwareUiEventListener) {
-        sdk.off(UI_EVENT, hardwareUiEventListener);
-      }
-      hardwareUiEventListener = (message: CoreMessage) => {
-        console.log('TopLEVEL EVENT ===>>>>: ', message);
-        if (message.type === UI_REQUEST.REQUEST_PIN) {
-          openDialog(sdk, message.payload.device.features);
+      },
+      processResponse: (res, item, itemIndex) => {
+        const response = res as {
+          path: string;
+          address: string;
+        };
+
+        let error = '';
+
+        if (response.address !== item.result.address) {
+          error = `actual: ${response.address}, expected: ${item.result.address}`;
         }
-        if (message.type === UI_REQUEST.REQUEST_PASSPHRASE) {
-          setTimeout(() => {
-            sdk.uiResponse({
-              type: UI_RESPONSE.RECEIVE_PASSPHRASE,
-              payload: {
-                value: currentPassphrase.current ?? '',
-              },
-            });
-          }, 200);
+
+        return Promise.resolve({
+          error,
+        });
+      },
+      removeHardwareListener: sdk => {
+        if (hardwareUiEventListener) {
+          sdk.off(UI_EVENT, hardwareUiEventListener);
         }
-      };
-      sdk.on(UI_EVENT, hardwareUiEventListener);
-      return Promise.resolve();
-    },
-    prepareRunner: async (connectId, deviceId, features, sdk) => {
-      const testCase = currentTestCase;
+        return Promise.resolve();
+      },
+    });
 
-      if (features?.passphrase_protection === true && testCase?.extra?.passphrase == null) {
-        await sdk.deviceSettings(connectId, {
-          usePassphrase: false,
-        });
-      }
-      if (!features?.passphrase_protection && testCase?.extra?.passphrase != null) {
-        await sdk.deviceSettings(connectId, {
-          usePassphrase: true,
-        });
-      }
-
-      currentPassphrase.current = testCase?.extra?.passphrase;
-    },
-    generateRequestParams: item => {
-      const { params } = item;
-      const requestParams = {
-        ...params,
-        showOnOneKey,
-        passphraseState: currentTestCase?.extra?.passphraseState,
-        useEmptyPassphrase: !currentTestCase?.extra?.passphrase,
-      };
-      return Promise.resolve({
-        method: item.method,
-        params: requestParams,
-      });
-    },
-    processResponse: (res, item, itemIndex) => {
-      const response = res as {
-        path: string;
-        address: string;
-      };
-
-      let error = '';
-
-      if (response.address !== item.result.address) {
-        error = `actual: ${response.address}, expected: ${item.result.address}`;
-      }
-
-      return Promise.resolve({
-        error,
-      });
-    },
-    removeHardwareListener: sdk => {
-      if (hardwareUiEventListener) {
-        sdk.off(UI_EVENT, hardwareUiEventListener);
-      }
-      return Promise.resolve();
-    },
-  });
+  // Additional effect to handle test case switching
+  // This ensures that when users switch test cases, any running tests are properly stopped
+  // and all previous test results are cleared for a clean state
+  const prevTestCaseRef = useRef<AddressTestCase | undefined>();
+  useEffect(() => {
+    if (
+      prevTestCaseRef.current &&
+      currentTestCase &&
+      prevTestCaseRef.current.name !== currentTestCase.name
+    ) {
+      // Test case changed - stop any running tests and clear all results
+      stopTest();
+      clearTestResults();
+    }
+    prevTestCaseRef.current = currentTestCase;
+  }, [currentTestCase, stopTest, clearTestResults]);
 
   const contentMemo = useMemo(
     () => (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added one-tap “Clear Results” to reset test state without restarting.
  - Enhanced request generation with passphrase/show-on-device options.
  - Improved result processing with clearer address mismatch reporting.

- Bug Fixes
  - Export report button now renders correctly.
  - Prevents stale or mixed results when switching test cases.
  - Safely removes hardware listeners to avoid lingering prompts.

- Improvements
  - Smoother PIN/passphrase prompt handling during tests.
  - More stable runner behavior and clearer status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->