### PR TITLE
chore: release 1.1.12

### DIFF
--- a/packages/connect-examples/electron-example/package.json
+++ b/packages/connect-examples/electron-example/package.json
@@ -2,7 +2,7 @@
   "name": "hardware-example",
   "productName": "HardwareExample",
   "executableName": "onekey-hardware-example",
-  "version": "1.1.12-alpha.2",
+  "version": "1.1.12",
   "author": "OneKey",
   "description": "End-to-end encrypted workspaces for teams",
   "main": "dist/index.js",
@@ -22,7 +22,7 @@
     "ts:check": "yarn tsc --noEmit"
   },
   "dependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.12-alpha.2",
+    "@onekeyfe/hd-transport-electron": "1.1.12",
     "@stoprocent/noble": "2.3.4",
     "debug": "4.3.4",
     "electron-is-dev": "^3.0.1",

--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.1.12-alpha.2",
+  "version": "1.1.12",
   "scripts": {
     "start": "cross-env CONNECT_SRC=https://localhost:8087/ yarn expo start --dev-client",
     "android": "yarn expo run:android",
@@ -19,10 +19,10 @@
     "@noble/ed25519": "^2.1.0",
     "@noble/hashes": "^1.3.3",
     "@noble/secp256k1": "^1.7.1",
-    "@onekeyfe/hd-ble-sdk": "1.1.12-alpha.2",
-    "@onekeyfe/hd-common-connect-sdk": "1.1.12-alpha.2",
-    "@onekeyfe/hd-core": "1.1.12-alpha.2",
-    "@onekeyfe/hd-web-sdk": "1.1.12-alpha.2",
+    "@onekeyfe/hd-ble-sdk": "1.1.12",
+    "@onekeyfe/hd-common-connect-sdk": "1.1.12",
+    "@onekeyfe/hd-core": "1.1.12",
+    "@onekeyfe/hd-web-sdk": "1.1.12",
     "@onekeyfe/react-native-ble-utils": "^0.1.3",
     "@polkadot/util-crypto": "13.1.1",
     "@react-native-async-storage/async-storage": "1.21.0",

--- a/packages/connect-examples/expo-playground/package.json
+++ b/packages/connect-examples/expo-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onekey-hardware-playground",
-  "version": "1.1.12-alpha.2",
+  "version": "1.1.12",
   "private": true,
   "sideEffects": [
     "app/utils/shim.js",
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0",
-    "@onekeyfe/hd-core": "1.1.12-alpha.2",
-    "@onekeyfe/hd-shared": "1.1.12-alpha.2",
-    "@onekeyfe/hd-web-sdk": "1.1.12-alpha.2",
+    "@onekeyfe/hd-core": "1.1.12",
+    "@onekeyfe/hd-shared": "1.1.12",
+    "@onekeyfe/hd-web-sdk": "1.1.12",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/packages/connect-examples/shared-constants/package.json
+++ b/packages/connect-examples/shared-constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekey-internal/shared-constants",
-  "version": "1.1.12-alpha.2",
+  "version": "1.1.12",
   "private": true,
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.1.12-alpha.2",
+  "version": "1.1.12",
   "description": "Core processes and APIs for communicating with OneKey hardware devices.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.12-alpha.2",
-    "@onekeyfe/hd-transport": "1.1.12-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.12",
+    "@onekeyfe/hd-transport": "1.1.12",
     "axios": "^0.27.2",
     "bignumber.js": "^9.0.2",
     "bytebuffer": "^5.0.1",

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.1.12-alpha.2",
+  "version": "1.1.12",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.12-alpha.2",
-    "@onekeyfe/hd-shared": "1.1.12-alpha.2",
-    "@onekeyfe/hd-transport-react-native": "1.1.12-alpha.2"
+    "@onekeyfe/hd-core": "1.1.12",
+    "@onekeyfe/hd-shared": "1.1.12",
+    "@onekeyfe/hd-transport-react-native": "1.1.12"
   }
 }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.1.12-alpha.2",
+  "version": "1.1.12",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.12-alpha.2",
-    "@onekeyfe/hd-shared": "1.1.12-alpha.2",
-    "@onekeyfe/hd-transport-emulator": "1.1.12-alpha.2",
-    "@onekeyfe/hd-transport-http": "1.1.12-alpha.2",
-    "@onekeyfe/hd-transport-lowlevel": "1.1.12-alpha.2",
-    "@onekeyfe/hd-transport-web-device": "1.1.12-alpha.2"
+    "@onekeyfe/hd-core": "1.1.12",
+    "@onekeyfe/hd-shared": "1.1.12",
+    "@onekeyfe/hd-transport-emulator": "1.1.12",
+    "@onekeyfe/hd-transport-http": "1.1.12",
+    "@onekeyfe/hd-transport-lowlevel": "1.1.12",
+    "@onekeyfe/hd-transport-web-device": "1.1.12"
   }
 }

