### PR TITLE
fix(developer-portal): show streaming indicator instead of copy button during AI response

### DIFF
--- a/packages/connect-examples/developer-portal/components/DocAIChatWidget.client.jsx
+++ b/packages/connect-examples/developer-portal/components/DocAIChatWidget.client.jsx
@@ -1105,23 +1105,34 @@ function ChatWidgetRuntime({ apiUrl, lang }) {
                               </ul>
                             </div>
                           ) : null}
-                          <div className={styles.actions} data-docs-ai="actions">
-                            <button
-                              type="button"
-                              onClick={() =>
-                                handleCopyMessage(message, shouldShowSources ? messageSources : [])
-                              }
-                            >
-                              <CopyIcon size={14} />
-                              <span>{copiedMessageId === message.id ? copy.copied : copy.copy}</span>
-                            </button>
-                            {latestAssistantMessage?.id === message.id ? (
-                              <button type="button" onClick={() => handleRetryMessage(message)}>
-                                <RotateCcwIcon size={14} />
-                                <span>{copy.retry}</span>
+                          {isStreamingMessage ? (
+                            <div className={styles.streamingIndicator} data-docs-ai="streaming">
+                              <span className={styles.streamingText}>{copy.sending}</span>
+                              <span className={styles.statusDots} aria-hidden="true">
+                                <span />
+                                <span />
+                                <span />
+                              </span>
+                            </div>
+                          ) : (
+                            <div className={styles.actions} data-docs-ai="actions">
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  handleCopyMessage(message, shouldShowSources ? messageSources : [])
+                                }
+                              >
+                                <CopyIcon size={14} />
+                                <span>{copiedMessageId === message.id ? copy.copied : copy.copy}</span>
                               </button>
-                            ) : null}
-                          </div>
+                              {latestAssistantMessage?.id === message.id ? (
+                                <button type="button" onClick={() => handleRetryMessage(message)}>
+                                  <RotateCcwIcon size={14} />
+                                  <span>{copy.retry}</span>
+                                </button>
+                              ) : null}
+                            </div>
+                          )}
                         </div>
                       ) : null}
                     </div>

--- a/packages/connect-examples/developer-portal/components/DocAIChatWidget.module.css
+++ b/packages/connect-examples/developer-portal/components/DocAIChatWidget.module.css
@@ -752,6 +752,21 @@
 
 .actions button:hover { color: var(--clr-sub); }
 
+/* Streaming indicator shown in place of actions while generating */
+.streamingIndicator {
+  margin-top: 10px;
+  margin-bottom: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--clr-muted);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.streamingText { color: inherit; }
+
 /* Copy action for user messages */
 .userActions {
   margin-top: 4px;


### PR DESCRIPTION
## Summary
- AI 对话流式回复过程中，隐藏 Copy/Retry 按钮，替换为 "生成中..." 加载动画指示器
- 回复完成后恢复显示 Copy/Retry 按钮
- 复用已有的 statusDots 脉冲动画，保持视觉一致性

## Test plan
- [ ] 打开 Developer Portal 的 AI 对话弹窗，发送一个问题
- [ ] 验证流式回复期间显示 "生成中" / "Generating" + 动画点，而非 Copy 按钮
- [ ] 验证回复完成后 Copy 和 Retry 按钮正常出现
- [ ] 验证中英文两种语言下文案正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)