### PR TITLE
chore(hd-web-sdk): upgrade cross-inpage-provider-core to 2.2.67

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
         "path": "packages/hd-cli"
       },
       "description": "4 OneKey hardware wallet skills — device (search, lock, verify), signing (27 chains, address, tx, message), firmware (check), security (PIN, passphrase, wipe)",
-      "version": "1.1.25-alpha.1",
+      "version": "1.1.26-alpha.0",
       "author": { "name": "OneKey" },
       "homepage": "https://onekey.so",
       "repository": "https://github.com/OneKeyHQ/hardware-js-sdk",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
         "path": "packages/hd-cli"
       },
       "description": "4 OneKey hardware wallet skills — device (search, lock, verify), signing (27 chains, address, tx, message), firmware (check), security (PIN, passphrase, wipe)",
-      "version": "1.1.26-alpha.0",
+      "version": "1.1.25-alpha.1",
       "author": { "name": "OneKey" },
       "homepage": "https://onekey.so",
       "repository": "https://github.com/OneKeyHQ/hardware-js-sdk",

--- a/packages/connect-examples/electron-example/package.json
+++ b/packages/connect-examples/electron-example/package.json
@@ -2,7 +2,7 @@
   "name": "hardware-example",
   "productName": "HardwareExample",
   "executableName": "onekey-hardware-example",
-  "version": "1.1.25",
+  "version": "1.1.26-alpha.0",
   "author": "OneKey",
   "description": "End-to-end encrypted workspaces for teams",
   "main": "dist/index.js",
@@ -22,7 +22,7 @@
     "ts:check": "yarn tsc --noEmit"
   },
   "dependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.25",
+    "@onekeyfe/hd-transport-electron": "1.1.26-alpha.0",
     "@stoprocent/noble": "2.3.16",
     "debug": "4.3.4",
     "electron-is-dev": "^3.0.1",

--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.1.25",
+  "version": "1.1.26-alpha.0",
   "scripts": {
     "start": "cross-env CONNECT_SRC=https://localhost:8087/ yarn expo start --dev-client",
     "android": "yarn expo run:android",
@@ -19,10 +19,10 @@
     "@noble/ed25519": "^2.1.0",
     "@noble/hashes": "^1.3.3",
     "@noble/secp256k1": "^1.7.1",
-    "@onekeyfe/hd-ble-sdk": "1.1.25",
-    "@onekeyfe/hd-common-connect-sdk": "1.1.25",
-    "@onekeyfe/hd-core": "1.1.25",
-    "@onekeyfe/hd-web-sdk": "1.1.25",
+    "@onekeyfe/hd-ble-sdk": "1.1.26-alpha.0",
+    "@onekeyfe/hd-common-connect-sdk": "1.1.26-alpha.0",
+    "@onekeyfe/hd-core": "1.1.26-alpha.0",
+    "@onekeyfe/hd-web-sdk": "1.1.26-alpha.0",
     "@onekeyfe/react-native-ble-utils": "^0.1.3",
     "@polkadot/util-crypto": "13.1.1",
     "@react-native-async-storage/async-storage": "1.21.0",

--- a/packages/connect-examples/expo-playground/package.json
+++ b/packages/connect-examples/expo-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onekey-hardware-playground",
-  "version": "1.1.25",
+  "version": "1.1.26-alpha.0",
   "private": true,
   "sideEffects": [
     "app/utils/shim.js",
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0",
-    "@onekeyfe/hd-common-connect-sdk": "1.1.25",
-    "@onekeyfe/hd-core": "1.1.25",
-    "@onekeyfe/hd-shared": "1.1.25",
+    "@onekeyfe/hd-common-connect-sdk": "1.1.26-alpha.0",
+    "@onekeyfe/hd-core": "1.1.26-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.0",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.1.25",
+  "version": "1.1.26-alpha.0",
   "description": "Core processes and APIs for communicating with OneKey hardware devices.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.25",
-    "@onekeyfe/hd-transport": "1.1.25",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.26-alpha.0",
     "axios": "1.12.2",
     "bignumber.js": "^9.0.2",
     "bytebuffer": "^5.0.1",

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.1.25",
+  "version": "1.1.26-alpha.0",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.25",
-    "@onekeyfe/hd-shared": "1.1.25",
-    "@onekeyfe/hd-transport-react-native": "1.1.25"
+    "@onekeyfe/hd-core": "1.1.26-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.0",
+    "@onekeyfe/hd-transport-react-native": "1.1.26-alpha.0"
   }
 }

