### PR TITLE
chore: bump version to 1.1.26-alpha.2

### DIFF
--- a/packages/connect-examples/developer-portal/package.json
+++ b/packages/connect-examples/developer-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/developer-portal",
-  "version": "1.1.26-alpha.1",
+  "version": "1.1.26-alpha.2",
   "private": true,
   "scripts": {
     "dev": "next",

--- a/packages/connect-examples/electron-example/package.json
+++ b/packages/connect-examples/electron-example/package.json
@@ -2,7 +2,7 @@
   "name": "hardware-example",
   "productName": "HardwareExample",
   "executableName": "onekey-hardware-example",
-  "version": "1.1.26-alpha.1",
+  "version": "1.1.26-alpha.2",
   "author": "OneKey",
   "description": "End-to-end encrypted workspaces for teams",
   "main": "dist/index.js",
@@ -22,7 +22,7 @@
     "ts:check": "yarn tsc --noEmit"
   },
   "dependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.26-alpha.1",
+    "@onekeyfe/hd-transport-electron": "1.1.26-alpha.2",
     "@stoprocent/noble": "2.3.16",
     "debug": "4.3.4",
     "electron-is-dev": "^3.0.1",

--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.1.26-alpha.1",
+  "version": "1.1.26-alpha.2",
   "scripts": {
     "start": "cross-env CONNECT_SRC=https://localhost:8087/ yarn expo start --dev-client",
     "android": "yarn expo run:android",
@@ -19,10 +19,10 @@
     "@noble/ed25519": "^2.1.0",
     "@noble/hashes": "^1.3.3",
     "@noble/secp256k1": "^1.7.1",
-    "@onekeyfe/hd-ble-sdk": "1.1.26-alpha.1",
-    "@onekeyfe/hd-common-connect-sdk": "1.1.26-alpha.1",
-    "@onekeyfe/hd-core": "1.1.26-alpha.1",
-    "@onekeyfe/hd-web-sdk": "1.1.26-alpha.1",
+    "@onekeyfe/hd-ble-sdk": "1.1.26-alpha.2",
+    "@onekeyfe/hd-common-connect-sdk": "1.1.26-alpha.2",
+    "@onekeyfe/hd-core": "1.1.26-alpha.2",
+    "@onekeyfe/hd-web-sdk": "1.1.26-alpha.2",
     "@onekeyfe/react-native-ble-utils": "^0.1.3",
     "@polkadot/util-crypto": "13.1.1",
     "@react-native-async-storage/async-storage": "1.21.0",

--- a/packages/connect-examples/expo-playground/package.json
+++ b/packages/connect-examples/expo-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onekey-hardware-playground",
-  "version": "1.1.26-alpha.1",
+  "version": "1.1.26-alpha.2",
   "private": true,
   "sideEffects": [
     "app/utils/shim.js",
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0",
-    "@onekeyfe/hd-common-connect-sdk": "1.1.26-alpha.1",
-    "@onekeyfe/hd-core": "1.1.26-alpha.1",
-    "@onekeyfe/hd-shared": "1.1.26-alpha.1",
+    "@onekeyfe/hd-common-connect-sdk": "1.1.26-alpha.2",
+    "@onekeyfe/hd-core": "1.1.26-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.2",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.1.26-alpha.1",
+  "version": "1.1.26-alpha.2",
   "description": "Core processes and APIs for communicating with OneKey hardware devices.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.26-alpha.1",
-    "@onekeyfe/hd-transport": "1.1.26-alpha.1",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.2",
+    "@onekeyfe/hd-transport": "1.1.26-alpha.2",
     "axios": "1.15.0",
     "bignumber.js": "^9.0.2",
     "bytebuffer": "^5.0.1",

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.1.26-alpha.1",
+  "version": "1.1.26-alpha.2",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.26-alpha.1",
-    "@onekeyfe/hd-shared": "1.1.26-alpha.1",
-    "@onekeyfe/hd-transport-react-native": "1.1.26-alpha.1"
+    "@onekeyfe/hd-core": "1.1.26-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.2",
+    "@onekeyfe/hd-transport-react-native": "1.1.26-alpha.2"
   }
 }

