### PR TITLE
fix: upgrade axios to 1.12.2 & sdk 1.1.13

### DIFF
--- a/packages/connect-examples/electron-example/package.json
+++ b/packages/connect-examples/electron-example/package.json
@@ -2,7 +2,7 @@
   "name": "hardware-example",
   "productName": "HardwareExample",
   "executableName": "onekey-hardware-example",
-  "version": "1.1.13-alpha.0",
+  "version": "1.1.13",
   "author": "OneKey",
   "description": "End-to-end encrypted workspaces for teams",
   "main": "dist/index.js",
@@ -22,7 +22,7 @@
     "ts:check": "yarn tsc --noEmit"
   },
   "dependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.13-alpha.0",
+    "@onekeyfe/hd-transport-electron": "1.1.13",
     "@stoprocent/noble": "2.3.4",
     "debug": "4.3.4",
     "electron-is-dev": "^3.0.1",

--- a/packages/connect-examples/electron-example/package.json
+++ b/packages/connect-examples/electron-example/package.json
@@ -2,7 +2,7 @@
   "name": "hardware-example",
   "productName": "HardwareExample",
   "executableName": "onekey-hardware-example",
-  "version": "1.1.12",
+  "version": "1.1.13-alpha.0",
   "author": "OneKey",
   "description": "End-to-end encrypted workspaces for teams",
   "main": "dist/index.js",
@@ -22,7 +22,7 @@
     "ts:check": "yarn tsc --noEmit"
   },
   "dependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.12",
+    "@onekeyfe/hd-transport-electron": "1.1.13-alpha.0",
     "@stoprocent/noble": "2.3.4",
     "debug": "4.3.4",
     "electron-is-dev": "^3.0.1",
@@ -42,6 +42,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "resolutions": {
-    "**/node-gyp": "^10.0.1"
+    "**/node-gyp": "^10.0.1",
+    "tmp": "0.2.4"
   }
 }

