### PR TITLE
fix: throw acquire error while birdge return 400

### DIFF
--- a/packages/connect-examples/electron-example/package.json
+++ b/packages/connect-examples/electron-example/package.json
@@ -2,7 +2,7 @@
   "name": "hardware-example",
   "productName": "HardwareExample",
   "executableName": "onekey-hardware-example",
-  "version": "1.1.13",
+  "version": "1.1.14-alpha.0",
   "author": "OneKey",
   "description": "End-to-end encrypted workspaces for teams",
   "main": "dist/index.js",
@@ -22,7 +22,7 @@
     "ts:check": "yarn tsc --noEmit"
   },
   "dependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.13",
+    "@onekeyfe/hd-transport-electron": "1.1.14-alpha.0",
     "@stoprocent/noble": "2.3.4",
     "debug": "4.3.4",
     "electron-is-dev": "^3.0.1",

--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.1.13",
+  "version": "1.1.14-alpha.0",
   "scripts": {
     "start": "cross-env CONNECT_SRC=https://localhost:8087/ yarn expo start --dev-client",
     "android": "yarn expo run:android",
@@ -19,10 +19,10 @@
     "@noble/ed25519": "^2.1.0",
     "@noble/hashes": "^1.3.3",
     "@noble/secp256k1": "^1.7.1",
-    "@onekeyfe/hd-ble-sdk": "1.1.13",
-    "@onekeyfe/hd-common-connect-sdk": "1.1.13",
-    "@onekeyfe/hd-core": "1.1.13",
-    "@onekeyfe/hd-web-sdk": "1.1.13",
+    "@onekeyfe/hd-ble-sdk": "1.1.14-alpha.0",
+    "@onekeyfe/hd-common-connect-sdk": "1.1.14-alpha.0",
+    "@onekeyfe/hd-core": "1.1.14-alpha.0",
+    "@onekeyfe/hd-web-sdk": "1.1.14-alpha.0",
     "@onekeyfe/react-native-ble-utils": "^0.1.3",
     "@polkadot/util-crypto": "13.1.1",
     "@react-native-async-storage/async-storage": "1.21.0",

--- a/packages/connect-examples/expo-playground/package.json
+++ b/packages/connect-examples/expo-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onekey-hardware-playground",
-  "version": "1.1.13",
+  "version": "1.1.14-alpha.0",
   "private": true,
   "sideEffects": [
     "app/utils/shim.js",
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0",
-    "@onekeyfe/hd-core": "1.1.13",
-    "@onekeyfe/hd-shared": "1.1.13",
-    "@onekeyfe/hd-web-sdk": "1.1.13",
+    "@onekeyfe/hd-core": "1.1.14-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
+    "@onekeyfe/hd-web-sdk": "1.1.14-alpha.0",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/packages/connect-examples/shared-constants/constants.js
+++ b/packages/connect-examples/shared-constants/constants.js
@@ -9,4 +9,4 @@
  * - "dev": "CONNECT_SRC=https://localhost:8087 webpack serve --mode=development"
  * - "start": "webpack serve --mode=development" (uses CDN)
  */
-export const getConnectSrc = () => process.env.CONNECT_SRC || `https://jssdk.onekey.so/1.1.13/`;
+export const getConnectSrc = () => process.env.CONNECT_SRC || `https://jssdk.onekey.so/1.1.14-alpha.0/`;

--- a/packages/connect-examples/shared-constants/constants.js
+++ b/packages/connect-examples/shared-constants/constants.js
@@ -9,4 +9,5 @@
  * - "dev": "CONNECT_SRC=https://localhost:8087 webpack serve --mode=development"
  * - "start": "webpack serve --mode=development" (uses CDN)
  */
-export const getConnectSrc = () => process.env.CONNECT_SRC || `https://jssdk.onekey.so/1.1.14-alpha.0/`;
+export const getConnectSrc = () =>
+  process.env.CONNECT_SRC || `https://jssdk.onekey.so/1.1.14-alpha.0/`;

--- a/packages/connect-examples/shared-constants/package.json
+++ b/packages/connect-examples/shared-constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekey-internal/shared-constants",
-  "version": "1.1.12",
+  "version": "1.1.14-alpha.0",
   "private": true,
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.1.13",
+  "version": "1.1.14-alpha.0",
   "description": "Core processes and APIs for communicating with OneKey hardware devices.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.13",
-    "@onekeyfe/hd-transport": "1.1.13",
+    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.14-alpha.0",
     "axios": "1.12.2",
     "bignumber.js": "^9.0.2",
     "bytebuffer": "^5.0.1",

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -671,9 +671,11 @@ const ensureConnected = async (
       } catch (error) {
         Log.debug('device list error: ', error);
         if (
-          [HardwareErrorCode.BridgeNotInstalled, HardwareErrorCode.BridgeTimeoutError].includes(
-            error.errorCode
-          )
+          [
+            HardwareErrorCode.BridgeNotInstalled,
+            HardwareErrorCode.BridgeTimeoutError,
+            HardwareErrorCode.BridgeNeedsPermission,
+          ].includes(error.errorCode)
         ) {
           _deviceList = undefined;
           reject(error);
@@ -740,6 +742,7 @@ const ensureConnected = async (
             HardwareErrorCode.DeviceDetectInBootloaderMode,
             HardwareErrorCode.BleCharacteristicNotifyChangeFailure,
             HardwareErrorCode.WebDeviceNotFoundOrNeedsPermission,
+            HardwareErrorCode.BridgeNeedsPermission,
           ].includes(error.errorCode)
         ) {
           reject(error);

--- a/packages/core/src/device/Device.ts
+++ b/packages/core/src/device/Device.ts
@@ -205,13 +205,13 @@ export class Device extends EventEmitter {
   connect() {
     const env = DataManager.getSettings('env');
     // eslint-disable-next-line no-async-promise-executor
-    return new Promise<boolean>(async resolve => {
+    return new Promise<boolean>(async (resolve, reject) => {
       if (DataManager.isBleConnect(env)) {
         try {
           await this.acquire();
           resolve(true);
         } catch (error) {
-          resolve(error);
+          reject(error);
         }
         return;
       }
@@ -221,7 +221,7 @@ export class Device extends EventEmitter {
           await this.acquire();
           resolve(true);
         } catch (error) {
-          resolve(error);
+          reject(error);
         }
         return;
       }

--- a/packages/core/src/device/DeviceConnector.ts
+++ b/packages/core/src/device/DeviceConnector.ts
@@ -85,7 +85,7 @@ export default class DeviceConnector {
       }
       return res;
     } catch (error) {
-      Log.debug('acquire error: ', error.message);
+      Log.error('acquire error: ', error.message);
       safeThrowError(error);
     }
   }

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.1.13",
+  "version": "1.1.14-alpha.0",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.13",
-    "@onekeyfe/hd-shared": "1.1.13",
-    "@onekeyfe/hd-transport-react-native": "1.1.13"
+    "@onekeyfe/hd-core": "1.1.14-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
+    "@onekeyfe/hd-transport-react-native": "1.1.14-alpha.0"
   }
 }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.1.13",
+  "version": "1.1.14-alpha.0",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.13",
-    "@onekeyfe/hd-shared": "1.1.13",
-    "@onekeyfe/hd-transport-emulator": "1.1.13",
-    "@onekeyfe/hd-transport-http": "1.1.13",
-    "@onekeyfe/hd-transport-lowlevel": "1.1.13",
-    "@onekeyfe/hd-transport-web-device": "1.1.13"
+    "@onekeyfe/hd-core": "1.1.14-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
+    "@onekeyfe/hd-transport-emulator": "1.1.14-alpha.0",
+    "@onekeyfe/hd-transport-http": "1.1.14-alpha.0",
+    "@onekeyfe/hd-transport-lowlevel": "1.1.14-alpha.0",
+    "@onekeyfe/hd-transport-web-device": "1.1.14-alpha.0"
   }
 }

--- a/packages/hd-transport-electron/package.json
+++ b/packages/hd-transport-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-electron",
-  "version": "1.1.13",
+  "version": "1.1.14-alpha.0",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -25,9 +25,9 @@
     "electron-log": ">=4.0.0"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.13",
-    "@onekeyfe/hd-shared": "1.1.13",
-    "@onekeyfe/hd-transport": "1.1.13",
+    "@onekeyfe/hd-core": "1.1.14-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.14-alpha.0",
     "@stoprocent/noble": "2.3.4",
     "p-retry": "^4.6.2"
   },

--- a/packages/hd-transport-emulator/package.json
+++ b/packages/hd-transport-emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-emulator",
-  "version": "1.1.13",
+  "version": "1.1.14-alpha.0",
   "description": "hardware emulator transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.13",
-    "@onekeyfe/hd-transport": "1.1.13",
+    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.14-alpha.0",
     "axios": "1.12.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.1.13",
+  "version": "1.1.14-alpha.0",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.13",
-    "@onekeyfe/hd-transport": "1.1.13",
+    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.14-alpha.0",
     "axios": "1.12.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-http/src/http.ts
+++ b/packages/hd-transport-http/src/http.ts
@@ -1,5 +1,9 @@
-import axios, { AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios';
-import { HardwareError, HardwareErrorCode } from '@onekeyfe/hd-shared';
+import axios, { AxiosError, AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios';
+import {
+  HardwareError,
+  HardwareErrorCode,
+  CreateHardwareErrorByBridgeError,
+} from '@onekeyfe/hd-shared';
 import secureJSON from 'secure-json-parse';
 
 export type HttpRequestOptions = {
@@ -50,19 +54,37 @@ export async function request(options: HttpRequestOptions) {
     transformResponse: data => data,
   };
 
-  const res = await axios.request(fetchOptions);
+  try {
+    const res = await axios.request(fetchOptions);
 
-  if (+res.status === 200) {
-    return parseResult(res.data);
-  }
-  const resJson = parseResult(res.data);
-  if (typeof resJson === 'object' && resJson != null && resJson.error != null) {
+    if (+res.status === 200) {
+      return parseResult(res.data);
+    }
+    const resJson = parseResult(res.data);
+    if (typeof resJson === 'object' && resJson != null && resJson.error != null) {
+      throw new HardwareError({
+        errorCode: HardwareErrorCode.NetworkError,
+        message: resJson.error,
+      });
+    } else {
+      throw new HardwareError({ errorCode: HardwareErrorCode.NetworkError, message: res.data });
+    }
+  } catch (err) {
+    const axiosErr = err as AxiosError<string>;
+    const respData = axiosErr?.response?.data;
+
+    if (typeof respData === 'string') {
+      const parsed = parseResult(respData);
+      if (typeof parsed === 'object' && parsed !== null && parsed.error) {
+        throw CreateHardwareErrorByBridgeError(String(parsed.error));
+      }
+      throw CreateHardwareErrorByBridgeError(respData);
+    }
+
     throw new HardwareError({
-      errorCode: HardwareErrorCode.NetworkError,
-      message: resJson.error,
+      errorCode: HardwareErrorCode.BridgeNetworkError,
+      message: axiosErr?.message || 'Bridge network error',
     });
-  } else {
-    throw new HardwareError({ errorCode: HardwareErrorCode.NetworkError, message: res.data });
   }
 }
 

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.1.13",
+  "version": "1.1.14-alpha.0",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.13",
-    "@onekeyfe/hd-transport": "1.1.13"
+    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.14-alpha.0"
   }
 }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.1.13",
+  "version": "1.1.14-alpha.0",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,8 +19,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.13",
-    "@onekeyfe/hd-transport": "1.1.13",
+    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.14-alpha.0",
     "@onekeyfe/react-native-ble-utils": "^0.1.4",
     "react-native-ble-plx": "3.5.0"
   }

--- a/packages/hd-transport-web-device/package.json
+++ b/packages/hd-transport-web-device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-web-device",
-  "version": "1.1.13",
+  "version": "1.1.14-alpha.0",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.13",
-    "@onekeyfe/hd-transport": "1.1.13"
+    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.14-alpha.0"
   },
   "devDependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.13",
+    "@onekeyfe/hd-transport-electron": "1.1.14-alpha.0",
     "@types/w3c-web-usb": "^1.0.6",
     "@types/web-bluetooth": "^0.0.17"
   }

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.1.13",
+  "version": "1.1.14-alpha.0",
   "description": "Transport layer abstractions and utilities for OneKey hardware SDK.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.1.13",
