### PR TITLE
fix(hd-cli): P1 improvements — safety, consistency, and skill docs

### DIFF
--- a/packages/hd-cli/src/chains.ts
+++ b/packages/hd-cli/src/chains.ts
@@ -227,10 +227,10 @@ export async function resolveSignTransaction(sdk: CoreApi, params: SignTransacti
     // XRP: implementation reads path + transaction from payload despite type declaration
     // eslint-disable-next-line @typescript-eslint/ban-types
     xrp: () =>
-      (sdk.xrpSignTransaction as (...args: unknown[]) => Promise<unknown>)(connectId, deviceId, {
+      sdk.xrpSignTransaction(connectId, deviceId, {
         path,
         transaction: tx,
-      }),
+      } as any),
     stellar: () =>
       sdk.stellarSignTransaction(connectId, deviceId, {
         path,

--- a/packages/hd-cli/src/cli.ts
+++ b/packages/hd-cli/src/cli.ts
@@ -490,7 +490,8 @@ program
     const globalOpts = program.opts();
     const sdk = await createSDK(globalOpts);
     try {
-      const result = await sdk.checkFirmwareRelease(globalOpts.connectId);
+      const params = getCommonParams(globalOpts);
+      const result = await sdk.checkFirmwareRelease(params.connectId);
       outputResult(globalOpts, result);
     } finally {
       sdk.dispose();
@@ -504,7 +505,8 @@ program
     const globalOpts = program.opts();
     const sdk = await createSDK(globalOpts);
     try {
-      const result = await sdk.checkAllFirmwareRelease(globalOpts.connectId);
+      const params = getCommonParams(globalOpts);
+      const result = await sdk.checkAllFirmwareRelease(params.connectId);
       outputResult(globalOpts, result);
     } finally {
       sdk.dispose();
@@ -546,7 +548,8 @@ program
     const globalOpts = program.opts();
     const sdk = await createSDK(globalOpts);
     try {
-      const result = await sdk.checkBootloaderRelease(globalOpts.connectId);
+      const params = getCommonParams(globalOpts);
+      const result = await sdk.checkBootloaderRelease(params.connectId);
       outputResult(globalOpts, result);
     } finally {
       sdk.dispose();
@@ -610,7 +613,18 @@ program
 program
   .command('device-wipe')
   .description('Factory reset — erase ALL data (IRREVERSIBLE)')
-  .action(async () => {
+  .requiredOption('--confirm-wipe', 'Confirm you understand this will erase ALL data permanently')
+  .action(async (opts) => {
+    if (!opts.confirmWipe) {
+      outputResult(program.opts(), {
+        success: false,
+        payload: {
+          error: 'Factory reset requires --confirm-wipe flag. WARNING: This will erase ALL data on the device permanently.',
+          code: 'CONFIRMATION_REQUIRED',
+        },
+      });
+      return;
+    }
     const globalOpts = program.opts();
     const sdk = await createSDK(globalOpts);
     try {

--- a/skills/device/SKILL.md
+++ b/skills/device/SKILL.md
@@ -19,8 +19,8 @@ update when installing, updating, or handling a failure.
 2. **Check version is latest** (once per session):
    - Fetch latest: `npm view @onekeyfe/hardware-cli version`
    - Compare with local `onekey-hw --version`
-   - Local version behind → **BLOCK operation**, run `npm update -g @onekeyfe/hardware-cli`
-   - Update failed → STOP, suggest manual update.
+   - Local version behind → **warn user**, run `npm update -g @onekeyfe/hardware-cli`
+   - If update fails → continue with current version (warn, do not block)
    - Update succeeded → continue with original command.
 
 ## Device Interaction Model

--- a/skills/firmware/SKILL.md
+++ b/skills/firmware/SKILL.md
@@ -39,6 +39,19 @@ Check bootloader version and status.
 onekey-hw bootloader-check [--connect-id <id>]
 ```
 
+### `onekey-hw firmware-update` / `onekey-hw firmware-update-ble`
+
+**These commands return an error by design.** They exist to provide a clear
+error message guiding users to the correct update method.
+
+```bash
+onekey-hw firmware-update
+# Returns: { success: false, payload: { error: "Firmware update via CLI is not supported...", code: "FIRMWARE_UPDATE_NOT_SUPPORTED" } }
+```
+
+**Agent note:** If the user requests firmware update, do NOT run these commands.
+Instead, directly guide them to the OneKey App or https://firmware.onekey.so/
+
 ### Firmware Updates
 
 **Firmware updates are NOT supported via CLI.**

--- a/skills/security/SKILL.md
+++ b/skills/security/SKILL.md
@@ -77,12 +77,14 @@ onekey-hw toggle-passphrase --enable <bool> [--connect-id <id>]
 Factory reset — erase all data from the device.
 
 ```bash
-onekey-hw device-wipe [--connect-id <id>]
+onekey-hw device-wipe --confirm-wipe [--connect-id <id>]
 ```
 
 **Agent notes:**
 - This is the most destructive operation. ALL data is permanently erased.
-- Require EXPLICIT double confirmation before executing.
+- The `--confirm-wipe` flag is REQUIRED — the command will not execute without it.
+- Require EXPLICIT double confirmation from the user before executing.
+- Verify user has recovery phrase backed up before proceeding.
 
 ### `onekey-hw device-settings`
 
@@ -139,9 +141,11 @@ Step 1 — Double confirmation
 → "WARNING: Factory reset will PERMANENTLY erase all data on your device.
    Do you have your recovery phrase backed up?"
 → Wait for confirmation
+→ "Are you absolutely sure? This cannot be undone."
+→ Wait for second confirmation
 
 Step 2 — Execute
-→ onekey-hw device-wipe --connect-id <id>
+→ onekey-hw device-wipe --confirm-wipe --connect-id <id>
 → "Device has been wiped. Use the OneKey App to set it up again."
 ```
 

--- a/skills/signing/SKILL.md
+++ b/skills/signing/SKILL.md
@@ -21,6 +21,10 @@ Every time before running any `onekey-hw` command, follow these steps in order.
    - Device in bootloader mode → cannot sign, guide to `hardware-firmware` skill.
    - Device not initialized → guide user to set up device first.
 
+3. **Check passphrase mode**: If user hasn't specified hidden wallet:
+   - Add `--use-empty-passphrase` to avoid passphrase prompt
+   - If user explicitly needs hidden wallet, use `--passphrase-state <state>`
+
 ## Device Interaction — IMPORTANT
 
 **All signing commands block while waiting for physical interaction on the device.**
@@ -247,8 +251,10 @@ onekey-hw sign-message \
 
 **Agent notes:**
 - Device will show the message for user verification.
-- **TON note**: `tonSignMessage` is a transfer-signing method, not arbitrary message
-  signing. Pass `--message` as JSON: `'{"destination":"UQ...","tonAmount":100,"seqno":0,"expireAt":1234567890}'`.
+- **TON note**: `sign-message --chain ton` is a **transfer-signing** method (tonSignMessage),
+  not arbitrary message signing. The `--message` parameter must be a JSON object:
+  `'{"destination":"UQ...","tonAmount":100,"seqno":0,"expireAt":1234567890}'`.
+  For TON wallet authentication, use `ton-sign-proof` instead.
 
 ### `onekey-hw sign-typed-data`
 


### PR DESCRIPTION
## Summary

- Fix firmware commands to use consistent `getCommonParams()` pattern
- Add `--confirm-wipe` safety flag to `device-wipe` (IRREVERSIBLE operation)
- Narrow XRP `signTransaction` type cast scope
- Fix skill documentation (device, signing, firmware, security)

## Changes

### Code Fixes

| Fix | File | Detail |
|---|---|---|
| Firmware params consistency | `cli.ts` | `firmware-check`, `firmware-check-all`, `bootloader-check` now use `getCommonParams()` |
| device-wipe safety | `cli.ts` | Added `--confirm-wipe` required flag; command refuses to run without it |
| XRP type cast | `chains.ts` | Narrowed from full method cast to params-only `as any` |

### Skill Documentation Fixes

| Fix | File | Detail |
|---|---|---|
| Version check blocking | `device/SKILL.md` | Downgraded from "BLOCK operation" to "warn user" |
| Passphrase guidance | `signing/SKILL.md` | Added `--use-empty-passphrase` to pre-flight checks |
| TON clarification | `signing/SKILL.md` | Clarified `sign-message --chain ton` is transfer-signing, not arbitrary message |
| firmware-update docs | `firmware/SKILL.md` | Documented error-by-design commands with agent guidance |
| device-wipe workflow | `security/SKILL.md` | Updated for `--confirm-wipe` flag + double confirmation workflow |

## Test plan

- [ ] `onekey-hw firmware-check` still works correctly
- [ ] `onekey-hw device-wipe` without `--confirm-wipe` returns structured error
- [ ] `onekey-hw device-wipe --confirm-wipe` proceeds to device interaction
- [ ] XRP sign-transaction still compiles and works
- [ ] Skill docs render correctly in markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)