--- a/packages/connect-examples/electron-example/webpack.config.ts
+++ b/packages/connect-examples/electron-example/webpack.config.ts
@@ -42,13 +42,15 @@ module.exports = {
   },
   externals: [
     nodeExternals({
-      allowlist: Object.keys({
-        ...pkg.dependencies,
-        ...pkg.devDependencies,
-      }),
+      allowlist: [
+        '@onekeyfe/hd-transport-electron',
+        ...Object.keys({
+          ...pkg.dependencies,
+          ...pkg.devDependencies,
+        }),
+      ],
     }),
     {
-      '@onekeyfe/hd-transport-electron': 'commonjs @onekeyfe/hd-transport-electron',
       '@stoprocent/noble': 'commonjs @stoprocent/noble',
       '@stoprocent/bluetooth-hci-socket': 'commonjs @stoprocent/bluetooth-hci-socket',
       bufferutil: 'commonjs bufferutil',

--- a/packages/connect-examples/expo-example/locale/en-US.json
+++ b/packages/connect-examples/expo-example/locale/en-US.json
@@ -92,6 +92,7 @@
   "label__upload_image_res_type": "Support PNG & MP4",
   "label__image_res_type": "Resource type",
   "label__res_file_suffix": "File Suffix",
+  "label__res_file_name": "File Name (wp|nft-{filename}-{random})",
   "label__res_type_wall_paper": "WallPaper",
   "label__res_type_nft": "NFT",
   "label__nft_data": "NFT Data",

--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.1.12",
+  "version": "1.1.13-alpha.0",
   "scripts": {
     "start": "cross-env CONNECT_SRC=https://localhost:8087/ yarn expo start --dev-client",
     "android": "yarn expo run:android",
@@ -19,10 +19,10 @@
     "@noble/ed25519": "^2.1.0",
     "@noble/hashes": "^1.3.3",
     "@noble/secp256k1": "^1.7.1",
-    "@onekeyfe/hd-ble-sdk": "1.1.12",
-    "@onekeyfe/hd-common-connect-sdk": "1.1.12",
-    "@onekeyfe/hd-core": "1.1.12",
-    "@onekeyfe/hd-web-sdk": "1.1.12",
+    "@onekeyfe/hd-ble-sdk": "1.1.13-alpha.0",
+    "@onekeyfe/hd-common-connect-sdk": "1.1.13-alpha.0",
+    "@onekeyfe/hd-core": "1.1.13-alpha.0",
+    "@onekeyfe/hd-web-sdk": "1.1.13-alpha.0",
     "@onekeyfe/react-native-ble-utils": "^0.1.3",
     "@polkadot/util-crypto": "13.1.1",
     "@react-native-async-storage/async-storage": "1.21.0",

--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.1.13-alpha.0",
+  "version": "1.1.13",
   "scripts": {
     "start": "cross-env CONNECT_SRC=https://localhost:8087/ yarn expo start --dev-client",
     "android": "yarn expo run:android",
@@ -19,10 +19,10 @@
     "@noble/ed25519": "^2.1.0",
     "@noble/hashes": "^1.3.3",
     "@noble/secp256k1": "^1.7.1",
-    "@onekeyfe/hd-ble-sdk": "1.1.13-alpha.0",
-    "@onekeyfe/hd-common-connect-sdk": "1.1.13-alpha.0",
-    "@onekeyfe/hd-core": "1.1.13-alpha.0",
-    "@onekeyfe/hd-web-sdk": "1.1.13-alpha.0",
+    "@onekeyfe/hd-ble-sdk": "1.1.13",
+    "@onekeyfe/hd-common-connect-sdk": "1.1.13",
+    "@onekeyfe/hd-core": "1.1.13",
+    "@onekeyfe/hd-web-sdk": "1.1.13",
     "@onekeyfe/react-native-ble-utils": "^0.1.3",
     "@polkadot/util-crypto": "13.1.1",
     "@react-native-async-storage/async-storage": "1.21.0",

--- a/packages/connect-examples/expo-playground/package.json
+++ b/packages/connect-examples/expo-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onekey-hardware-playground",
-  "version": "1.1.12",
+  "version": "1.1.13-alpha.0",
   "private": true,
   "sideEffects": [
     "app/utils/shim.js",
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0",
-    "@onekeyfe/hd-core": "1.1.12",
-    "@onekeyfe/hd-shared": "1.1.12",
-    "@onekeyfe/hd-web-sdk": "1.1.12",
+    "@onekeyfe/hd-core": "1.1.13-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
+    "@onekeyfe/hd-web-sdk": "1.1.13-alpha.0",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/packages/connect-examples/expo-playground/package.json
+++ b/packages/connect-examples/expo-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onekey-hardware-playground",
-  "version": "1.1.13-alpha.0",
+  "version": "1.1.13",
   "private": true,
   "sideEffects": [
     "app/utils/shim.js",
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0",
-    "@onekeyfe/hd-core": "1.1.13-alpha.0",
-    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
-    "@onekeyfe/hd-web-sdk": "1.1.13-alpha.0",
+    "@onekeyfe/hd-core": "1.1.13",
+    "@onekeyfe/hd-shared": "1.1.13",
+    "@onekeyfe/hd-web-sdk": "1.1.13",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@onekeyfe/hd-shared": "1.1.13",
     "@onekeyfe/hd-transport": "1.1.13",
-    "axios": "0.30.1",
+    "axios": "1.12.2",
     "bignumber.js": "^9.0.2",
     "bytebuffer": "^5.0.1",
     "jszip": "^3.10.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.1.13-alpha.0",
+  "version": "1.1.13",
   "description": "Core processes and APIs for communicating with OneKey hardware devices.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
-    "@onekeyfe/hd-transport": "1.1.13-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.13",
+    "@onekeyfe/hd-transport": "1.1.13",
     "axios": "1.12.0",
     "bignumber.js": "^9.0.2",
     "bytebuffer": "^5.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@onekeyfe/hd-shared": "1.1.13",
     "@onekeyfe/hd-transport": "1.1.13",
-    "axios": "1.12.0",
+    "axios": "0.30.1",
     "bignumber.js": "^9.0.2",
     "bytebuffer": "^5.0.1",
     "jszip": "^3.10.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.1.12",
+  "version": "1.1.13-alpha.0",
   "description": "Core processes and APIs for communicating with OneKey hardware devices.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,9 +25,9 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.12",
-    "@onekeyfe/hd-transport": "1.1.12",
-    "axios": "^0.27.2",
+    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.13-alpha.0",
+    "axios": "1.12.0",
     "bignumber.js": "^9.0.2",
     "bytebuffer": "^5.0.1",
     "jszip": "^3.10.1",

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.1.12",
+  "version": "1.1.13-alpha.0",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.12",
-    "@onekeyfe/hd-shared": "1.1.12",
-    "@onekeyfe/hd-transport-react-native": "1.1.12"
+    "@onekeyfe/hd-core": "1.1.13-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
+    "@onekeyfe/hd-transport-react-native": "1.1.13-alpha.0"
   }
 }

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.1.13-alpha.0",
+  "version": "1.1.13",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.13-alpha.0",
-    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
-    "@onekeyfe/hd-transport-react-native": "1.1.13-alpha.0"
+    "@onekeyfe/hd-core": "1.1.13",
+    "@onekeyfe/hd-shared": "1.1.13",
+    "@onekeyfe/hd-transport-react-native": "1.1.13"
   }
 }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.1.13-alpha.0",
+  "version": "1.1.13",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.13-alpha.0",
-    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
-    "@onekeyfe/hd-transport-emulator": "1.1.13-alpha.0",
-    "@onekeyfe/hd-transport-http": "1.1.13-alpha.0",
-    "@onekeyfe/hd-transport-lowlevel": "1.1.13-alpha.0",
-    "@onekeyfe/hd-transport-web-device": "1.1.13-alpha.0"
+    "@onekeyfe/hd-core": "1.1.13",
+    "@onekeyfe/hd-shared": "1.1.13",
+    "@onekeyfe/hd-transport-emulator": "1.1.13",
+    "@onekeyfe/hd-transport-http": "1.1.13",
+    "@onekeyfe/hd-transport-lowlevel": "1.1.13",
+    "@onekeyfe/hd-transport-web-device": "1.1.13"
   }
 }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.1.12",
