### PR TITLE
chore: release 1.1.20-alpha.2

### DIFF
--- a/packages/connect-examples/electron-example/package.json
+++ b/packages/connect-examples/electron-example/package.json
@@ -2,7 +2,7 @@
   "name": "hardware-example",
   "productName": "HardwareExample",
   "executableName": "onekey-hardware-example",
-  "version": "1.1.20-alpha.1",
+  "version": "1.1.20-alpha.2",
   "author": "OneKey",
   "description": "End-to-end encrypted workspaces for teams",
   "main": "dist/index.js",
@@ -22,7 +22,7 @@
     "ts:check": "yarn tsc --noEmit"
   },
   "dependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.20-alpha.1",
+    "@onekeyfe/hd-transport-electron": "1.1.20-alpha.2",
     "@stoprocent/noble": "2.3.4",
     "debug": "4.3.4",
     "electron-is-dev": "^3.0.1",

--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.1.20-alpha.1",
+  "version": "1.1.20-alpha.2",
   "scripts": {
     "start": "cross-env CONNECT_SRC=https://localhost:8087/ yarn expo start --dev-client",
     "android": "yarn expo run:android",
@@ -19,10 +19,10 @@
     "@noble/ed25519": "^2.1.0",
     "@noble/hashes": "^1.3.3",
     "@noble/secp256k1": "^1.7.1",
-    "@onekeyfe/hd-ble-sdk": "1.1.20-alpha.1",
-    "@onekeyfe/hd-common-connect-sdk": "1.1.20-alpha.1",
-    "@onekeyfe/hd-core": "1.1.20-alpha.1",
-    "@onekeyfe/hd-web-sdk": "1.1.20-alpha.1",
+    "@onekeyfe/hd-ble-sdk": "1.1.20-alpha.2",
+    "@onekeyfe/hd-common-connect-sdk": "1.1.20-alpha.2",
+    "@onekeyfe/hd-core": "1.1.20-alpha.2",
+    "@onekeyfe/hd-web-sdk": "1.1.20-alpha.2",
     "@onekeyfe/react-native-ble-utils": "^0.1.3",
     "@polkadot/util-crypto": "13.1.1",
     "@react-native-async-storage/async-storage": "1.21.0",

--- a/packages/connect-examples/expo-playground/package.json
+++ b/packages/connect-examples/expo-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onekey-hardware-playground",
-  "version": "1.1.20-alpha.1",
+  "version": "1.1.20-alpha.2",
   "private": true,
   "sideEffects": [
     "app/utils/shim.js",
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0",
-    "@onekeyfe/hd-common-connect-sdk": "1.1.20-alpha.1",
-    "@onekeyfe/hd-core": "1.1.20-alpha.1",
-    "@onekeyfe/hd-shared": "1.1.20-alpha.1",
+    "@onekeyfe/hd-common-connect-sdk": "1.1.20-alpha.2",
+    "@onekeyfe/hd-core": "1.1.20-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.20-alpha.2",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.1.20-alpha.1",
+  "version": "1.1.20-alpha.2",
   "description": "Core processes and APIs for communicating with OneKey hardware devices.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.20-alpha.1",
-    "@onekeyfe/hd-transport": "1.1.20-alpha.1",
+    "@onekeyfe/hd-shared": "1.1.20-alpha.2",
+    "@onekeyfe/hd-transport": "1.1.20-alpha.2",
     "axios": "1.12.2",
     "bignumber.js": "^9.0.2",
     "bytebuffer": "^5.0.1",

--- a/packages/core/src/device/Device.ts
+++ b/packages/core/src/device/Device.ts
@@ -201,7 +201,7 @@ export class Device extends EventEmitter {
       connectId: DataManager.isBleConnect(env) ? this.mainId || null : getDeviceUUID(this.features),
       /** Hardware ID, will not change at any time */
       uuid: getDeviceUUID(this.features),
-      communicationType: this.originalDescriptor.type,
+      commType: this.originalDescriptor.commType,
       sdkInstanceId: this.sdkInstanceId,
       instanceId: this.instanceId,
       createdAt: this.createdAt,

--- a/packages/core/src/types/device.ts
+++ b/packages/core/src/types/device.ts
@@ -2,7 +2,7 @@ import { EDeviceType } from '@onekeyfe/hd-shared';
 
 import type { IVersionArray } from './settings';
 import type { PROTO } from '../constants';
-import type { OneKeyDeviceCommunicationType } from '@onekeyfe/hd-transport';
+import type { OneKeyDeviceCommType } from '@onekeyfe/hd-transport';
 
 export type DeviceStatus = 'available' | 'occupied' | 'used';
 
@@ -26,7 +26,7 @@ export type KnownDevice = {
   uuid: string;
   deviceId: string | null;
   deviceType: IDeviceType | null;
-  communicationType: OneKeyDeviceCommunicationType | null;
+  commType: OneKeyDeviceCommType | null;
   path: string;
   label: string;
   bleName: string | null;
@@ -50,6 +50,7 @@ export type SearchDevice = {
   deviceId: string | null;
   deviceType: IDeviceType;
   name: string;
+  commType: OneKeyDeviceCommType;
 };
 
 // export type UnknownDevice = {

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.1.20-alpha.1",
+  "version": "1.1.20-alpha.2",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.20-alpha.1",
-    "@onekeyfe/hd-shared": "1.1.20-alpha.1",
-    "@onekeyfe/hd-transport-react-native": "1.1.20-alpha.1"
+    "@onekeyfe/hd-core": "1.1.20-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.20-alpha.2",
+    "@onekeyfe/hd-transport-react-native": "1.1.20-alpha.2"
   }
 }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.1.20-alpha.1",
+  "version": "1.1.20-alpha.2",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.20-alpha.1",
-    "@onekeyfe/hd-shared": "1.1.20-alpha.1",
-    "@onekeyfe/hd-transport-emulator": "1.1.20-alpha.1",
-    "@onekeyfe/hd-transport-http": "1.1.20-alpha.1",
-    "@onekeyfe/hd-transport-lowlevel": "1.1.20-alpha.1",
-    "@onekeyfe/hd-transport-web-device": "1.1.20-alpha.1"
+    "@onekeyfe/hd-core": "1.1.20-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.20-alpha.2",
+    "@onekeyfe/hd-transport-emulator": "1.1.20-alpha.2",
+    "@onekeyfe/hd-transport-http": "1.1.20-alpha.2",
+    "@onekeyfe/hd-transport-lowlevel": "1.1.20-alpha.2",
+    "@onekeyfe/hd-transport-web-device": "1.1.20-alpha.2"
   }
 }