--- a/packages/hd-cli/package.json
+++ b/packages/hd-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hardware-cli",
-  "version": "1.1.26-alpha.1",
+  "version": "1.1.26-alpha.2",
   "description": "OneKey hardware wallet CLI for testing device communication",
   "author": "OneKey",
   "license": "Apache-2.0",
@@ -29,10 +29,10 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-common-connect-sdk": "1.1.26-alpha.1",
-    "@onekeyfe/hd-core": "1.1.26-alpha.1",
-    "@onekeyfe/hd-shared": "1.1.26-alpha.1",
-    "@onekeyfe/hd-transport-usb": "1.1.26-alpha.1",
+    "@onekeyfe/hd-common-connect-sdk": "1.1.26-alpha.2",
+    "@onekeyfe/hd-core": "1.1.26-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.2",
+    "@onekeyfe/hd-transport-usb": "1.1.26-alpha.2",
     "commander": "^12.0.0"
   }
 }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.1.26-alpha.1",
+  "version": "1.1.26-alpha.2",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,12 +20,12 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.26-alpha.1",
-    "@onekeyfe/hd-shared": "1.1.26-alpha.1",
-    "@onekeyfe/hd-transport-emulator": "1.1.26-alpha.1",
-    "@onekeyfe/hd-transport-http": "1.1.26-alpha.1",
-    "@onekeyfe/hd-transport-lowlevel": "1.1.26-alpha.1",
-    "@onekeyfe/hd-transport-usb": "1.1.26-alpha.1",
-    "@onekeyfe/hd-transport-web-device": "1.1.26-alpha.1"
+    "@onekeyfe/hd-core": "1.1.26-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.2",
+    "@onekeyfe/hd-transport-emulator": "1.1.26-alpha.2",
+    "@onekeyfe/hd-transport-http": "1.1.26-alpha.2",
+    "@onekeyfe/hd-transport-lowlevel": "1.1.26-alpha.2",
+    "@onekeyfe/hd-transport-usb": "1.1.26-alpha.2",
+    "@onekeyfe/hd-transport-web-device": "1.1.26-alpha.2"
   }
 }

--- a/packages/hd-transport-electron/package.json
+++ b/packages/hd-transport-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-electron",
-  "version": "1.1.26-alpha.1",
+  "version": "1.1.26-alpha.2",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -25,9 +25,9 @@
     "electron-log": ">=4.0.0"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.26-alpha.1",
-    "@onekeyfe/hd-shared": "1.1.26-alpha.1",
-    "@onekeyfe/hd-transport": "1.1.26-alpha.1",
+    "@onekeyfe/hd-core": "1.1.26-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.2",
+    "@onekeyfe/hd-transport": "1.1.26-alpha.2",
     "@stoprocent/noble": "2.3.16",
     "p-retry": "^4.6.2"
   },

--- a/packages/hd-transport-emulator/package.json
+++ b/packages/hd-transport-emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-emulator",
-  "version": "1.1.26-alpha.1",
+  "version": "1.1.26-alpha.2",
   "description": "hardware emulator transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.26-alpha.1",
-    "@onekeyfe/hd-transport": "1.1.26-alpha.1",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.2",
+    "@onekeyfe/hd-transport": "1.1.26-alpha.2",
     "axios": "1.15.0",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.1.26-alpha.1",
+  "version": "1.1.26-alpha.2",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.26-alpha.1",
-    "@onekeyfe/hd-transport": "1.1.26-alpha.1",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.2",
+    "@onekeyfe/hd-transport": "1.1.26-alpha.2",
     "axios": "1.15.0",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.1.26-alpha.1",
+  "version": "1.1.26-alpha.2",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.26-alpha.1",
-    "@onekeyfe/hd-transport": "1.1.26-alpha.1"
+    "@onekeyfe/hd-shared": "1.1.26-alpha.2",
+    "@onekeyfe/hd-transport": "1.1.26-alpha.2"
   }
 }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.1.26-alpha.1",