--- a/packages/hd-cli/package.json
+++ b/packages/hd-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hardware-cli",
-  "version": "1.1.25",
+  "version": "1.1.26-alpha.0",
   "description": "OneKey hardware wallet CLI for AI agent integration",
   "author": "OneKey",
   "license": "Apache-2.0",
@@ -24,10 +24,10 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-common-connect-sdk": "1.1.25",
-    "@onekeyfe/hd-core": "1.1.25",
-    "@onekeyfe/hd-shared": "1.1.25",
-    "@onekeyfe/hd-transport-usb": "1.1.25",
+    "@onekeyfe/hd-common-connect-sdk": "1.1.26-alpha.0",
+    "@onekeyfe/hd-core": "1.1.26-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.0",
+    "@onekeyfe/hd-transport-usb": "1.1.26-alpha.0",
     "commander": "^12.0.0",
     "eventemitter2": "^6.4.9",
     "lodash": "^4.17.21",

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.1.25",
+  "version": "1.1.26-alpha.0",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.25",
-    "@onekeyfe/hd-shared": "1.1.25",
-    "@onekeyfe/hd-transport-emulator": "1.1.25",
-    "@onekeyfe/hd-transport-http": "1.1.25",
-    "@onekeyfe/hd-transport-lowlevel": "1.1.25",
-    "@onekeyfe/hd-transport-web-device": "1.1.25"
+    "@onekeyfe/hd-core": "1.1.26-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.0",
+    "@onekeyfe/hd-transport-emulator": "1.1.26-alpha.0",
+    "@onekeyfe/hd-transport-http": "1.1.26-alpha.0",
+    "@onekeyfe/hd-transport-lowlevel": "1.1.26-alpha.0",
+    "@onekeyfe/hd-transport-web-device": "1.1.26-alpha.0"
   }
 }

--- a/packages/hd-transport-electron/package.json
+++ b/packages/hd-transport-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-electron",
-  "version": "1.1.25",
+  "version": "1.1.26-alpha.0",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -25,9 +25,9 @@
     "electron-log": ">=4.0.0"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.25",
-    "@onekeyfe/hd-shared": "1.1.25",
-    "@onekeyfe/hd-transport": "1.1.25",
+    "@onekeyfe/hd-core": "1.1.26-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.26-alpha.0",
     "@stoprocent/noble": "2.3.16",
     "p-retry": "^4.6.2"
   },

--- a/packages/hd-transport-emulator/package.json
+++ b/packages/hd-transport-emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-emulator",
-  "version": "1.1.25",
+  "version": "1.1.26-alpha.0",
   "description": "hardware emulator transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.25",
-    "@onekeyfe/hd-transport": "1.1.25",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.26-alpha.0",
     "axios": "1.12.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.1.25",
+  "version": "1.1.26-alpha.0",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.25",
-    "@onekeyfe/hd-transport": "1.1.25",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.26-alpha.0",
     "axios": "1.12.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.1.25",
+  "version": "1.1.26-alpha.0",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.25",
-    "@onekeyfe/hd-transport": "1.1.25"
+    "@onekeyfe/hd-shared": "1.1.26-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.26-alpha.0"
   }
 }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.1.25",
+  "version": "1.1.26-alpha.0",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,9 +19,9 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.25",
-    "@onekeyfe/hd-shared": "1.1.25",
-    "@onekeyfe/hd-transport": "1.1.25",
+    "@onekeyfe/hd-core": "1.1.26-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.26-alpha.0",
     "@onekeyfe/react-native-ble-utils": "^0.1.4",
     "react-native-ble-plx": "3.5.1"
   }

--- a/packages/hd-transport-usb/package.json
+++ b/packages/hd-transport-usb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-usb",
-  "version": "1.1.25",
+  "version": "1.1.26-alpha.0",
   "description": "OneKey hardware wallet direct USB transport plugin (libusb)",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.25",
-    "@onekeyfe/hd-transport": "1.1.25",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.26-alpha.0",
     "bytebuffer": "^5.0.1",
     "usb": "^2.14.0"
   }

