### PR TITLE
chore(ci): remove legacy S3 CDN deploy from release-web

### DIFF
--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -5,6 +5,8 @@ on: workflow_dispatch
 jobs:
   release-web:
     runs-on: ubuntu-latest
+    env:
+      PUBLIC_PATH: 'https://jssdk.onekey.so/${{ github.event.repository.name }}/${{ github.sha }}/'
     steps:
       - uses: actions/checkout@v4
       - name: Setup Environment

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -5,9 +5,6 @@ on: workflow_dispatch
 jobs:
   release-web:
     runs-on: ubuntu-latest
-    env:
-      HOST_PATH: '${{ github.event.repository.name }}/${{ github.sha }}/'
-      PUBLIC_PATH: 'https://jssdk.onekey.so/${{ github.event.repository.name }}/${{ github.sha }}/'
     steps:
       - uses: actions/checkout@v4
       - name: Setup Environment
@@ -23,21 +20,6 @@ jobs:
       - name: Build Target
         run: |
           yarn build
-
-      - name: Build Target
-        env:
-          PUBLIC_PATH: ${{ env.PUBLIC_PATH }}
-        run: |
-          yarn build
-
-      - name: Deploy to CDN
-        uses: OneKeyHQ/onekey-github-actions/s3-upload@main
-        with:
-          aws_key_id: ${{ secrets.AWS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_bucket: ${{ secrets.AWS_BUCKET }}
-          source_dir: './packages/hd-web-sdk/build/'
-          destination_dir: ${{ env.HOST_PATH }}
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -20,6 +20,8 @@ jobs:
           yarn
           yarn bootstrap
       - name: Build Target
+        env:
+          PUBLIC_PATH: ${{ env.PUBLIC_PATH }}
         run: |
           yarn build
 


### PR DESCRIPTION
## Summary
- remove legacy CDN deploy step from `release-web` workflow
- remove AWS secret inputs (`AWS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_BUCKET`) and CDN path envs
- keep build and artifact upload so manual workflow still produces downloadable artifacts

## Test plan
- [ ] Trigger `deploy-release-iframe-web` workflow manually
- [ ] Confirm build step succeeds
- [ ] Confirm no AWS/CDN deploy step appears
- [ ] Confirm artifact upload succeeds and build output is downloadable


Made with [Cursor](https://cursor.com)