### PR TITLE
[codex] fix developer portal sources endpoint

### DIFF
--- a/packages/connect-examples/developer-portal/components/DocAIChatWidget.client.jsx
+++ b/packages/connect-examples/developer-portal/components/DocAIChatWidget.client.jsx
@@ -24,7 +24,7 @@ import styles from './DocAIChatWidget.module.css';
  * Priority:
  *   1. NEXT_PUBLIC_DOCS_AI_API_URL env var — explicit override (local dev, staging)
  *   2. Hostname-based mapping:
- *        *.onekey.so       →  https://rag.onekey.so/api/chat
+ *        *.onekey.so       →  https://rag.onekeycn.com/api/chat
  *        anything else     →  https://rag.onekeytest.com/api/chat
  *
  * Local dev example — add to developer-portal/.env.local:
@@ -40,7 +40,7 @@ const resolveApiUrl = () => {
 
   // Production: use the matching RAG service for the deployment domain
   if (hostname === 'onekey.so' || hostname.endsWith('.onekey.so')) {
-    return 'https://rag.onekey.so/api/chat';
+    return 'https://rag.onekeycn.com/api/chat';
   }
 
   // Test env, localhost, and all other origins → test RAG service

--- a/packages/connect-examples/developer-portal/components/LandingPage.jsx
+++ b/packages/connect-examples/developer-portal/components/LandingPage.jsx
@@ -11,7 +11,7 @@ import {
   ArrowUpRight,
   ChevronDown,
   X,
-  Bot,
+  // Bot,
 } from 'lucide-react'
 
 const heroSecurity05 = '/landing-page/security-05.png'
@@ -139,6 +139,7 @@ export function LandingPage({ locale = 'en' }) {
       href: `/${locale}/hardware-sdk/transport/native-ble`,
       cta: copy.viewDocs,
     },
+    /*
     {
       title: isZh ? 'OneKey Agent Wallet' : 'OneKey Agent Wallet',
       description: isZh
@@ -148,6 +149,7 @@ export function LandingPage({ locale = 'en' }) {
       href: `/${locale}/agent-wallet`,
       cta: copy.viewDocs,
     },
+    */
   ]
 
   const dappCards = [

--- a/packages/connect-examples/developer-portal/content/en/_meta.js
+++ b/packages/connect-examples/developer-portal/content/en/_meta.js
@@ -13,6 +13,7 @@ export default {
       copyPage: false,
     },
   },
+  /*
   'agent-wallet': {
     title: 'Agent Wallet',
     type: 'menu',
@@ -44,6 +45,7 @@ export default {
       safety: { title: 'Safety Rules', href: '/en/agent-wallet/safety' },
     },
   },
+  */
   // Navigation menus with dropdown items
   'hardware-sdk': {
     title: 'Hardware Integration',

--- a/packages/connect-examples/developer-portal/content/en/hardware-sdk/index.mdx
+++ b/packages/connect-examples/developer-portal/content/en/hardware-sdk/index.mdx
@@ -163,7 +163,7 @@ import { DeviceCompatibilityTable } from '../../../components/DeviceCompatibilit
 
 - Low-level transport & message protocol (for debugging or custom adapters): [Low-Level Transport Plugin](/en/hardware-sdk/concepts/low-level-plugin)
 - Migration from the legacy `hd-web-sdk` flow: [Migration Guide](/en/hardware-sdk/legacy-guides)
-- AI agent integration via OneKey skills: [AI Agent Integration](/en/hardware-sdk/agent-integration)
+<!-- - AI agent integration via OneKey skills: [AI Agent Integration](/en/hardware-sdk/agent-integration) -->
 
 ## Support
 

--- a/packages/connect-examples/developer-portal/content/zh/_meta.js
+++ b/packages/connect-examples/developer-portal/content/zh/_meta.js
@@ -13,6 +13,7 @@ export default {
       copyPage: false,
     },
   },
+  /*
   'agent-wallet': {
     title: 'Agent Wallet',
     type: 'menu',
@@ -44,6 +45,7 @@ export default {
       safety: { title: '安全规则', href: '/zh/agent-wallet/safety' },
     },
   },
+  */
   // 导航菜单及下拉项
   'hardware-sdk': {
     title: '硬件接入',

--- a/packages/connect-examples/developer-portal/content/zh/hardware-sdk/index.mdx
+++ b/packages/connect-examples/developer-portal/content/zh/hardware-sdk/index.mdx
@@ -163,7 +163,7 @@ import { DeviceCompatibilityTable } from '../../../components/DeviceCompatibilit
 
 - 底层传输与消息协议（调试 / 自定义适配器场景）：[底层传输插件](/zh/hardware-sdk/concepts/low-level-plugin)
 - 从老的 `hd-web-sdk` 方案迁移：[迁移指引](/zh/hardware-sdk/legacy-guides)
-- AI Agent 集成 OneKey skills：[AI Agent 集成](/zh/hardware-sdk/agent-integration)
+<!-- - AI Agent 集成 OneKey skills：[AI Agent 集成](/zh/hardware-sdk/agent-integration) -->
 
 ## 支持
 


### PR DESCRIPTION
## Summary

- Point the production developer portal RAG chat endpoint at `https://rag.onekeycn.com/api/chat`, so the existing sources derivation requests `https://rag.onekeycn.com/api/sources`.
- Comment out Agent Wallet entry points instead of deleting them, preserving the original menu/card/link code for later restoration.

## Validation

- Confirmed the final `DocAIChatWidget.client.jsx` diff only changes the production RAG domain and leaves `resolveSourcesApiUrl()` behavior unchanged from `onekey`.
- Verified `https://rag.onekeycn.com/api/chat` derives `https://rag.onekeycn.com/api/sources`.
- `git diff --check origin/onekey..HEAD` passed.
- `node --check` passed for `content/en/_meta.js` and `content/zh/_meta.js`.
- Parsed `components/LandingPage.jsx` and `components/DocAIChatWidget.client.jsx` with Babel JSX parser.
- Earlier full local `yarn build` could not be completed because dependency install stalled; a symlinked dependency reuse attempt was rejected by Next/Turbopack for pointing outside the worktree root.