+  "version": "1.1.13-alpha.0",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.12",
-    "@onekeyfe/hd-shared": "1.1.12",
-    "@onekeyfe/hd-transport-emulator": "1.1.12",
-    "@onekeyfe/hd-transport-http": "1.1.12",
-    "@onekeyfe/hd-transport-lowlevel": "1.1.12",
-    "@onekeyfe/hd-transport-web-device": "1.1.12"
+    "@onekeyfe/hd-core": "1.1.13-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
+    "@onekeyfe/hd-transport-emulator": "1.1.13-alpha.0",
+    "@onekeyfe/hd-transport-http": "1.1.13-alpha.0",
+    "@onekeyfe/hd-transport-lowlevel": "1.1.13-alpha.0",
+    "@onekeyfe/hd-transport-web-device": "1.1.13-alpha.0"
   }
 }

--- a/packages/hd-transport-electron/package.json
+++ b/packages/hd-transport-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-electron",
-  "version": "1.1.12",
+  "version": "1.1.13-alpha.0",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -25,9 +25,9 @@
     "electron-log": ">=4.0.0"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.12",
-    "@onekeyfe/hd-shared": "1.1.12",
-    "@onekeyfe/hd-transport": "1.1.12",
+    "@onekeyfe/hd-core": "1.1.13-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.13-alpha.0",
     "@stoprocent/noble": "2.3.4",
     "p-retry": "^4.6.2"
   },

--- a/packages/hd-transport-electron/package.json
+++ b/packages/hd-transport-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-electron",
-  "version": "1.1.13-alpha.0",
+  "version": "1.1.13",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -25,9 +25,9 @@
     "electron-log": ">=4.0.0"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.13-alpha.0",
-    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
-    "@onekeyfe/hd-transport": "1.1.13-alpha.0",
+    "@onekeyfe/hd-core": "1.1.13",
+    "@onekeyfe/hd-shared": "1.1.13",
+    "@onekeyfe/hd-transport": "1.1.13",
     "@stoprocent/noble": "2.3.4",
     "p-retry": "^4.6.2"
   },

--- a/packages/hd-transport-emulator/package.json
+++ b/packages/hd-transport-emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-emulator",
-  "version": "1.1.12",
+  "version": "1.1.13-alpha.0",
   "description": "hardware emulator transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,9 +24,9 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.12",
-    "@onekeyfe/hd-transport": "1.1.12",
-    "axios": "^0.27.2",
+    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.13-alpha.0",
+    "axios": "1.12.0",
     "secure-json-parse": "^4.0.0"
   }
 }

--- a/packages/hd-transport-emulator/package.json
+++ b/packages/hd-transport-emulator/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@onekeyfe/hd-shared": "1.1.13",
     "@onekeyfe/hd-transport": "1.1.13",