--- a/packages/hd-transport-web-device/package.json
+++ b/packages/hd-transport-web-device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-web-device",
-  "version": "1.1.25",
+  "version": "1.1.26-alpha.0",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.25",
-    "@onekeyfe/hd-transport": "1.1.25"
+    "@onekeyfe/hd-shared": "1.1.26-alpha.0",
+    "@onekeyfe/hd-transport": "1.1.26-alpha.0"
   },
   "devDependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.25",
+    "@onekeyfe/hd-transport-electron": "1.1.26-alpha.0",
     "@types/w3c-web-usb": "^1.0.6",
     "@types/web-bluetooth": "^0.0.17"
   }

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.1.25",
+  "version": "1.1.26-alpha.0",
   "description": "Transport layer abstractions and utilities for OneKey hardware SDK.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.1.25",
+  "version": "1.1.26-alpha.0",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "2.2.67",
-    "@onekeyfe/hd-core": "1.1.25",
-    "@onekeyfe/hd-shared": "1.1.25",
-    "@onekeyfe/hd-transport-http": "1.1.25",
-    "@onekeyfe/hd-transport-web-device": "1.1.25"
+    "@onekeyfe/hd-core": "1.1.26-alpha.0",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.0",
+    "@onekeyfe/hd-transport-http": "1.1.26-alpha.0",
+    "@onekeyfe/hd-transport-web-device": "1.1.26-alpha.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -20,7 +20,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/cross-inpage-provider-core": "^0.0.17",
+    "@onekeyfe/cross-inpage-provider-core": "2.2.67",
     "@onekeyfe/hd-core": "1.1.25",
     "@onekeyfe/hd-shared": "1.1.25",
     "@onekeyfe/hd-transport-http": "1.1.25",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.1.25",
+  "version": "1.1.26-alpha.0",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4546,7 +4546,7 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
   integrity sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==
 
-"@noble/hashes@^1.8.0":
+"@noble/hashes@^1.7.1", "@noble/hashes@^1.8.0":
   version "1.8.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
@@ -4776,34 +4776,35 @@
   dependencies:
     "@octokit/openapi-types" "^11.2.0"
 
-"@onekeyfe/cross-inpage-provider-core@^0.0.17":
-  version "0.0.17"
-  resolved "https://registry.yarnpkg.com/@onekeyfe/cross-inpage-provider-core/-/cross-inpage-provider-core-0.0.17.tgz#ca73217ca048e8991971ed6c06510b1efac1f30f"
-  integrity sha512-QJ9jFvpYIwS1av+JT0z9sO4KMjVGVCZVFT3lePgXBks6zuSLvX6zfBCGSu2X4b2QS3JkA55pGrReUup9o9yX7Q==
+"@onekeyfe/cross-inpage-provider-core@2.2.67":
+  version "2.2.67"
+  resolved "https://registry.npmjs.org/@onekeyfe/cross-inpage-provider-core/-/cross-inpage-provider-core-2.2.67.tgz#b8c9af864161d186a404eb5c891aa61ee81ea93f"
+  integrity sha512-vExbTnrLC+Qvt/4Gf0yNZunU2SjTUnPHhWtzwfLfKiXX8Ob7tT8Ccr4du5xTJVdFX1bjjYpOlnwsGJ0YYHpTTQ==
   dependencies:
-    "@onekeyfe/cross-inpage-provider-errors" "^0.0.17"
-    "@onekeyfe/cross-inpage-provider-events" "^0.0.17"
-    "@onekeyfe/cross-inpage-provider-types" "^0.0.17"
+    "@noble/hashes" "^1.7.1"
+    "@onekeyfe/cross-inpage-provider-errors" "2.2.67"
+    "@onekeyfe/cross-inpage-provider-events" "2.2.67"
+    "@onekeyfe/cross-inpage-provider-types" "2.2.67"
     events "^3.3.0"
-    lodash "^4.17.21"
+    lodash-es "^4.17.21"
     ms "^2.1.3"
 
