### PR TITLE
feat: support emmcFileWrite

### DIFF
--- a/packages/connect-examples/electron-example/package.json
+++ b/packages/connect-examples/electron-example/package.json
@@ -2,7 +2,7 @@
   "name": "hardware-example",
   "productName": "HardwareExample",
   "executableName": "onekey-hardware-example",
-  "version": "1.1.14-alpha.0",
+  "version": "1.1.14-alpha.1",
   "author": "OneKey",
   "description": "End-to-end encrypted workspaces for teams",
   "main": "dist/index.js",
@@ -22,7 +22,7 @@
     "ts:check": "yarn tsc --noEmit"
   },
   "dependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.14-alpha.0",
+    "@onekeyfe/hd-transport-electron": "1.1.14-alpha.1",
     "@stoprocent/noble": "2.3.4",
     "debug": "4.3.4",
     "electron-is-dev": "^3.0.1",

--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.1.14-alpha.0",
+  "version": "1.1.14-alpha.1",
   "scripts": {
     "start": "cross-env CONNECT_SRC=https://localhost:8087/ yarn expo start --dev-client",
     "android": "yarn expo run:android",
@@ -19,10 +19,10 @@
     "@noble/ed25519": "^2.1.0",
     "@noble/hashes": "^1.3.3",
     "@noble/secp256k1": "^1.7.1",
-    "@onekeyfe/hd-ble-sdk": "1.1.14-alpha.0",
-    "@onekeyfe/hd-common-connect-sdk": "1.1.14-alpha.0",
-    "@onekeyfe/hd-core": "1.1.14-alpha.0",
-    "@onekeyfe/hd-web-sdk": "1.1.14-alpha.0",
+    "@onekeyfe/hd-ble-sdk": "1.1.14-alpha.1",
+    "@onekeyfe/hd-common-connect-sdk": "1.1.14-alpha.1",
+    "@onekeyfe/hd-core": "1.1.14-alpha.1",
+    "@onekeyfe/hd-web-sdk": "1.1.14-alpha.1",
     "@onekeyfe/react-native-ble-utils": "^0.1.3",
     "@polkadot/util-crypto": "13.1.1",
     "@react-native-async-storage/async-storage": "1.21.0",

--- a/packages/connect-examples/expo-playground/app/data/methods/firmware.ts
+++ b/packages/connect-examples/expo-playground/app/data/methods/firmware.ts
@@ -105,6 +105,36 @@ const api: UnifiedMethodConfig[] = [
     ],
   },
   {
+    method: 'emmcFileWrite',
+    description: 'methodDescriptions.emmcFileWrite',
+    noDeviceIdReq: true,
+    presets: [
+      {
+        title: 'EMMC write file',
+        parameters: [
+          {
+            name: 'filePath',
+            type: 'string',
+            required: true,
+            label: 'EMMC Path',
+            placeholder: '0:boot/bootloader.bin',
+            value: '0:boot/bootloader.bin',
+          },
+          {
+            name: 'payload',
+            type: 'file',
+            required: true,
+            label: 'Binary',
+            description: 'Upload binary file (.bin) to write into EMMC',
+            accept: '.bin',
+            visible: true,
+            editable: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
     method: 'firmwareUpdateV3',
     description: 'methodDescriptions.firmwareUpdateV3',
     noDeviceIdReq: true,

--- a/packages/connect-examples/expo-playground/package.json
+++ b/packages/connect-examples/expo-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onekey-hardware-playground",
-  "version": "1.1.14-alpha.0",
+  "version": "1.1.14-alpha.1",
   "private": true,
   "sideEffects": [
     "app/utils/shim.js",
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0",
-    "@onekeyfe/hd-core": "1.1.14-alpha.0",
-    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
-    "@onekeyfe/hd-web-sdk": "1.1.14-alpha.0",
+    "@onekeyfe/hd-core": "1.1.14-alpha.1",
+    "@onekeyfe/hd-shared": "1.1.14-alpha.1",
+    "@onekeyfe/hd-web-sdk": "1.1.14-alpha.1",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/packages/connect-examples/shared-constants/constants.js
+++ b/packages/connect-examples/shared-constants/constants.js
@@ -10,4 +10,4 @@
  * - "start": "webpack serve --mode=development" (uses CDN)
  */
 export const getConnectSrc = () =>
-  process.env.CONNECT_SRC || `https://jssdk.onekey.so/1.1.14-alpha.0/`;
+  process.env.CONNECT_SRC || `https://jssdk.onekey.so/1.1.14-alpha.1/`;

--- a/packages/connect-examples/shared-constants/package.json
+++ b/packages/connect-examples/shared-constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekey-internal/shared-constants",
-  "version": "1.1.14-alpha.0",
+  "version": "1.1.14-alpha.1",
   "private": true,
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.1.14-alpha.0",
+  "version": "1.1.14-alpha.1",
   "description": "Core processes and APIs for communicating with OneKey hardware devices.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
-    "@onekeyfe/hd-transport": "1.1.14-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.14-alpha.1",
+    "@onekeyfe/hd-transport": "1.1.14-alpha.1",
     "axios": "1.12.2",
     "bignumber.js": "^9.0.2",
     "bytebuffer": "^5.0.1",

--- a/packages/core/src/api/BaseMethod.ts
+++ b/packages/core/src/api/BaseMethod.ts
@@ -58,8 +58,8 @@ export abstract class BaseMethod<Params = undefined> {
   useDevice: boolean;
 
   /**
-   * 不允许的设备模式。如果当前设备模式在该数组中，则抛出异常。
-   * NOT_INITIALIZE, BOOTLOADER, SEEDLESS
+   * 允许的设备模式。当前设备模式在该数组中，则可以允许运行。
+   * eg. NOT_INITIALIZE, BOOTLOADER, SEEDLESS
    */
   allowDeviceMode: string[];
 

--- a/packages/core/src/api/EmmcFileWrite.ts
+++ b/packages/core/src/api/EmmcFileWrite.ts
@@ -1,0 +1,49 @@
+import { RebootType } from '@onekeyfe/hd-transport';
+import { validateParams } from './helpers/paramsValidator';
+import { UI_REQUEST } from '../events/ui-request';
+import { FirmwareUpdateBaseMethod } from './firmware/FirmwareUpdateBaseMethod';
+import type { PROTO } from '../constants';
+
+/**
+ * 简单封装的 EMMC 文件写入方法
+ * - 仅调用 emmcCommonUpdateProcess，将指定二进制内容写入到给定 emmc 路径
+ */
+type EmmcFileWriteParams = PROTO.FirmwareUpload & {
+  /** 目标写入路径（需以 `0:` 开头，例如 `0:updates/firmware.bin`） */
+  filePath: string;
+};
+
+export default class EmmcFileWrite extends FirmwareUpdateBaseMethod<EmmcFileWriteParams> {
+  init() {
+    const { payload } = this;
+    // 仅做基本参数校验，不引入任何接口条件判断
+    validateParams(payload, [
+      { name: 'payload', type: 'buffer', required: true },
+      { name: 'filePath', type: 'string', required: true },
+    ]);
+
+    this.allowDeviceMode = [UI_REQUEST.BOOTLOADER, UI_REQUEST.NOT_INITIALIZE];
+    this.useDevicePassphraseState = false;
+
+    this.params = {
+      payload: payload.payload,
+      filePath: payload.filePath,
+    };
+  }
+
+  async run() {
+    const { payload, filePath } = this.params;
+    await this.enterBootloaderMode();
+    await this.emmcCommonUpdateProcess({ payload, filePath });
+    // 写入完成后执行正常重启
+    try {
+      await this.reboot(RebootType.Normal);
+    } catch (e) {
+      // 重启失败不影响写入结果，保守记录但不抛出
+    }
+
+    return {
+      filePath,
+    };
+  }
+}

--- a/packages/core/src/api/firmware/FirmwareUpdateBaseMethod.ts
+++ b/packages/core/src/api/firmware/FirmwareUpdateBaseMethod.ts
@@ -6,6 +6,7 @@ import {
   HardwareError,
   HardwareErrorCode,
 } from '@onekeyfe/hd-shared';
+import { RebootType } from '@onekeyfe/hd-transport';
 import type { KnownDevice } from '../../types';
 
 import {
@@ -400,5 +401,17 @@ export class FirmwareUpdateBaseMethod<Params> extends BaseMethod<Params> {
         await wait(2000);
       }
     }
+  }
+
+  /**
+   * @description 设备重启（Bootloader 侧可用）
+   * @param rebootType 重启类型，参考 RebootType 枚举
+   */
+  async reboot(rebootType: RebootType) {
+    const typedCall = this.device.getCommands().typedCall.bind(this.device.getCommands());
+    const res = await typedCall('Reboot', 'Success', {
+      reboot_type: rebootType,
+    });
+    return res.message;
   }
 }

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -37,6 +37,7 @@ export { default as firmwareUpdate } from './FirmwareUpdate';
 export { default as firmwareUpdateV2 } from './FirmwareUpdateV2';
 export { default as firmwareUpdateV3 } from './FirmwareUpdateV3';
 export { default as promptWebDeviceAccess } from './PromptWebDeviceAccess';
+export { default as emmcFileWrite } from './EmmcFileWrite';
 
 export { default as cipherKeyValue } from './CipherKeyValue';
 

--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -259,6 +259,7 @@ export const createCoreApi = (
     call({ ...params, connectId, method: 'firmwareUpdateV2' }),
   firmwareUpdateV3: (connectId, params) =>
     call({ ...params, connectId, method: 'firmwareUpdateV3' }),
+  emmcFileWrite: (connectId, params) => call({ ...params, connectId, method: 'emmcFileWrite' }),
   promptWebDeviceAccess: params => call({ ...params, method: 'promptWebDeviceAccess' }),
 
   tronGetAddress: (connectId, deviceId, params) =>

--- a/packages/core/src/types/api/emmcFileWrite.ts
+++ b/packages/core/src/types/api/emmcFileWrite.ts
@@ -1,0 +1,12 @@
+import type { Params, Response } from '../params';
+
+export interface EmmcFileWriteParams {
+  payload: ArrayBuffer;
+  filePath: string; // e.g. '0:boot/bootloader.bin'
+  hash?: string;
+}
+
+export declare function emmcFileWrite(
+  connectId: string | undefined,
+  params: Params<EmmcFileWriteParams>
+): Response<number>;

--- a/packages/core/src/types/api/export.ts
+++ b/packages/core/src/types/api/export.ts
@@ -26,6 +26,7 @@ export type {
   FirmwareUpdateBinaryParams,
   FirmwareUpdateV3Params,
 } from './firmwareUpdate';
+export type { EmmcFileWriteParams } from './emmcFileWrite';
 
 export type { AllNetworkAddressParams, AllNetworkGetAddressParams } from './allNetworkGetAddress';
 

--- a/packages/core/src/types/api/index.ts
+++ b/packages/core/src/types/api/index.ts
@@ -17,6 +17,7 @@ import { getPassphraseState } from './getPassphraseState';
 import { checkFirmwareRelease } from './checkFirmwareRelease';
 import { checkBLEFirmwareRelease } from './checkBLEFirmwareRelease';
 import { firmwareUpdate, firmwareUpdateV2, firmwareUpdateV3 } from './firmwareUpdate';
+import { emmcFileWrite } from './emmcFileWrite';
 import { promptWebDeviceAccess } from './promptWebDeviceAccess';
 
 import { deviceReset } from './deviceReset';
@@ -225,6 +226,7 @@ export type CoreApi = {
   firmwareUpdate: typeof firmwareUpdate;
   firmwareUpdateV2: typeof firmwareUpdateV2;
   firmwareUpdateV3: typeof firmwareUpdateV3;
+  emmcFileWrite: typeof emmcFileWrite;
   cipherKeyValue: typeof cipherKeyValue;
 
   /**

--- a/packages/core/src/utils/findDefectiveBatchDevice.ts
+++ b/packages/core/src/utils/findDefectiveBatchDevice.ts
@@ -1,4 +1,3 @@
-import { EDeviceType } from '@onekeyfe/hd-shared';
 import type { Features } from '../types';
 import { getDeviceUUID, getDeviceType } from './deviceInfoUtils';
 

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.1.14-alpha.0",
+  "version": "1.1.14-alpha.1",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.14-alpha.0",
-    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
-    "@onekeyfe/hd-transport-react-native": "1.1.14-alpha.0"
+    "@onekeyfe/hd-core": "1.1.14-alpha.1",
+    "@onekeyfe/hd-shared": "1.1.14-alpha.1",
+    "@onekeyfe/hd-transport-react-native": "1.1.14-alpha.1"
   }
 }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.1.14-alpha.0",
+  "version": "1.1.14-alpha.1",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.14-alpha.0",
-    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
-    "@onekeyfe/hd-transport-emulator": "1.1.14-alpha.0",
-    "@onekeyfe/hd-transport-http": "1.1.14-alpha.0",
-    "@onekeyfe/hd-transport-lowlevel": "1.1.14-alpha.0",
-    "@onekeyfe/hd-transport-web-device": "1.1.14-alpha.0"
+    "@onekeyfe/hd-core": "1.1.14-alpha.1",
+    "@onekeyfe/hd-shared": "1.1.14-alpha.1",
+    "@onekeyfe/hd-transport-emulator": "1.1.14-alpha.1",
+    "@onekeyfe/hd-transport-http": "1.1.14-alpha.1",
+    "@onekeyfe/hd-transport-lowlevel": "1.1.14-alpha.1",
+    "@onekeyfe/hd-transport-web-device": "1.1.14-alpha.1"
   }
 }

--- a/packages/hd-transport-electron/package.json
+++ b/packages/hd-transport-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-electron",
-  "version": "1.1.14-alpha.0",
+  "version": "1.1.14-alpha.1",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -25,9 +25,9 @@
     "electron-log": ">=4.0.0"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.14-alpha.0",
-    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
-    "@onekeyfe/hd-transport": "1.1.14-alpha.0",
+    "@onekeyfe/hd-core": "1.1.14-alpha.1",
+    "@onekeyfe/hd-shared": "1.1.14-alpha.1",
+    "@onekeyfe/hd-transport": "1.1.14-alpha.1",
     "@stoprocent/noble": "2.3.4",
     "p-retry": "^4.6.2"
   },

--- a/packages/hd-transport-emulator/package.json
+++ b/packages/hd-transport-emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-emulator",
-  "version": "1.1.14-alpha.0",
+  "version": "1.1.14-alpha.1",
   "description": "hardware emulator transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
-    "@onekeyfe/hd-transport": "1.1.14-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.14-alpha.1",
+    "@onekeyfe/hd-transport": "1.1.14-alpha.1",
     "axios": "1.12.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.1.14-alpha.0",
+  "version": "1.1.14-alpha.1",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
-    "@onekeyfe/hd-transport": "1.1.14-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.14-alpha.1",
+    "@onekeyfe/hd-transport": "1.1.14-alpha.1",
     "axios": "1.12.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.1.14-alpha.0",
+  "version": "1.1.14-alpha.1",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
-    "@onekeyfe/hd-transport": "1.1.14-alpha.0"
+    "@onekeyfe/hd-shared": "1.1.14-alpha.1",
+    "@onekeyfe/hd-transport": "1.1.14-alpha.1"
   }
 }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.1.14-alpha.0",
+  "version": "1.1.14-alpha.1",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,8 +19,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
-    "@onekeyfe/hd-transport": "1.1.14-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.14-alpha.1",
+    "@onekeyfe/hd-transport": "1.1.14-alpha.1",
     "@onekeyfe/react-native-ble-utils": "^0.1.4",
     "react-native-ble-plx": "3.5.0"
   }

--- a/packages/hd-transport-web-device/package.json
+++ b/packages/hd-transport-web-device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-web-device",
-  "version": "1.1.14-alpha.0",
+  "version": "1.1.14-alpha.1",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
-    "@onekeyfe/hd-transport": "1.1.14-alpha.0"
+    "@onekeyfe/hd-shared": "1.1.14-alpha.1",
+    "@onekeyfe/hd-transport": "1.1.14-alpha.1"
   },
   "devDependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.14-alpha.0",
+    "@onekeyfe/hd-transport-electron": "1.1.14-alpha.1",
     "@types/w3c-web-usb": "^1.0.6",
     "@types/web-bluetooth": "^0.0.17"
   }

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.1.14-alpha.0",
+  "version": "1.1.14-alpha.1",
   "description": "Transport layer abstractions and utilities for OneKey hardware SDK.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.1.14-alpha.0",
+  "version": "1.1.14-alpha.1",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "^0.0.17",
-    "@onekeyfe/hd-core": "1.1.14-alpha.0",
-    "@onekeyfe/hd-shared": "1.1.14-alpha.0",
-    "@onekeyfe/hd-transport-http": "1.1.14-alpha.0",
-    "@onekeyfe/hd-transport-web-device": "1.1.14-alpha.0"
+    "@onekeyfe/hd-core": "1.1.14-alpha.1",
+    "@onekeyfe/hd-shared": "1.1.14-alpha.1",
+    "@onekeyfe/hd-transport-http": "1.1.14-alpha.1",
+    "@onekeyfe/hd-transport-web-device": "1.1.14-alpha.1"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.1.14-alpha.0",
+  "version": "1.1.14-alpha.1",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",


### PR DESCRIPTION
添加一个单独调用emmcFileWrite的方法，内部使用。只用于用户无法进入board更新boot的情况
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced EMMC file write capability in the core API and playground, enabling users to upload .bin files to a specified device path.

- Chores
  - Updated all packages to version 1.1.14-alpha.1 and aligned dependencies across SDKs and transports.
  - Switched the default Connect script URL to the new 1.1.14-alpha.1 endpoint.
  - Minor internal cleanup in utilities (no user-facing impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->