### PR TITLE
fix(security): upgrade fast-xml-parser to 4.5.4 (CVE-2026-25896)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "tmp": "0.2.4",
     "micromatch": "4.0.8",
     "sha.js": "2.4.12",
-    "cipher-base": "1.0.5"
+    "cipher-base": "1.0.5",
+    "fast-xml-parser": "4.5.4"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14265,10 +14265,10 @@ fast-safe-stringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
-fast-xml-parser@^4.0.12, fast-xml-parser@^4.2.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.3.4.tgz#385cc256ad7bbc57b91515a38a22502a9e1fca0d"
-  integrity sha512-utnwm92SyozgA3hhH2I8qldf2lBqm6qHOICawRNRFu1qMe3+oqr+GcXjGqTmXTMGE5T4eC03kr/rlh5C1IRdZA==
+fast-xml-parser@4.5.4, fast-xml-parser@^4.0.12, fast-xml-parser@^4.2.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.5.4.tgz#64e52ddf1308001893bd225d5b1768840511c797"
+  integrity sha512-jE8ugADnYOBsu1uaoayVl1tVKAMNOXyjwvv2U6udEA2ORBhDooJDWoGxTkhd4Qn4yh59JVVt/pKXtjPwx9OguQ==
   dependencies:
     strnum "^1.0.5"
 


### PR DESCRIPTION
Add yarn resolution to force fast-xml-parser 4.5.4, fixing entity encoding bypass via regex injection in DOCTYPE entity names.