+  "version": "1.1.14-alpha.0",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "^0.0.17",
-    "@onekeyfe/hd-core": "1.1.13",
-    "@onekeyfe/hd-shared": "1.1.13",
-    "@onekeyfe/hd-transport-http": "1.1.13",
-    "@onekeyfe/hd-transport-web-device": "1.1.13"
+    "@onekeyfe/hd-core": "1.1.14-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
+    "@onekeyfe/hd-transport-http": "1.1.14-alpha.0",
+    "@onekeyfe/hd-transport-web-device": "1.1.14-alpha.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.1.13",
+  "version": "1.1.14-alpha.0",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",

--- a/packages/shared/src/HardwareError.ts
+++ b/packages/shared/src/HardwareError.ts
@@ -448,6 +448,11 @@ export const HardwareErrorCode = {
   FirmwareVerificationFailed: 820,
 
   /**
+   * Web bridge coonect needs permission
+   */
+  BridgeNeedsPermission: 821,
+
+  /**
    * Lowlevel transport connect error
    */
   LowlevelTrasnportConnectError: 900,
@@ -589,6 +594,7 @@ export const HardwareErrorCodeMessage: HardwareErrorCodeMessageMapping = {
   [HardwareErrorCode.BTCPsbtTooManyUtxos]: 'PSBT too many utxos',
   [HardwareErrorCode.EmmcFileWriteFirmwareError]: 'EMMC file write firmware error',
   [HardwareErrorCode.FirmwareVerificationFailed]: 'Firmware verification failed',
+  [HardwareErrorCode.BridgeNeedsPermission]: 'Bridge needs permission',
 
   /**
    * Lowlevel transport
@@ -635,6 +641,17 @@ export const CreateErrorByMessage = (message: string): HardwareError => {
     }
   }
   return new HardwareError(message);
+};
+
+// Map low-level bridge/libusb error strings to structured HardwareError
+export const CreateHardwareErrorByBridgeError = (raw: string): HardwareError => {
+  const msg = String(raw || '');
+  // Permission denied when accessing USB device via libusb (e.g., missing udev rules)
+  if (msg.includes('LIBUSB_ERROR_ACCESS')) {
+    return TypedError(HardwareErrorCode.BridgeNeedsPermission, 'LIBUSB_ERROR_ACCESS');
+  }
+  // Fallback: treat as bridge/network error with original message
+  return TypedError(HardwareErrorCode.BridgeNetworkError, msg);
 };
 
 const createNewFirmwareUnReleaseHardwareError = (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Clearer "Bridge needs permission" error with dedicated code and message for improved user guidance.

- Bug Fixes
  - Device connection now properly surfaces errors instead of silent failures.
  - Improved HTTP transport error parsing and mapping for clearer, actionable messages.
  - Raised logging severity for connection acquisition errors to aid troubleshooting.

- Chores
  - Updated default Connect CDN URL to the latest prerelease.
  - Bumped packages and aligned internal dependencies to 1.1.14-alpha.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->