-    "axios": "0.30.1",
+    "axios": "1.12.2",
     "secure-json-parse": "^4.0.0"
   }
 }

--- a/packages/hd-transport-emulator/package.json
+++ b/packages/hd-transport-emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-emulator",
-  "version": "1.1.13-alpha.0",
+  "version": "1.1.13",
   "description": "hardware emulator transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
-    "@onekeyfe/hd-transport": "1.1.13-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.13",
+    "@onekeyfe/hd-transport": "1.1.13",
     "axios": "1.12.0",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-emulator/package.json
+++ b/packages/hd-transport-emulator/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@onekeyfe/hd-shared": "1.1.13",
     "@onekeyfe/hd-transport": "1.1.13",
-    "axios": "1.12.0",
+    "axios": "0.30.1",
     "secure-json-parse": "^4.0.0"
   }
 }

--- a/packages/hd-transport-emulator/src/http.ts
+++ b/packages/hd-transport-emulator/src/http.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig } from 'axios';
+import axios, { AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios';
 import { HardwareError, HardwareErrorCode } from '@onekeyfe/hd-shared';
 import secureJSON from 'secure-json-parse';
 
@@ -66,19 +66,16 @@ export async function request(options: HttpRequestOptions) {
   }
 }
 
-axios.interceptors.request.use(config => {
+axios.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   if (typeof window !== 'undefined') {
     return config;
   }
   // node environment
   if (config.url?.startsWith('http://localhost:21333')) {
-    if (!config?.headers?.Origin) {
+    if (!config.headers.get('Origin')) {
       console.log('set node request origin');
       // add Origin field for request headers
-      config.headers = {
-        ...config.headers,
-        Origin: 'https://jssdk.onekey.so',
-      };
+      config.headers.set('Origin', 'https://jssdk.onekey.so');
     }
   }
   return config;

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@onekeyfe/hd-shared": "1.1.13",
     "@onekeyfe/hd-transport": "1.1.13",
-    "axios": "0.30.1",
+    "axios": "1.12.2",
     "secure-json-parse": "^4.0.0"
   }
 }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@onekeyfe/hd-shared": "1.1.13",
     "@onekeyfe/hd-transport": "1.1.13",
-    "axios": "1.12.0",
+    "axios": "0.30.1",
     "secure-json-parse": "^4.0.0"
   }
 }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.1.12",
+  "version": "1.1.13-alpha.0",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,9 +24,9 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.12",
-    "@onekeyfe/hd-transport": "1.1.12",
-    "axios": "^0.27.2",
+    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.13-alpha.0",
+    "axios": "1.12.0",
     "secure-json-parse": "^4.0.0"
   }
 }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.1.13-alpha.0",
+  "version": "1.1.13",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
-    "@onekeyfe/hd-transport": "1.1.13-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.13",
+    "@onekeyfe/hd-transport": "1.1.13",
     "axios": "1.12.0",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-http/src/http.ts
+++ b/packages/hd-transport-http/src/http.ts
@@ -73,7 +73,7 @@ axios.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   // node environment
   if (config.url?.startsWith('http://localhost:21320')) {
     if (!config.headers.get('Origin')) {
-      console.log('set node request origin');
+      // 移除可能导致 EPIPE 错误的 console.log
       // add Origin field for request headers
       config.headers.set('Origin', 'https://jssdk.onekey.so');
     }

--- a/packages/hd-transport-http/src/http.ts
+++ b/packages/hd-transport-http/src/http.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig } from 'axios';
+import axios, { AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios';
 import { HardwareError, HardwareErrorCode } from '@onekeyfe/hd-shared';
 import secureJSON from 'secure-json-parse';
 
@@ -66,19 +66,16 @@ export async function request(options: HttpRequestOptions) {
   }
 }
 
