### PR TITLE
fix(developer-portal): restore footer layout with SDK version and commit hash

### DIFF
--- a/packages/connect-examples/developer-portal/components/LandingPage.jsx
+++ b/packages/connect-examples/developer-portal/components/LandingPage.jsx
@@ -339,23 +339,23 @@ export function LandingPage({ locale = 'en' }) {
         </section>
       </main>
 
-      <footer className="mt-[180px] w-full bg-[#101111]">
-        <div className="mx-auto flex w-full max-w-[1440px] flex-col px-[64px] pb-[80px]">
-          <div className="flex flex-col gap-[80px] lg:flex-row lg:gap-[120px]">
-            <div className="flex shrink-0 flex-col gap-[32px]">
+      <footer className="mt-[120px] w-full rounded-t-[64px] bg-[#101111]">
+        <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-[80px] px-[64px] py-[120px] lg:flex-row lg:gap-[133px]">
+          <div className="flex shrink-0 flex-col gap-[10px]">
+            <div className="flex flex-col gap-[16px]">
               <img
                 src="/landing-page/onekey-brand.svg"
                 alt="OneKey"
-                className="h-[40px] w-auto"
+                className="h-[57px] w-[233px]"
               />
               <div className="relative">
                 <button
                   type="button"
                   onClick={() => setShowLanguageMenu(!showLanguageMenu)}
-                  className="flex w-fit items-center gap-[8px] rounded-[50px] border border-white/20 px-[20px] py-[10px] text-[14px] font-medium text-white"
+                  className="flex w-fit items-center gap-[8px] rounded-[50px] border border-white px-[20px] py-[10px] text-[16px] font-medium text-white"
                 >
                   {isZh ? '中文' : 'English'}
-                  <ChevronDown className={`size-[16px] transition-transform ${showLanguageMenu ? 'rotate-180' : ''}`} />
+                  <ChevronDown className={`size-[24px] transition-transform ${showLanguageMenu ? 'rotate-180' : ''}`} />
                 </button>
                 {showLanguageMenu && (
                   <div className="absolute left-0 top-full z-20 mt-[8px] flex flex-col overflow-hidden rounded-[12px] border border-white/10 bg-[#1a1a1a]">
@@ -377,19 +377,82 @@ export function LandingPage({ locale = 'en' }) {
                 )}
               </div>
             </div>
+            <div className="flex flex-col gap-[24px] pt-[10px]">
+              <div className="flex items-center gap-[16px]">
+                <a
+                  href="https://twitter.com/onekeyHQ"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Twitter"
+                >
+                  <img src="/landing-page/social/twitter.svg" alt="" className="size-[24px]" />
+                </a>
+                <a
+                  href="https://github.com/OneKeyHQ"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="GitHub"
+                >
+                  <img src="/landing-page/social/github.svg" alt="" className="size-[24px]" />
+                </a>
+                <a
+                  href="https://discord.gg/onekey"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Discord"
+                >
+                  <img src="/landing-page/social/discord.svg" alt="" className="size-[24px]" />
+                </a>
+              </div>
+              <div className="flex flex-col gap-[16px]">
+                <div className="flex items-center gap-[16px]">
+                  <a
+                    href="https://github.com/OneKeyHQ"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <img
+                      src="/landing-page/badge-osi.svg"
+                      alt="Open Source"
+                      className="h-[33px] w-[96px]"
+                    />
+                  </a>
+                  <img
+                    src="/landing-page/badge-cceal.svg"
+                    alt="CCEAL 5+ ISO 27001"
+                    className="h-[32px] w-[108px]"
+                  />
+                </div>
+                <p className="text-[12px] leading-[15px] text-white/60">
+                  Since 2019 - {new Date().getFullYear()} | OneKey Limited All Rights Reserved
+                </p>
+                <p className="mt-2 text-[11px] leading-[14px] text-white/40 font-mono">
+                  SDK v{process.env.NEXT_PUBLIC_SDK_VERSION || 'dev'}
+                  {process.env.NEXT_PUBLIC_COMMIT_SHORT && process.env.NEXT_PUBLIC_COMMIT_SHORT !== 'local' && (
+                    <> · <a
+                      href={`https://github.com/OneKeyHQ/hardware-js-sdk/commit/${process.env.NEXT_PUBLIC_COMMIT_ID || ''}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="hover:text-white/60 transition-colors"
+                    >{process.env.NEXT_PUBLIC_COMMIT_SHORT}</a></>
+                  )}
+                </p>
+              </div>
+            </div>
+          </div>
 
-            <div className="flex flex-1 flex-wrap gap-[60px] lg:gap-[120px]">
-              <div className="flex flex-col gap-[24px]">
-                <span className="text-[14px] leading-[20px]" style={{ color: 'rgba(255, 255, 255, 0.6)' }}>
+          <div className="flex flex-1 flex-col gap-[80px]">
+            <div className="flex flex-wrap gap-[40px] lg:gap-[80px]">
+              <div className="flex flex-col gap-[32px]">
+                <p className="text-[14px] font-medium leading-[20px] text-white/60">
                   {getFooterData(isZh, locale).portalColumn.title}
-                </span>
+                </p>
                 <div className="flex flex-col gap-[16px]">
                   {getFooterData(isZh, locale).portalColumn.items.map((item) => (
                     <a
                       key={item.label}
                       href={item.href}
-                      className="text-[14px] leading-[20px] hover:opacity-80"
-                      style={{ color: '#FFFFFF' }}
+                      className="text-[16px] leading-[20px] text-white hover:text-white/80"
                       target={item.href.startsWith('http') ? '_blank' : undefined}
                       rel={item.href.startsWith('http') ? 'noopener noreferrer' : undefined}
                     >
@@ -399,17 +462,16 @@ export function LandingPage({ locale = 'en' }) {
                 </div>
               </div>
 
-              <div className="flex flex-col gap-[24px]">
-                <span className="text-[14px] leading-[20px]" style={{ color: 'rgba(255, 255, 255, 0.6)' }}>
+              <div className="flex flex-col gap-[32px]">
+                <p className="text-[14px] font-medium leading-[17px] text-white/60">
                   {getFooterData(isZh, locale).legalColumn.title}
-                </span>
+                </p>
                 <div className="flex flex-col gap-[16px]">
                   {getFooterData(isZh, locale).legalColumn.items.map((item) => (
                     <a
                       key={item.label}
                       href={item.href}
-                      className="text-[14px] font-medium leading-[20px] hover:opacity-80"
-                      style={{ color: '#FFFFFF' }}
+                      className="text-[16px] font-medium leading-[20px] text-white hover:text-white/80"
                       target="_blank"
                       rel="noopener noreferrer"
                     >
@@ -419,61 +481,12 @@ export function LandingPage({ locale = 'en' }) {
                 </div>
               </div>
             </div>
-          </div>
 
-          <div className="mt-[100px] flex flex-col gap-[28px]">
-            <div className="flex items-center gap-[16px]">
-              <a
-                href="https://twitter.com/onekeyHQ"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Twitter"
-              >
-                <img src="/landing-page/social/twitter.svg" alt="" className="size-[24px]" />
-              </a>
-              <a
-                href="https://github.com/OneKeyHQ"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="GitHub"
-              >
-                <img src="/landing-page/social/github.svg" alt="" className="size-[24px]" />
-              </a>
-              <a
-                href="https://discord.gg/onekey"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Discord"
-              >
-                <img src="/landing-page/social/discord.svg" alt="" className="size-[24px]" />
-              </a>
-            </div>
-            <div className="flex items-center gap-[16px]">
-              <a
-                href="https://github.com/OneKeyHQ"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <img
-                  src="/landing-page/badge-osi.svg"
-                  alt="Open Source"
-                  className="h-[28px] w-auto"
-                />
-              </a>
-              <img
-                src="/landing-page/badge-cceal.svg"
-                alt="CEPREI ISO/IEC 27001"
-                className="h-[28px] w-auto"
-              />
-            </div>
-            <div className="flex items-center gap-[24px]">
-              <span className="text-[12px] leading-[16px]" style={{ color: 'rgba(255, 255, 255, 0.4)' }}>
-                {new Date().getFullYear()} OneKey, Inc. All rights reserved.
-              </span>
+            <div className="flex flex-col gap-[16px]">
               <button
                 type="button"
                 onClick={() => setShowSubscribeModal(true)}
-                className="w-fit rounded-[50px] border border-white/20 px-[24px] py-[10px] text-[14px] font-medium text-white hover:bg-white/10"
+                className="w-fit rounded-[50px] border border-white px-[20px] py-[10px] text-[16px] font-medium text-white hover:bg-white/10"
               >
                 {isZh ? '订阅我们的通知' : 'Subscribe to our notifications'}
               </button>


### PR DESCRIPTION
## Summary

- Restores SDK version + commit hash display in the landing page footer (removed by #655)
- Restores original copyright text: "Since 2019 - {year} | OneKey Limited All Rights Reserved"
- Restores `rounded-t-[64px]` rounded top corner on footer
- Restores social icons and badge icons to left column (under logo), not bottom row
- Restores Subscribe button to right column bottom (not next to copyright)
- Restores footer padding `py-[120px]` and two-column `lg:flex-row` layout

## Root Cause

Commit `917e49c3` (#655) redesigned the landing page footer and accidentally removed the SDK version/commit hash display and broke the overall footer layout. The footer was working correctly at v1.1.22 (commit `d9d816ec`).

## Test plan

- [ ] Build developer portal and verify footer shows `SDK v{version} · {commit_hash}`
- [ ] Verify footer has rounded top corners
- [ ] Verify social icons (X, GitHub, Discord) appear in left column under logo
- [ ] Verify copyright text reads "Since 2019 - {year} | OneKey Limited All Rights Reserved"
- [ ] Verify Subscribe button is in right column at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)