### PR TITLE
feat(hd-cli): add schema command and HardwareSigner integration

### DIFF
--- a/packages/hd-cli/CLAUDE.md
+++ b/packages/hd-cli/CLAUDE.md
@@ -29,6 +29,31 @@ onekey-hw get-address --chain evm --use-empty-passphrase
 onekey-hw sign-message --chain evm --message "hello" --use-empty-passphrase
 ```
 
+## Schema Discovery (for AI Agents)
+
+```bash
+# List all commands with their options
+onekey-hw schema list
+
+# Get schema for a specific command
+onekey-hw schema get-address
+onekey-hw schema sign-transaction
+```
+
+## Integration with app-monorepo CLI
+
+The `@onekeyfe/hardware-cli` package exports a `HardwareSigner` interface
+for programmatic integration:
+
+```typescript
+import { createHardwareSigner } from '@onekeyfe/hardware-cli';
+
+const signer = await createHardwareSigner({ useEmptyPassphrase: true });
+const { address } = await signer.getAddress('evm');
+const signed = await signer.signTransaction('evm', txData);
+signer.dispose();
+```
+
 ## Important
 
 - All signing operations require **physical confirmation** on the hardware device

--- a/packages/hd-cli/src/cli.ts
+++ b/packages/hd-cli/src/cli.ts
@@ -693,6 +693,78 @@ program
   });
 
 // ============================================================
+// Schema Discovery (for AI Agent integration)
+// ============================================================
+
+const schemaCmd = program
+  .command('schema')
+  .description('Show JSON Schema for CLI commands (for AI agent integration)');
+
+schemaCmd
+  .command('list')
+  .description('List all available commands')
+  .action(() => {
+    const commands = program.commands
+      .filter(c => c.name() !== 'schema')
+      .map(c => ({
+        name: c.name(),
+        description: c.description(),
+        options: c.options.map(o => ({
+          flags: o.flags,
+          description: o.description,
+          required: o.required,
+          defaultValue: o.defaultValue,
+        })),
+      }));
+    console.log(JSON.stringify({ commands }, null, 2));
+    process.exit(0);
+  });
+
+schemaCmd
+  .argument('[command]', 'Command name to get schema for')
+  .action((cmdName: string | undefined) => {
+    if (!cmdName) {
+      // Same as schema list
+      const commands = program.commands
+        .filter(c => c.name() !== 'schema')
+        .map(c => ({
+          name: c.name(),
+          description: c.description(),
+          options: c.options.map(o => ({
+            flags: o.flags,
+            description: o.description,
+            required: o.required,
+            defaultValue: o.defaultValue,
+          })),
+        }));
+      console.log(JSON.stringify({ commands }, null, 2));
+      process.exit(0);
+      return;
+    }
+    const cmd = program.commands.find(c => c.name() === cmdName);
+    if (!cmd) {
+      console.error(JSON.stringify({
+        success: false,
+        payload: { error: `Unknown command: ${cmdName}`, code: 'UNKNOWN_COMMAND' },
+      }));
+      process.exit(1);
+      return;
+    }
+    const schema = {
+      name: cmd.name(),
+      description: cmd.description(),
+      options: cmd.options.map(o => ({
+        flags: o.flags,
+        description: o.description,
+        required: o.required,
+        defaultValue: o.defaultValue,
+      })),
+    };
+    console.log(JSON.stringify(schema, null, 2));
+    process.exit(0);
+  });
+
+// ============================================================
 // Helpers
 // ============================================================
 

--- a/packages/hd-cli/src/index.ts
+++ b/packages/hd-cli/src/index.ts
@@ -36,3 +36,74 @@ export type {
   SignMessageParams,
   BatchGetAddressParams,
 } from './chains';
+
+/**
+ * Hardware signer interface — bridge for app-monorepo CLI integration.
+ * Allows `onekey transfer --signer hardware` to use hardware wallet signing.
+ */
+export interface HardwareSigner {
+  /** Get address for a given chain */
+  getAddress(chain: string, path?: string): Promise<{ address: string; path: string }>;
+  /** Sign a transaction (requires physical device confirmation) */
+  signTransaction(chain: string, tx: Record<string, unknown>, path?: string): Promise<{ signature: string; [key: string]: unknown }>;
+  /** Sign a message */
+  signMessage(chain: string, message: string, path?: string): Promise<{ signature: string; [key: string]: unknown }>;
+  /** Dispose SDK resources */
+  dispose(): void;
+}
+
+export async function createHardwareSigner(opts?: {
+  connectId?: string;
+  deviceId?: string;
+  useEmptyPassphrase?: boolean;
+}): Promise<HardwareSigner> {
+  const sdk = await createSDK(opts || {});
+
+  return {
+    async getAddress(chain: string, path?: string) {
+      const result = await resolveGetAddress(sdk, {
+        chain,
+        path,
+        showOnDevice: false,
+        connectId: opts?.connectId,
+        deviceId: opts?.deviceId,
+      });
+      if (result && typeof result === 'object' && 'success' in result && !(result as any).success) {
+        throw new Error((result as any).payload?.error || 'Failed to get address');
+      }
+      return { address: (result as any).payload?.address || (result as any).address, path: (result as any).path };
+    },
+
+    async signTransaction(chain: string, tx: Record<string, unknown>, path?: string) {
+      const result = await resolveSignTransaction(sdk, {
+        chain,
+        path,
+        transaction: tx,
+        connectId: opts?.connectId,
+        deviceId: opts?.deviceId,
+      });
+      if (result && typeof result === 'object' && 'success' in result && !(result as any).success) {
+        throw new Error((result as any).payload?.error || 'Failed to sign transaction');
+      }
+      return result as any;
+    },
+
+    async signMessage(chain: string, message: string, path?: string) {
+      const result = await resolveSignMessage(sdk, {
+        chain,
+        path,
+        message,
+        connectId: opts?.connectId,
+        deviceId: opts?.deviceId,
+      });
+      if (result && typeof result === 'object' && 'success' in result && !(result as any).success) {
+        throw new Error((result as any).payload?.error || 'Failed to sign message');
+      }
+      return result as any;
+    },
+
+    dispose() {
+      sdk.dispose();
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add `onekey-hw schema` command for AI agent self-discovery of available commands and parameters
- Add `HardwareSigner` interface and `createHardwareSigner()` factory for programmatic integration with app-monorepo CLI
- Update CLAUDE.md with schema discovery and integration documentation

## Background

The hardware CLI (`onekey-hw`) and app-monorepo CLI (`onekey`) are completely isolated. This PR bridges them by:

1. **Schema self-discovery** — `onekey-hw schema list` / `onekey-hw schema <cmd>` outputs JSON Schema, matching the `onekey schema` pattern in app-monorepo. AI agents can now discover commands programmatically instead of relying solely on SKILL.md docs.

2. **HardwareSigner interface** — A clean programmatic API that app-monorepo can import to add `--signer hardware` support to `onekey transfer`, enabling end-to-end hardware wallet flows without manual CLI bridging.

## Changed Files

| File | Change |
|---|---|
| `packages/hd-cli/src/cli.ts` | Add `schema` command group (list + per-command) |
| `packages/hd-cli/src/index.ts` | Add `HardwareSigner` interface + `createHardwareSigner()` |
| `packages/hd-cli/CLAUDE.md` | Document schema discovery and integration usage |

## Test plan

- [ ] `onekey-hw schema list` returns JSON with all commands
- [ ] `onekey-hw schema get-address` returns correct options
- [ ] `onekey-hw schema nonexistent` returns structured error
- [ ] `createHardwareSigner()` can be imported and instantiated
- [ ] Existing CLI commands still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)