-axios.interceptors.request.use(config => {
+axios.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   if (typeof window !== 'undefined') {
     return config;
   }
   // node environment
   if (config.url?.startsWith('http://localhost:21320')) {
-    if (!config?.headers?.Origin) {
+    if (!config.headers.get('Origin')) {
       console.log('set node request origin');
       // add Origin field for request headers
-      config.headers = {
-        ...config.headers,
-        Origin: 'https://jssdk.onekey.so',
-      };
+      config.headers.set('Origin', 'https://jssdk.onekey.so');
     }
   }
   return config;

--- a/packages/hd-transport-http/src/http.ts
+++ b/packages/hd-transport-http/src/http.ts
@@ -73,7 +73,6 @@ axios.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   // node environment
   if (config.url?.startsWith('http://localhost:21320')) {
     if (!config.headers.get('Origin')) {
-      // 移除可能导致 EPIPE 错误的 console.log
       // add Origin field for request headers
       config.headers.set('Origin', 'https://jssdk.onekey.so');
     }

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.1.13-alpha.0",
+  "version": "1.1.13",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
-    "@onekeyfe/hd-transport": "1.1.13-alpha.0"
+    "@onekeyfe/hd-shared": "1.1.13",
+    "@onekeyfe/hd-transport": "1.1.13"
   }
 }

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.1.12",
+  "version": "1.1.13-alpha.0",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.12",
-    "@onekeyfe/hd-transport": "1.1.12"
+    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.13-alpha.0"
   }
 }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.1.13-alpha.0",
+  "version": "1.1.13",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,8 +19,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
-    "@onekeyfe/hd-transport": "1.1.13-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.13",
+    "@onekeyfe/hd-transport": "1.1.13",
     "@onekeyfe/react-native-ble-utils": "^0.1.4",
     "react-native-ble-plx": "3.5.0"
   }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.1.12",
+  "version": "1.1.13-alpha.0",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,8 +19,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.12",
-    "@onekeyfe/hd-transport": "1.1.12",
+    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.13-alpha.0",
     "@onekeyfe/react-native-ble-utils": "^0.1.4",
     "react-native-ble-plx": "3.5.0"
   }

--- a/packages/hd-transport-web-device/package.json
+++ b/packages/hd-transport-web-device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-web-device",
-  "version": "1.1.12",
+  "version": "1.1.13-alpha.0",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.12",
-    "@onekeyfe/hd-transport": "1.1.12"
+    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.13-alpha.0"
   },
   "devDependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.12",
+    "@onekeyfe/hd-transport-electron": "1.1.13-alpha.0",
     "@types/w3c-web-usb": "^1.0.6",
     "@types/web-bluetooth": "^0.0.17"
   }

--- a/packages/hd-transport-web-device/package.json
+++ b/packages/hd-transport-web-device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-web-device",
-  "version": "1.1.13-alpha.0",
+  "version": "1.1.13",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
-    "@onekeyfe/hd-transport": "1.1.13-alpha.0"
+    "@onekeyfe/hd-shared": "1.1.13",
+    "@onekeyfe/hd-transport": "1.1.13"
   },
   "devDependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.13-alpha.0",
+    "@onekeyfe/hd-transport-electron": "1.1.13",
     "@types/w3c-web-usb": "^1.0.6",
     "@types/web-bluetooth": "^0.0.17"
   }

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.1.12",
+  "version": "1.1.13-alpha.0",
   "description": "Transport layer abstractions and utilities for OneKey hardware SDK.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.1.13-alpha.0",
+  "version": "1.1.13",
   "description": "Transport layer abstractions and utilities for OneKey hardware SDK.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.1.13-alpha.0",
+  "version": "1.1.13",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "^0.0.17",
-    "@onekeyfe/hd-core": "1.1.13-alpha.0",
-    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
-    "@onekeyfe/hd-transport-http": "1.1.13-alpha.0",
-    "@onekeyfe/hd-transport-web-device": "1.1.13-alpha.0"
+    "@onekeyfe/hd-core": "1.1.13",
+    "@onekeyfe/hd-shared": "1.1.13",
+    "@onekeyfe/hd-transport-http": "1.1.13",
+    "@onekeyfe/hd-transport-web-device": "1.1.13"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.1.12",
+  "version": "1.1.13-alpha.0",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "^0.0.17",
-    "@onekeyfe/hd-core": "1.1.12",
-    "@onekeyfe/hd-shared": "1.1.12",
-    "@onekeyfe/hd-transport-http": "1.1.12",
-    "@onekeyfe/hd-transport-web-device": "1.1.12"
+    "@onekeyfe/hd-core": "1.1.13-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.13-alpha.0",
+    "@onekeyfe/hd-transport-http": "1.1.13-alpha.0",
+    "@onekeyfe/hd-transport-web-device": "1.1.13-alpha.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.1.12",
+  "version": "1.1.13-alpha.0",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.1.13-alpha.0",
+  "version": "1.1.13",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9851,13 +9851,14 @@ axe-core@^4.10.0:
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz#04145965ac7894faddbac30861e5d8f11bfd14fc"
   integrity sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==
 