+  "version": "1.1.26-alpha.2",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,9 +19,9 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.26-alpha.1",
-    "@onekeyfe/hd-shared": "1.1.26-alpha.1",
-    "@onekeyfe/hd-transport": "1.1.26-alpha.1",
+    "@onekeyfe/hd-core": "1.1.26-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.2",
+    "@onekeyfe/hd-transport": "1.1.26-alpha.2",
     "@onekeyfe/react-native-ble-utils": "^0.1.4",
     "react-native-ble-plx": "3.5.1"
   }

--- a/packages/hd-transport-usb/package.json
+++ b/packages/hd-transport-usb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-usb",
-  "version": "1.1.26-alpha.1",
+  "version": "1.1.26-alpha.2",
   "description": "OneKey hardware wallet direct USB transport plugin (libusb)",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.26-alpha.1",
-    "@onekeyfe/hd-transport": "1.1.26-alpha.1",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.2",
+    "@onekeyfe/hd-transport": "1.1.26-alpha.2",
     "bytebuffer": "^5.0.1",
     "usb": "^2.14.0"
   }

--- a/packages/hd-transport-web-device/package.json
+++ b/packages/hd-transport-web-device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-web-device",
-  "version": "1.1.26-alpha.1",
+  "version": "1.1.26-alpha.2",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.26-alpha.1",
-    "@onekeyfe/hd-transport": "1.1.26-alpha.1"
+    "@onekeyfe/hd-shared": "1.1.26-alpha.2",
+    "@onekeyfe/hd-transport": "1.1.26-alpha.2"
   },
   "devDependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.26-alpha.1",
+    "@onekeyfe/hd-transport-electron": "1.1.26-alpha.2",
     "@types/w3c-web-usb": "^1.0.6",
     "@types/web-bluetooth": "^0.0.17"
   }

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.1.26-alpha.1",
+  "version": "1.1.26-alpha.2",
   "description": "Transport layer abstractions and utilities for OneKey hardware SDK.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.1.26-alpha.1",
+  "version": "1.1.26-alpha.2",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "2.2.67",
-    "@onekeyfe/hd-core": "1.1.26-alpha.1",
-    "@onekeyfe/hd-shared": "1.1.26-alpha.1",
-    "@onekeyfe/hd-transport-http": "1.1.26-alpha.1",
-    "@onekeyfe/hd-transport-web-device": "1.1.26-alpha.1"
+    "@onekeyfe/hd-core": "1.1.26-alpha.2",
+    "@onekeyfe/hd-shared": "1.1.26-alpha.2",
+    "@onekeyfe/hd-transport-http": "1.1.26-alpha.2",
+    "@onekeyfe/hd-transport-web-device": "1.1.26-alpha.2"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.1.26-alpha.1",
+  "version": "1.1.26-alpha.2",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11337,6 +11337,11 @@ commander@^10.0.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
 
+commander@^12.0.0, commander@~12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
+  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
+
 commander@^13.0.0:
   version "13.1.0"
   resolved "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz#776167db68c78f38dcce1f9b8d7b8b9a488abf46"
@@ -11371,11 +11376,6 @@ commander@^9.4.1:
   version "9.5.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
   integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
-
-commander@~12.1.0:
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
-  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
 
 common-path-prefix@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Summary
- Bumps all 14 published packages and the connect-examples apps from \`1.1.26-alpha.1\` to \`1.1.26-alpha.2\`.
- \`check-versions.js\` passes: all 14 packages aligned at \`1.1.26-alpha.2\`.

## Why
The previous \`yarn publish:alpha\` run failed (\`lerna ERR! EUNCOMMIT\` on an unrelated \`yarn.lock\` change), but before it errored, \`alpha.1\` had already been reserved / partially tagged. Rather than retry \`alpha.1\` and risk registry conflicts, we roll forward to \`alpha.2\` for the next publish attempt.

## Test plan
- [x] \`node scripts/check-versions.js\` → All 14 packages at \`1.1.26-alpha.2\`
- [ ] Ensure \`yarn.lock\` is clean in the publishing workspace, then run \`yarn publish:alpha\` (or the team's usual publish command)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/hardware-js-sdk/pull/766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
