### PR TITLE
fix(hd-cli): decode pinentry Assuan percent-encoding for passphrase

### DIFF
--- a/packages/hd-cli/package.json
+++ b/packages/hd-cli/package.json
@@ -26,7 +26,8 @@
     "get-address": "node dist/cli.js get-address",
     "ping": "node dist/cli.js ping",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "test": "jest"
   },
   "dependencies": {
     "@onekeyfe/hd-common-connect-sdk": "1.1.26-alpha.2",

--- a/packages/hd-cli/src/__tests__/pinentry.test.ts
+++ b/packages/hd-cli/src/__tests__/pinentry.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Unit tests for pinentry stdout parsing.
+ *
+ * These tests exercise the pure Assuan-protocol parser — no hardware,
+ * no child process, no keychain. They catch the class of bugs that
+ * silently corrupt a user's passphrase (e.g. losing `%` characters,
+ * mis-splitting multi-line responses, trailing CR from CRLF shells).
+ *
+ * Mirrors app-monorepo/apps/cli/src/__tests__/pinentry.test.ts so both
+ * CLIs stay aligned on the same decoding semantics.
+ */
+
+import { decodeAssuanData, parsePinentryStdout } from '../pinentry';
+
+describe('decodeAssuanData', () => {
+  it('passes plain ASCII through unchanged', () => {
+    expect(decodeAssuanData('hello-world')).toBe('hello-world');
+  });
+
+  it('decodes a literal percent (%25 -> %)', () => {
+    // pinentry sends `D a%25b%25c` for the user input `a%b%c`
+    expect(decodeAssuanData('a%25b%25c')).toBe('a%b%c');
+  });
+
+  it('decodes CR (%0D) and LF (%0A)', () => {
+    expect(decodeAssuanData('line1%0Dline2%0Aline3')).toBe(
+      'line1\rline2\nline3'
+    );
+  });
+
+  it('handles trailing percent encoding', () => {
+    expect(decodeAssuanData('end%25')).toBe('end%');
+  });
+
+  it('handles uppercase and lowercase hex', () => {
+    expect(decodeAssuanData('%2a%2A')).toBe('**');
+  });
+
+  it('leaves a bare % (not followed by 2 hex chars) untouched', () => {
+    // pinentry never produces this, but the decoder must not corrupt it.
+    expect(decodeAssuanData('100%')).toBe('100%');
+    expect(decodeAssuanData('%2')).toBe('%2');
+    expect(decodeAssuanData('%zz')).toBe('%zz');
+  });
+
+  it('leaves an empty string alone', () => {
+    expect(decodeAssuanData('')).toBe('');
+  });
+
+  // Assuan only percent-encodes %, CR, and LF. Every other byte — including
+  // multi-byte UTF-8 sequences, extended ASCII, spaces, symbols — goes over
+  // the D line untouched. These tests mirror the real passphrases exercised
+  // by expo-example/TestSpecialPassphraseWallet, so a decoder change that
+  // accidentally mangles non-ASCII input fails here instead of only in a
+  // hardware-required integration run.
+  it('passes UTF-8 multi-byte scripts through unchanged', () => {
+    expect(decodeAssuanData('你好passphrase')).toBe('你好passphrase');
+    expect(decodeAssuanData('私のパスワード')).toBe('私のパスワード');
+    expect(decodeAssuanData('myسياسةpassphrase')).toBe('myسياسةpassphrase');
+  });
+
+  it('passes extended ASCII and accented chars unchanged', () => {
+    expect(decodeAssuanData('¥Øÿ')).toBe('¥Øÿ');
+    expect(decodeAssuanData('P@sswôrd€')).toBe('P@sswôrd€');
+    expect(decodeAssuanData('mi política de frase de contraseña')).toBe(
+      'mi política de frase de contraseña'
+    );
+  });
+
+  it('preserves leading and trailing spaces', () => {
+    // Regression guard: a .trim() added "defensively" anywhere in the pipe
+    // would derive the wrong passphraseState for Wallet-4 and silently
+    // unlock a different hidden wallet. expo-example Wallet-4 exercises
+    // exactly this passphrase.
+    expect(decodeAssuanData(' My Passphrase ')).toBe(' My Passphrase ');
+  });
+
+  it('passes a multi-script mixed passphrase through unchanged', () => {
+    // Matches expo-example Wallet-1 — the "everything all at once" case.
+    const mixed = 'Aa0!)_+맪Ӎ¬}¨¥ϸΔѭЧゞく6鼵';
+    expect(decodeAssuanData(mixed)).toBe(mixed);
+  });
+});
+
+describe('parsePinentryStdout', () => {
+  it('parses a real pinentry-mac success response', () => {
+    const stdout =
+      'OK Pleased to meet you, process 38946\nOK\nOK\nD a%25b%25c\nOK\n';
+    expect(parsePinentryStdout(stdout)).toEqual({
+      data: 'a%b%c',
+      cancelled: false,
+    });
+  });
+
+  it('returns no data and cancelled=false when user clicks OK on empty', () => {
+    // Pinentry omits the D line entirely when the input is empty.
+    const stdout = 'OK Pleased to meet you\nOK\nOK\nOK\n';
+    expect(parsePinentryStdout(stdout)).toEqual({ cancelled: false });
+  });
+
+  it('flags cancellation via ERR 83886179', () => {
+    const stdout =
+      'OK Pleased to meet you\nOK\nOK\nERR 83886179 Operation cancelled\n';
+    expect(parsePinentryStdout(stdout)).toEqual({ cancelled: true });
+  });
+
+  it('concatenates multi-line D responses before decoding', () => {
+    // User typed `first-half-with-%-end` (literal `%`). Pinentry encoded
+    // `%` as `%25` and the line-length limit happened to split right inside
+    // that triple — `%2` ends line 1, `5` starts line 2. We must concat
+    // raw chunks *first*, then decode — otherwise `%2` alone is not a
+    // valid `%XX` triple and the `%` would be permanently lost.
+    const stdout = ['OK', 'D first-half-with-%2', 'D 5-end', 'OK'].join('\n');
+    expect(parsePinentryStdout(stdout)).toEqual({
+      data: 'first-half-with-%-end',
+      cancelled: false,
+    });
+  });
+
+  it('also concatenates D chunks that do not split inside %XX', () => {
+    const stdout = ['OK', 'D part-one-', 'D part-two', 'OK'].join('\n');
+    expect(parsePinentryStdout(stdout)).toEqual({
+      data: 'part-one-part-two',
+      cancelled: false,
+    });
+  });
+
+  it('handles CRLF line endings (pinentry-gnome3/qt)', () => {
+    const stdout = 'OK Pleased\r\nOK\r\nOK\r\nD secret%25here\r\nOK\r\n';
+    expect(parsePinentryStdout(stdout)).toEqual({
+      data: 'secret%here',
+      cancelled: false,
+    });
+  });
+
+  it('decodes CR/LF inside the passphrase (theoretical)', () => {
+    const stdout = 'OK\nD line1%0Dline2%0Aline3\nOK\n';
+    expect(parsePinentryStdout(stdout)).toEqual({
+      data: 'line1\rline2\nline3',
+      cancelled: false,
+    });
+  });
+
+  it('flags cancellation via "Operation cancelled" message', () => {
+    // Some pinentry variants surface cancellation without the canonical
+    // error code — just the human-readable string.
+    const stdout = 'OK\nOK\nERR Operation cancelled\n';
+    expect(parsePinentryStdout(stdout)).toEqual({ cancelled: true });
+  });
+
+  it('handles empty stdout without throwing', () => {
+    expect(parsePinentryStdout('')).toEqual({ cancelled: false });
+  });
+
+  // End-to-end sanity over a full stdout frame carrying the real-world
+  // passphrases exercised by expo-example. Guards the `D ` prefix strip
+  // (`.slice(2)`) against any future refactor that would drop a byte from
+  // the leading space (e.g. switching to `.slice(1).trimStart()`).
+  it('parses a stdout frame carrying a UTF-8 passphrase', () => {
+    const stdout = 'OK Pleased to meet you\nOK\nOK\nD 你好passphrase\nOK\n';
+    expect(parsePinentryStdout(stdout)).toEqual({
+      data: '你好passphrase',
+      cancelled: false,
+    });
+  });
+
+  it('parses a stdout frame with surrounding spaces in the passphrase', () => {
+    const stdout = 'OK\nOK\nOK\nD  My Passphrase \nOK\n';
+    expect(parsePinentryStdout(stdout)).toEqual({
+      data: ' My Passphrase ',
+      cancelled: false,
+    });
+  });
+
+  it('parses a stdout frame with a mixed-script passphrase', () => {
+    // expo-example Wallet-1 — guards that neither split nor slice corrupts
+    // surrogate pairs (e.g. `鼵` U+9E35 fits in a single UTF-16 unit, but
+    // `맪` U+B9AA also does; kept together here as a smoke test).
+    const stdout = 'OK\nD Aa0!)_+맪Ӎ¬}¨¥ϸΔѭЧゞく6鼵\nOK\n';
+    expect(parsePinentryStdout(stdout)).toEqual({
+      data: 'Aa0!)_+맪Ӎ¬}¨¥ϸΔѭЧゞく6鼵',
+      cancelled: false,
+    });
+  });
+});