-axios@^0.27.2:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
-  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+axios@1.12.0:
+  version "1.12.0"
+  resolved "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz#11248459be05a5ee493485628fa0e4323d0abfc3"
+  integrity sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==
   dependencies:
-    follow-redirects "^1.14.9"
-    form-data "^4.0.0"
+    follow-redirects "^1.15.6"
+    form-data "^4.0.4"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^3.2.1:
   version "3.2.1"
@@ -14537,10 +14538,15 @@ flow-parser@0.*, flow-parser@^0.206.0:
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.206.0.tgz#f4f794f8026535278393308e01ea72f31000bfef"
   integrity sha512-HVzoK3r6Vsg+lKvlIZzaWNBVai+FXTX1wdYhz/wVlH13tb/gOdLXmlTqy6odmTBhT5UoWUbq0k8263Qhr9d88w==
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.9:
+follow-redirects@^1.0.0:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+
+follow-redirects@^1.15.6:
+  version "1.15.11"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
+  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
 
 fontfaceobserver@^2.1.0:
   version "2.3.0"
@@ -14585,7 +14591,7 @@ form-data@^3.0.1:
     hasown "^2.0.2"
     mime-types "^2.1.35"
 
-form-data@^4.0.0:
+form-data@^4.0.0, form-data@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
   integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
@@ -21356,6 +21362,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~0.0.0:
   version "0.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9851,12 +9851,12 @@ axe-core@^4.10.0:
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz#04145965ac7894faddbac30861e5d8f11bfd14fc"
   integrity sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==
 
-axios@0.30.1:
-  version "0.30.1"
-  resolved "https://registry.npmjs.org/axios/-/axios-0.30.1.tgz#7ab803b877eca707ea5f4de55ea0358fe26898e0"
-  integrity sha512-2XabsR1u0/B6OoKy57/xJmPkQiUvdoV93oW4ww+Xjee7C2er/O5U77lvqycDkT2VQDtfjYcjw8ZV8GDaoqwjHQ==
+axios@1.12.2:
+  version "1.12.2"
+  resolved "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz#6c307390136cf7a2278d09cec63b136dfc6e6da7"
+  integrity sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==
   dependencies:
-    follow-redirects "^1.15.4"
+    follow-redirects "^1.15.6"
     form-data "^4.0.4"
     proxy-from-env "^1.1.0"
 
@@ -14543,7 +14543,7 @@ follow-redirects@^1.0.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
 
-follow-redirects@^1.15.4:
+follow-redirects@^1.15.6:
   version "1.15.11"
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
   integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9851,12 +9851,12 @@ axe-core@^4.10.0:
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz#04145965ac7894faddbac30861e5d8f11bfd14fc"
   integrity sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==
 
-axios@1.12.0:
-  version "1.12.0"
-  resolved "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz#11248459be05a5ee493485628fa0e4323d0abfc3"
-  integrity sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==
+axios@0.30.1:
+  version "0.30.1"
+  resolved "https://registry.npmjs.org/axios/-/axios-0.30.1.tgz#7ab803b877eca707ea5f4de55ea0358fe26898e0"
+  integrity sha512-2XabsR1u0/B6OoKy57/xJmPkQiUvdoV93oW4ww+Xjee7C2er/O5U77lvqycDkT2VQDtfjYcjw8ZV8GDaoqwjHQ==
   dependencies:
-    follow-redirects "^1.15.6"
+    follow-redirects "^1.15.4"
     form-data "^4.0.4"
     proxy-from-env "^1.1.0"
 
@@ -14543,7 +14543,7 @@ follow-redirects@^1.0.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
 
-follow-redirects@^1.15.6:
+follow-redirects@^1.15.4:
   version "1.15.11"
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
   integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped many packages to 1.1.13 for alignment across core, transports, SDKs, shared, and examples; updated internal dependencies and HTTP client.
  * Refreshed example apps (Electron, Expo, Playground); added a package resolution in the Electron example and adjusted Electron bundling behavior.
* **Bug Fixes**
  * Improved HTTP header handling to ensure correct Origin behavior in transport modules.
* **New Features**
  * Added a new locale label "File Name (wp|nft-{filename}-{random})" to the Expo example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->