--- a/packages/hd-transport-electron/package.json
+++ b/packages/hd-transport-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-electron",
-  "version": "1.1.20-alpha.1",
+  "version": "1.1.20-alpha.2",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -25,9 +25,9 @@
     "electron-log": ">=4.0.0"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.20-alpha.1",
-    "@onekeyfe/hd-shared": "1.1.20-alpha.1",
-    "@onekeyfe/hd-transport": "1.1.20-alpha.1",
+    "@onekeyfe/hd-core": "1.1.20-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.20-alpha.2",
+    "@onekeyfe/hd-transport": "1.1.20-alpha.2",
     "@stoprocent/noble": "2.3.4",
     "p-retry": "^4.6.2"
   },

--- a/packages/hd-transport-electron/src/noble-ble-handler.ts
+++ b/packages/hd-transport-electron/src/noble-ble-handler.ts
@@ -824,7 +824,7 @@ async function enumerateDevices(): Promise<DeviceInfo[]> {
           if (!existingDevice) {
             const deviceName = peripheral.advertisement?.localName || 'Unknown Device';
             devices.push({
-              type: 'electron-ble',
+              commType: 'electron-ble',
               id,
               name: deviceName,
               state: peripheral.state || 'disconnected',
@@ -883,7 +883,7 @@ function getDevice(deviceId: string): DeviceInfo | null {
   if (peripheral) {
     const deviceName = peripheral.advertisement?.localName || 'Unknown Device';
     return {
-      type: 'electron-ble',
+      commType: 'electron-ble',
       id: peripheral.id,
       name: deviceName,
       state: peripheral.state || 'disconnected',
@@ -895,7 +895,7 @@ function getDevice(deviceId: string): DeviceInfo | null {
   if (connectedPeripheral) {
     const deviceName = connectedPeripheral.advertisement?.localName || 'Unknown Device';
     return {
-      type: 'electron-ble',
+      commType: 'electron-ble',
       id: connectedPeripheral.id,
       name: deviceName,
       state: connectedPeripheral.state || 'connected',
@@ -905,7 +905,7 @@ function getDevice(deviceId: string): DeviceInfo | null {
   // For direct connection mode, return a placeholder device info
   // This allows the connection process to proceed without prior discovery
   return {
-    type: 'electron-ble',
+    commType: 'electron-ble',
     id: deviceId,
     name: 'OneKey Device',
     state: 'disconnected',

--- a/packages/hd-transport-emulator/package.json
+++ b/packages/hd-transport-emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-emulator",
-  "version": "1.1.20-alpha.1",
+  "version": "1.1.20-alpha.2",
   "description": "hardware emulator transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.20-alpha.1",
-    "@onekeyfe/hd-transport": "1.1.20-alpha.1",
+    "@onekeyfe/hd-shared": "1.1.20-alpha.2",
+    "@onekeyfe/hd-transport": "1.1.20-alpha.2",
     "axios": "1.12.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-emulator/src/index.ts
+++ b/packages/hd-transport-emulator/src/index.ts
@@ -81,7 +81,7 @@ export default class EmulatorTransport {
   async enumerate() {
     const devicesS = await this._post({ url: '/enumerate' });
     const devices = check.devices(devicesS);
-    return devices.map(device => ({ ...device, type: 'emulator' }));
+    return devices.map(device => ({ ...device, commType: 'emulator' }));
   }
 
   _acquireMixed(input: AcquireInput) {

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.1.20-alpha.1",
+  "version": "1.1.20-alpha.2",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.20-alpha.1",
-    "@onekeyfe/hd-transport": "1.1.20-alpha.1",
+    "@onekeyfe/hd-shared": "1.1.20-alpha.2",
+    "@onekeyfe/hd-transport": "1.1.20-alpha.2",
     "axios": "1.12.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-http/src/index.ts
+++ b/packages/hd-transport-http/src/index.ts
@@ -77,7 +77,7 @@ export default class HttpTransport {
   async enumerate() {
     const devicesS = await this._post({ url: '/enumerate' });
     const devices = check.devices(devicesS);
-    return devices.map(device => ({ ...device, type: 'bridge' }));
+    return devices.map(device => ({ ...device, commType: 'bridge' }));
   }
 
   _acquireMixed(input: AcquireInput) {

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.1.20-alpha.1",
+  "version": "1.1.20-alpha.2",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.20-alpha.1",
-    "@onekeyfe/hd-transport": "1.1.20-alpha.1"
+    "@onekeyfe/hd-shared": "1.1.20-alpha.2",
+    "@onekeyfe/hd-transport": "1.1.20-alpha.2"
   }
 }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.1.20-alpha.1",
+  "version": "1.1.20-alpha.2",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,8 +19,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.20-alpha.1",
-    "@onekeyfe/hd-transport": "1.1.20-alpha.1",
+    "@onekeyfe/hd-shared": "1.1.20-alpha.2",
+    "@onekeyfe/hd-transport": "1.1.20-alpha.2",
     "@onekeyfe/react-native-ble-utils": "^0.1.4",
     "react-native-ble-plx": "3.5.0"
   }

--- a/packages/hd-transport-react-native/src/index.ts
+++ b/packages/hd-transport-react-native/src/index.ts
@@ -215,7 +215,7 @@ export default class ReactNativeBleTransport {
 
       const addDevice = (device: Device) => {
         if (deviceList.every(d => d.id !== device.id)) {
-          deviceList.push({ ...device, type: 'ble' } as IOneKeyDevice);
+          deviceList.push({ ...device, commType: 'ble' } as IOneKeyDevice);
         }
       };
 

--- a/packages/hd-transport-web-device/package.json
+++ b/packages/hd-transport-web-device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-web-device",
-  "version": "1.1.20-alpha.1",
+  "version": "1.1.20-alpha.2",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.20-alpha.1",
-    "@onekeyfe/hd-transport": "1.1.20-alpha.1"
+    "@onekeyfe/hd-shared": "1.1.20-alpha.2",
+    "@onekeyfe/hd-transport": "1.1.20-alpha.2"
   },
   "devDependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.20-alpha.1",
+    "@onekeyfe/hd-transport-electron": "1.1.20-alpha.2",
     "@types/w3c-web-usb": "^1.0.6",
     "@types/web-bluetooth": "^0.0.17"
   }

--- a/packages/hd-transport-web-device/src/webusb.ts
+++ b/packages/hd-transport-web-device/src/webusb.ts
@@ -115,7 +115,7 @@ export default class WebUsbTransport {
     this.deviceList = onekeyDevices.map(device => ({
       path: device.serialNumber as string,
       device,
-      type: 'webusb',
+      commType: 'webusb',
     }));
 
     return this.deviceList;

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.1.20-alpha.1",
+  "version": "1.1.20-alpha.2",
   "description": "Transport layer abstractions and utilities for OneKey hardware SDK.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-transport/src/index.ts
+++ b/packages/hd-transport/src/index.ts
@@ -23,7 +23,7 @@ export type {
   LowlevelTransportSharedPlugin,
   LowLevelDevice,
   OneKeyDeviceInfoBase,
-  OneKeyDeviceCommunicationType,
+  OneKeyDeviceCommType,
 } from './types';
 
 export { Messages } from './types';

--- a/packages/hd-transport/src/types/transport.ts
+++ b/packages/hd-transport/src/types/transport.ts
@@ -1,6 +1,6 @@
 import type EventEmitter from 'events';
 
-export type OneKeyDeviceCommunicationType =
+export type OneKeyDeviceCommType =
   | 'usb'
   | 'webusb'
   | 'ble'
@@ -25,7 +25,7 @@ export type OneKeyMobileDeviceInfo = {
 };
 
 export type OneKeyDeviceInfoBase = {
-  type: OneKeyDeviceCommunicationType;
+  commType: OneKeyDeviceCommType;
 };
 
 // TODO: sorting type by communication type

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.1.20-alpha.1",
+  "version": "1.1.20-alpha.2",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "^0.0.17",
-    "@onekeyfe/hd-core": "1.1.20-alpha.1",
-    "@onekeyfe/hd-shared": "1.1.20-alpha.1",
-    "@onekeyfe/hd-transport-http": "1.1.20-alpha.1",
-    "@onekeyfe/hd-transport-web-device": "1.1.20-alpha.1"
+    "@onekeyfe/hd-core": "1.1.20-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.20-alpha.2",
+    "@onekeyfe/hd-transport-http": "1.1.20-alpha.2",
+    "@onekeyfe/hd-transport-web-device": "1.1.20-alpha.2"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.1.20-alpha.1",
+  "version": "1.1.20-alpha.2",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Device information API field renamed from `type` to `commType` across all transport and core modules.

* **Chores**
  * Updated package version to 1.1.20-alpha.2.
  * Updated all internal package dependencies to 1.1.20-alpha.2.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->