--- a/packages/hd-cli/src/pinentry.ts
+++ b/packages/hd-cli/src/pinentry.ts
@@ -1,0 +1,146 @@
+/**
+ * Secure passphrase input via the system pinentry program
+ * (pinentry-mac / pinentry / pinentry-gnome3 / pinentry-qt).
+ *
+ * The passphrase is entered in an OS dialog and returned as a string —
+ * it never appears in the terminal, shell history, process arguments,
+ * or env vars. Commands are piped over stdin so the dialog configuration
+ * (description, prompt) doesn't show up in argv either.
+ *
+ * Ported from app-monorepo apps/cli/src/utils/pinentry.ts; kept as a
+ * standalone module so the pure parser functions can be unit-tested
+ * without touching the SDK, child processes, or hardware.
+ */
+
+import { execFile, execFileSync } from 'node:child_process';
+
+const PINENTRY_PROGRAMS = [
+  'pinentry-mac',
+  'pinentry',
+  'pinentry-gnome3',
+  'pinentry-qt',
+];
+
+// Assuan protocol percent-encodes %, CR, and LF in D data lines.
+// Without decoding, a passphrase containing `%` would be silently corrupted
+// (e.g. `a%b` -> `a%25b`), deriving a wrong passphraseState and exposing a
+// different — empty — hidden wallet.
+export function decodeAssuanData(encoded: string): string {
+  return encoded.replace(/%([0-9A-Fa-f]{2})/g, (_, hex: string) =>
+    String.fromCharCode(parseInt(hex, 16))
+  );
+}
+
+// Parse pinentry stdout into either a passphrase or a cancellation signal.
+// Handles two edge cases beyond the basic `D <data>` shape:
+//   1. Multi-line D responses — long passphrases past Assuan's ~1000-byte
+//      line limit get split across several `D` lines and must be concatenated
+//      *before* percent-decoding (a split inside `%XX` would otherwise corrupt
+//      the byte).
+//   2. CRLF line endings — pinentry-mac uses LF, but pinentry-gnome3/qt may
+//      emit CRLF; splitting on `\r?\n` strips the trailing CR that would
+//      otherwise become a literal trailing byte in the passphrase.
+export function parsePinentryStdout(stdout: string): {
+  data?: string;
+  cancelled: boolean;
+} {
+  // Pinentry error code 83886179 is the canonical "user cancelled" signal —
+  // surfaces either as a non-zero exit or as an ERR line.
+  const cancelled =
+    stdout.includes('ERR 83886179') || stdout.includes('Operation cancelled');
+
+  const dataChunks = stdout
+    .split(/\r?\n/)
+    .filter(l => l.startsWith('D '))
+    .map(l => l.slice(2));
+
+  if (dataChunks.length > 0) {
+    return { data: decodeAssuanData(dataChunks.join('')), cancelled };
+  }
+  return { cancelled };
+}
+
+export function findPinentry(): string | null {
+  for (const prog of PINENTRY_PROGRAMS) {
+    try {
+      const result = execFileSync('which', [prog], {
+        encoding: 'utf-8',
+        timeout: 2000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      if (result.trim()) return prog;
+    } catch {
+      // Program not found — try the next one.
+    }
+  }
+  return null;
+}
+
+export interface PinentryResult {
+  value: string;
+  passphraseOnDevice: boolean;
+}
+
+// CLI-variant policy differs from app-monorepo: we fall back to on-device
+// entry instead of rejecting, because `onekey-hw` is used by AI agents that
+// can't recover from a thrown error mid-flow. The device screen is always
+// a valid second path.
+export function promptPassphraseViaPinentry(): Promise<PinentryResult> {
+  return new Promise((resolve, reject) => {
+    const pinentryBin = findPinentry();
+    if (!pinentryBin) {
+      process.stderr.write(
+        '[onekey-hw] No pinentry found, falling back to on-device entry.\n'
+      );
+      resolve({ value: '', passphraseOnDevice: true });
+      return;
+    }
+
+    const commands = [
+      'SETDESC OneKey Hardware Wallet',
+      'SETPROMPT Enter passphrase',
+      'GETPIN',
+      'BYE',
+    ].join('\n');
+
+    const child = execFile(
+      pinentryBin,
+      [],
+      { timeout: 120_000, encoding: 'utf-8' },
+      (error, stdout) => {
+        const { data, cancelled } = parsePinentryStdout(stdout ?? '');
+
+        if (error) {
+          if (error.killed || cancelled) {
+            process.stderr.write(
+              '[onekey-hw] Passphrase entry cancelled, falling back to on-device.\n'
+            );
+            resolve({ value: '', passphraseOnDevice: true });
+            return;
+          }
+          reject(error);
+          return;
+        }
+
+        if (data !== undefined) {
+          resolve({ value: data, passphraseOnDevice: false });
+          return;
+        }
+
+        if (cancelled) {
+          process.stderr.write(
+            '[onekey-hw] Passphrase entry cancelled, falling back to on-device.\n'
+          );
+          resolve({ value: '', passphraseOnDevice: true });
+          return;
+        }
+
+        // Empty passphrase (OK pressed with no input) — on-device fallback.
+        resolve({ value: '', passphraseOnDevice: true });
+      }
+    );
+
+    child.stdin?.write(commands);
+    child.stdin?.end();
+  });
+}

--- a/packages/hd-cli/src/sdk.ts
+++ b/packages/hd-cli/src/sdk.ts
@@ -9,12 +9,14 @@
  *     preloaded via preloadSessionCache on next invocation
  */
 
-import { execFile, execFileSync } from 'node:child_process';
 import * as readline from 'node:readline';
 import HardwareSDK from '@onekeyfe/hd-common-connect-sdk';
 import { DEVICE, UI_EVENT, UI_REQUEST, UI_RESPONSE } from '@onekeyfe/hd-core';
 
+import { promptPassphraseViaPinentry } from './pinentry';
+
 import type { ConnectSettings } from '@onekeyfe/hd-core';
+import type { PinentryResult } from './pinentry';
 
 export interface SDKOptions {
   connectId?: string;
@@ -45,88 +47,6 @@ let currentOpts: SDKOptions = {};
 let sdkReadyPromise: Promise<typeof HardwareSDK> | null = null;
 
 // ---------------------------------------------------------------------------
-// Pinentry — secure passphrase input via native OS dialog
-// ---------------------------------------------------------------------------
-
-const PINENTRY_PROGRAMS = ['pinentry-mac', 'pinentry', 'pinentry-gnome3', 'pinentry-qt'];
-
-function findPinentry(): string | null {
-  for (const prog of PINENTRY_PROGRAMS) {
-    try {
-      const result = execFileSync('which', [prog], {
-        encoding: 'utf-8',
-        timeout: 2000,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
-      if (result.trim()) return prog;
-    } catch {
-      // not found
-    }
-  }
-  return null;
-}
-
-function promptPassphraseViaPinentry(): Promise<{
-  value: string;
-  passphraseOnDevice: boolean;
-}> {
-  return new Promise((resolve, reject) => {
-    const pinentryBin = findPinentry();
-    if (!pinentryBin) {
-      process.stderr.write('[onekey-hw] No pinentry found, falling back to on-device entry.\n');
-      resolve({ value: '', passphraseOnDevice: true });
-      return;
-    }
-
-    const commands = [
-      'SETDESC OneKey Hardware Wallet',
-      'SETPROMPT Enter passphrase',
-      'GETPIN',
-      'BYE',
-    ].join('\n');
-
-    const child = execFile(
-      pinentryBin,
-      [],
-      { timeout: 120_000, encoding: 'utf-8' },
-      (error, stdout) => {
-        if (error) {
-          if (error.killed || (stdout && stdout.includes('ERR 83886179'))) {
-            process.stderr.write(
-              '[onekey-hw] Passphrase entry cancelled, falling back to on-device.\n'
-            );
-            resolve({ value: '', passphraseOnDevice: true });
-            return;
-          }
-          reject(error);
-          return;
-        }
-
-        const dataLine = stdout.split('\n').find(l => l.startsWith('D '));
-        if (dataLine) {
-          resolve({ value: dataLine.slice(2), passphraseOnDevice: false });
-          return;
-        }
-
-        if (stdout.includes('ERR 83886179') || stdout.includes('Operation cancelled')) {
-          process.stderr.write(
-            '[onekey-hw] Passphrase entry cancelled, falling back to on-device.\n'
-          );
-          resolve({ value: '', passphraseOnDevice: true });
-          return;
-        }
-
-        // Empty passphrase — on-device
-        resolve({ value: '', passphraseOnDevice: true });
-      }
-    );
-
-    child.stdin?.write(commands);
-    child.stdin?.end();
-  });
-}
-
-// ---------------------------------------------------------------------------
 // Interactive prompts
 // ---------------------------------------------------------------------------
 
@@ -138,16 +58,13 @@ function promptPassphraseViaPinentry(): Promise<{
  */
 function resolvePassphraseByChoice(
   choice: '1' | '2' | '3'
-): Promise<{ value: string; passphraseOnDevice: boolean }> {
+): Promise<PinentryResult> {
   if (choice === '1') return Promise.resolve({ value: '', passphraseOnDevice: false });
   if (choice === '2') return promptPassphraseViaPinentry();
   return Promise.resolve({ value: '', passphraseOnDevice: true });
 }
 
-function promptPassphraseMode(): Promise<{
-  value: string;
-  passphraseOnDevice: boolean;
-}> {
+function promptPassphraseMode(): Promise<PinentryResult> {
   if (!process.stdin.isTTY) {
     return Promise.resolve({ value: '', passphraseOnDevice: true });
   }

--- a/packages/hd-cli/tsconfig.json
+++ b/packages/hd-cli/tsconfig.json
@@ -12,5 +12,5 @@
     "declaration": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/__tests__/**", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

Fix a silent hidden-wallet divergence: pinentry D-line data is percent-encoded per the Assuan protocol (`%` → `%25`, CR → `%0D`, LF → `%0A`). The previous `onekey-hw` code in `packages/hd-cli/src/sdk.ts` passed `dataLine.slice(2)` through verbatim, so any passphrase containing `%` derived a wrong `passphraseState` and unlocked a different — empty — hidden wallet.

- Extract pinentry into `packages/hd-cli/src/pinentry.ts` (pure parser + child-process wrapper) so the decoder can be unit-tested without spawning pinentry or connecting to hardware.
- Handle two adjacent edge cases with the same failure mode:
  - Multi-line `D` responses (long passphrases past the ~1000-byte Assuan line limit) must be concatenated **before** percent-decoding; a split inside `%XX` would otherwise drop a byte.
  - pinentry-gnome3/qt may emit CRLF; `\r?\n` keeps the trailing CR out of the passphrase bytes.
- Add **23 unit tests** — 14 ported from app-monorepo plus 9 new cases that exercise all the fixtures used by `expo-example/TestSpecialPassphraseWallet` (UTF-8 scripts, extended ASCII, accented Latin, leading/trailing spaces, multi-script mix). Guards the decoder against future regressions on real passphrases that the hardware integration suite depends on.

Mirrors the equivalent fix in app-monorepo [PR #11135](https://github.com/OneKeyHQ/app-monorepo/pull/11135) (commit `9f326504c2`). Both CLIs now share the same Assuan-decoding semantics.

## Test plan

- [x] `yarn test` in `packages/hd-cli` → **23/23 passing** (0.6s; no hardware / child-process / keychain involvement)
- [x] `npx tsc --noEmit` → clean
- [x] `yarn build` in `packages/hd-cli` → dist built, `__tests__/` excluded from publish output
- [ ] Manual smoke on a real device: `onekey-hw get-address --chain evm` with a passphrase containing `%`, verify the derived address matches the expected hidden-wallet address
- [ ] Run `expo-example` passphrase tests on real hardware to confirm no regression on the non-pinentry event path

## Coverage matrix

| expo-example passphrase sample | Unit-test guard |
| --- | --- |
| Plain ASCII (`Wallet-9`, session-count) | ✅ |
| Contains `%` (previously broken) | ✅ `%25` / `%XX` split across lines |
| Contains `\r` / `\n` (theoretical) | ✅ `%0D` / `%0A` |
| UTF-8 scripts (`Wallet-5/6/7`) | ✅ new |
| Extended ASCII / accents (`Wallet-2/3/8`) | ✅ new |
| Leading/trailing spaces (`Wallet-4`) | ✅ new (regression guard against `.trim()`) |
| Multi-script mix (`Wallet-1`) | ✅ new |
| pinentry-gnome3/qt CRLF | ✅ |
| User cancelled (`ERR 83886179` / `Operation cancelled`) | ✅ |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/hardware-js-sdk/pull/770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