-"@onekeyfe/cross-inpage-provider-errors@^0.0.17":
-  version "0.0.17"
-  resolved "https://registry.yarnpkg.com/@onekeyfe/cross-inpage-provider-errors/-/cross-inpage-provider-errors-0.0.17.tgz#1812c8993ca47e06f699db0c397c63a53c90b74d"
-  integrity sha512-J4b8j9TzaJWtJ1FjmxggsyDOQQobnXYjzyfosIp6b36dz+v7+H+N0o436T6qkbFxZJqXZzAF2zSMjXn/t+JNaw==
+"@onekeyfe/cross-inpage-provider-errors@2.2.67":
+  version "2.2.67"
+  resolved "https://registry.npmjs.org/@onekeyfe/cross-inpage-provider-errors/-/cross-inpage-provider-errors-2.2.67.tgz#75072675f4da1af2645523d18b76b41a0099d8b2"
+  integrity sha512-rd8/TGbNbe62+wvS6SpNxiBJeDVb1tKQcrN2LnZQKXW3NL7jbh0uDsiGmwKVbLPdXTd8hDRcQWdHDDiHGV8G+g==
   dependencies:
-    fast-safe-stringify "^2.1.1"
+    fast-safe-stringify "^2.0.6"
 
-"@onekeyfe/cross-inpage-provider-events@^0.0.17":
-  version "0.0.17"
-  resolved "https://registry.yarnpkg.com/@onekeyfe/cross-inpage-provider-events/-/cross-inpage-provider-events-0.0.17.tgz#9412e8a164d55a157475d8aed19bedeb7c2df959"
-  integrity sha512-mRpLJkBAhaDEhVIKY6WI9+Zwdb6LhFJjM8E0HLHgxZlOmswKmNAhY4lgYr3Z8iF2yX2//Z46DqW0C5nWsDdVYA==
+"@onekeyfe/cross-inpage-provider-events@2.2.67":
+  version "2.2.67"
+  resolved "https://registry.npmjs.org/@onekeyfe/cross-inpage-provider-events/-/cross-inpage-provider-events-2.2.67.tgz#ee95b980fd165d98dc984210980d86dd2bf27298"
+  integrity sha512-RAHMNOzy5fCdF5MnbrMEtTahyGNUSz3Fc+0+buNfN8LiLL6lvPyztQ97spGzOjJIeruSfNU0PBuJ4azrnpRgxQ==
 
-"@onekeyfe/cross-inpage-provider-types@^0.0.17":
-  version "0.0.17"
-  resolved "https://registry.yarnpkg.com/@onekeyfe/cross-inpage-provider-types/-/cross-inpage-provider-types-0.0.17.tgz#0c88c1a2febac44ec1600e0e59da732579cbd045"
-  integrity sha512-QqjIPXQHb3UG9w79ujjL5L5Qd6oCrymQ/x2J2rYICtr56G6shHTmUvRZxAvne0ZsLv8UBGqZWbepVdnPipehYQ==
+"@onekeyfe/cross-inpage-provider-types@2.2.67":
+  version "2.2.67"
+  resolved "https://registry.npmjs.org/@onekeyfe/cross-inpage-provider-types/-/cross-inpage-provider-types-2.2.67.tgz#e36a59855a1d781f296d7563a93cac868ae46098"
+  integrity sha512-sjTF8kpcxWrZtFfHtdQhJ6KneyLTmg+Z4rnn0acEK5Vwoy07EjmF9xjBTyMoInrNwPc7OIwkaiXX+JYr0ovNgw==
 
 "@onekeyfe/react-native-ble-utils@^0.1.3":
   version "0.1.3"
@@ -14272,9 +14273,9 @@ fast-loops@^1.1.3:
   resolved "https://registry.yarnpkg.com/fast-loops/-/fast-loops-1.1.3.tgz#ce96adb86d07e7bf9b4822ab9c6fac9964981f75"
   integrity sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g==
 
-fast-safe-stringify@^2.1.1:
+fast-safe-stringify@^2.0.6:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
+  resolved "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
 fast-xml-parser@4.5.4, fast-xml-parser@^4.0.12, fast-xml-parser@^4.2.4:
@@ -18119,6 +18120,11 @@ locate-path@^7.1.0:
   integrity sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==
   dependencies:
     p-locate "^6.0.0"
+
+lodash-es@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Summary
- Upgrade `@onekeyfe/cross-inpage-provider-core` from `^0.0.17` to `^2.2.67` in `@onekeyfe/hd-web-sdk`
- All used APIs (`JsBridgeIframe`, `setPostMessageListenerFlag`, `IJsBridgeIframeConfig`) remain compatible — no code changes needed

## Test plan
- [ ] Verify `yarn install` succeeds
- [ ] Verify hd-web-sdk builds without errors
- [ ] Test iframe bridge communication works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)