--- a/packages/hd-transport-electron/package.json
+++ b/packages/hd-transport-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-electron",
-  "version": "1.1.12-alpha.2",
+  "version": "1.1.12",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -25,9 +25,9 @@
     "electron-log": ">=4.0.0"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.12-alpha.2",
-    "@onekeyfe/hd-shared": "1.1.12-alpha.2",
-    "@onekeyfe/hd-transport": "1.1.12-alpha.2",
+    "@onekeyfe/hd-core": "1.1.12",
+    "@onekeyfe/hd-shared": "1.1.12",
+    "@onekeyfe/hd-transport": "1.1.12",
     "@stoprocent/noble": "2.3.4",
     "p-retry": "^4.6.2"
   },

--- a/packages/hd-transport-emulator/package.json
+++ b/packages/hd-transport-emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-emulator",
-  "version": "1.1.12-alpha.2",
+  "version": "1.1.12",
   "description": "hardware emulator transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.12-alpha.2",
-    "@onekeyfe/hd-transport": "1.1.12-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.12",
+    "@onekeyfe/hd-transport": "1.1.12",
     "axios": "^0.27.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.1.12-alpha.2",
+  "version": "1.1.12",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.12-alpha.2",
-    "@onekeyfe/hd-transport": "1.1.12-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.12",
+    "@onekeyfe/hd-transport": "1.1.12",
     "axios": "^0.27.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.1.12-alpha.2",
+  "version": "1.1.12",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.12-alpha.2",
-    "@onekeyfe/hd-transport": "1.1.12-alpha.2"
+    "@onekeyfe/hd-shared": "1.1.12",
+    "@onekeyfe/hd-transport": "1.1.12"
   }
 }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.1.12-alpha.2",
+  "version": "1.1.12",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,8 +19,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.12-alpha.2",
-    "@onekeyfe/hd-transport": "1.1.12-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.12",
+    "@onekeyfe/hd-transport": "1.1.12",
     "@onekeyfe/react-native-ble-utils": "^0.1.4",
     "react-native-ble-plx": "3.5.0"
   }

--- a/packages/hd-transport-web-device/package.json
+++ b/packages/hd-transport-web-device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-web-device",
-  "version": "1.1.12-alpha.2",
+  "version": "1.1.12",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.12-alpha.2",
-    "@onekeyfe/hd-transport": "1.1.12-alpha.2"
+    "@onekeyfe/hd-shared": "1.1.12",
+    "@onekeyfe/hd-transport": "1.1.12"
   },
   "devDependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.12-alpha.2",
+    "@onekeyfe/hd-transport-electron": "1.1.12",
     "@types/w3c-web-usb": "^1.0.6",
     "@types/web-bluetooth": "^0.0.17"
   }

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.1.12-alpha.2",
+  "version": "1.1.12",
   "description": "Transport layer abstractions and utilities for OneKey hardware SDK.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.1.12-alpha.2",
+  "version": "1.1.12",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "^0.0.17",
-    "@onekeyfe/hd-core": "1.1.12-alpha.2",
-    "@onekeyfe/hd-shared": "1.1.12-alpha.2",
-    "@onekeyfe/hd-transport-http": "1.1.12-alpha.2",
-    "@onekeyfe/hd-transport-web-device": "1.1.12-alpha.2"
+    "@onekeyfe/hd-core": "1.1.12",
+    "@onekeyfe/hd-shared": "1.1.12",
+    "@onekeyfe/hd-transport-http": "1.1.12",
+    "@onekeyfe/hd-transport-web-device": "1.1.12"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.1.12-alpha.2",
+  "version": "1.1.12",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Promoted multiple packages from pre-release (1.1.12-alpha.2) to stable (1.1.12), including core SDKs, shared utilities, BLE SDK, web SDK, Electron/React Native transports, HTTP/low-level/web-device transports, and example apps (Electron, Expo).
  - Aligned all internal dependencies to the stable 1.1.12 versions for consistency across platforms.
  - No functional changes; this release standardizes versioning and ensures compatibility across the suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->