### PR TITLE
fix: run matching standalone automation SDK suites

### DIFF
--- a/packages/connect-examples/expo-example/docs/automation-test-design.md
+++ b/packages/connect-examples/expo-example/docs/automation-test-design.md
@@ -145,6 +145,10 @@ interface AutomationScenario {
   - 地址：`testTools/slip39Test/addressData`
   - 公钥：`testTools/slip39Test/pubKeyData`
 - `scenarioResolver` 通过 `slip39DatasetId + passphraseVariantId` 组装 case id，例如 `count20_one_passphrase_2`
+- `expo-example` 不直接控制多份助记词导入过程，只负责下发 `phonePilotSequenceId`
+- 多份导入的 share 切换逻辑在 `PhonePilot/electron/mcp/sequences.ts` 的 `generateSlip39ShareSteps()` 中生成
+- `2-of-3` 场景会从 PhonePilot 配置的 3 份 share 中随机选择 2 份导入；本仓库的数据集只校验达到阈值所需的 2 份结果
+- 如果出现“第一份导入完成后切换到第二份时点错”的问题，应优先检查 PhonePilot 的 share 切换步骤，而不是 `useAutomationTest.ts`
 
 ### Passphrase literal
 

--- a/packages/connect-examples/expo-example/src/atoms/automationAtoms.ts
+++ b/packages/connect-examples/expo-example/src/atoms/automationAtoms.ts
@@ -148,9 +148,7 @@ export const canStartAutomationAtom = atom(get => {
   const isConnected = get(phonePilotConnectionStateAtom) === 'connected';
   const isRunning = get(isAutomationRunningAtom);
   const config = get(automationConfigAtom);
-  const scenarioDrivenIds = config.scenarioIds.filter(
-    id => id !== STANDALONE_MODULE_SCENARIO_ID
-  );
+  const scenarioDrivenIds = config.scenarioIds.filter(id => id !== STANDALONE_MODULE_SCENARIO_ID);
   const hasStandaloneSuites = config.testSuites.some(suiteType =>
     STANDALONE_TEST_SUITES.includes(suiteType)
   );

--- a/packages/connect-examples/expo-example/src/atoms/automationAtoms.ts
+++ b/packages/connect-examples/expo-example/src/atoms/automationAtoms.ts
@@ -5,7 +5,10 @@
 import { atom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
 
-import { STANDALONE_TEST_SUITES } from '../services/phonePilotMcp/types';
+import {
+  STANDALONE_MODULE_SCENARIO_ID,
+  STANDALONE_TEST_SUITES,
+} from '../services/phonePilotMcp/types';
 
 import type {
   AutomationTestConfig,
@@ -145,11 +148,14 @@ export const canStartAutomationAtom = atom(get => {
   const isConnected = get(phonePilotConnectionStateAtom) === 'connected';
   const isRunning = get(isAutomationRunningAtom);
   const config = get(automationConfigAtom);
+  const scenarioDrivenIds = config.scenarioIds.filter(
+    id => id !== STANDALONE_MODULE_SCENARIO_ID
+  );
   const hasStandaloneSuites = config.testSuites.some(suiteType =>
     STANDALONE_TEST_SUITES.includes(suiteType)
   );
   const hasRunnableScenarioModule =
-    config.scenarioIds.length > 0 &&
+    scenarioDrivenIds.length > 0 &&
     (config.devicePreparationMode === 'deviceFlowOnly' || config.testSuites.length > 0);
   const hasRunnableStandaloneModule =
     config.devicePreparationMode !== 'deviceFlowOnly' && hasStandaloneSuites;

--- a/packages/connect-examples/expo-example/src/data/ethereum.ts
+++ b/packages/connect-examples/expo-example/src/data/ethereum.ts
@@ -485,7 +485,7 @@ const api: PlaygroundProps[] = [
               {
                 chainId: 1,
                 address: '0x4Cd241E8d1510e30b2076397afc7508Ae59C66c9',
-                nonce: '0x5',
+                nonce: '0x6',
               },
             ],
           },

--- a/packages/connect-examples/expo-example/src/services/phonePilotMcp/index.ts
+++ b/packages/connect-examples/expo-example/src/services/phonePilotMcp/index.ts
@@ -50,6 +50,8 @@ export class PhonePilotClient {
 
   private connectionState: ConnectionState = 'disconnected';
 
+  private armConnected = false;
+
   private onStateChange?: (state: ConnectionState) => void;
 
   private requestId = 0;
@@ -144,12 +146,14 @@ export class PhonePilotClient {
       if (!this.sessionId) {
         throw new Error('MCP connection succeeded but mcp-session-id header is missing');
       }
+      this.armConnected = false;
       await this.sendNotification('notifications/initialized', {});
 
       this.updateState('connected');
       return true;
     } catch (error) {
       this.sessionId = null;
+      this.armConnected = false;
       console.error('PhonePilot MCP connection failed:', error);
       this.updateState('error');
       return false;
@@ -174,7 +178,55 @@ export class PhonePilotClient {
       }
       this.sessionId = null;
     }
+    this.armConnected = false;
     this.updateState('disconnected');
+  }
+
+  private isArmDisconnectedError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return message.includes('Not connected to arm controller');
+  }
+
+  private async armConnectInternal(): Promise<ArmConnectResult> {
+    const result = await this.callTool<ArmConnectResult>('arm-connect', {});
+    if (!result.success) {
+      this.armConnected = false;
+      throw new Error(result.message || 'arm-connect failed');
+    }
+    this.armConnected = true;
+    return result;
+  }
+
+  private async ensureArmConnected(forceReconnect = false): Promise<void> {
+    if (!forceReconnect && this.armConnected) {
+      return;
+    }
+
+    await this.armConnectInternal();
+  }
+
+  private async withArmConnection<T>(operation: () => Promise<T>): Promise<T> {
+    if (this.armConnected) {
+      return operation();
+    }
+
+    try {
+      const result = await operation();
+      // Operation succeeded without an explicit arm-connect call, which means
+      // the arm session is already active on the PhonePilot side.
+      this.armConnected = true;
+      return result;
+    } catch (error) {
+      if (!this.isArmDisconnectedError(error)) {
+        throw error;
+      }
+
+      this.armConnected = false;
+      await this.ensureArmConnected(true);
+      const result = await operation();
+      this.armConnected = true;
+      return result;
+    }
   }
 
   private async sendRequest<T>(
@@ -333,27 +385,35 @@ export class PhonePilotClient {
   }
 
   async armConnect(): Promise<ArmConnectResult> {
-    return this.callTool<ArmConnectResult>('arm-connect', {});
+    return this.armConnectInternal();
   }
 
   async armDisconnect(): Promise<ArmDisconnectResult> {
-    return this.callTool<ArmDisconnectResult>('arm-disconnect', {});
+    try {
+      return await this.callTool<ArmDisconnectResult>('arm-disconnect', {});
+    } finally {
+      this.armConnected = false;
+    }
   }
 
   async armMove(x: number, y: number, captureFrame = false): Promise<ArmMoveResult> {
-    const { result, frame } = await this.callToolWithImage<ArmMoveResult>('arm-move', {
-      x,
-      y,
-      captureFrame,
-    });
+    const { result, frame } = await this.withArmConnection(() =>
+      this.callToolWithImage<ArmMoveResult>('arm-move', {
+        x,
+        y,
+        captureFrame,
+      })
+    );
     return { ...result, frame };
   }
 
   async armClick(depth = 12, captureFrame = false): Promise<ArmClickResult> {
-    const { result, frame } = await this.callToolWithImage<ArmClickResult>('arm-click', {
-      depth,
-      captureFrame,
-    });
+    const { result, frame } = await this.withArmConnection(() =>
+      this.callToolWithImage<ArmClickResult>('arm-click', {
+        depth,
+        captureFrame,
+      })
+    );
     return { ...result, frame };
   }
 
@@ -368,27 +428,32 @@ export class PhonePilotClient {
   }
 
   async confirmAction(): Promise<ActionResult> {
-    return this.callTool<ActionResult>('confirm-action', { action: 'confirm' });
+    return this.withArmConnection(() =>
+      this.callTool<ActionResult>('confirm-action', { action: 'confirm' })
+    );
   }
 
   async cancelAction(): Promise<ActionResult> {
-    return this.callTool<ActionResult>('confirm-action', { action: 'cancel' });
+    return this.withArmConnection(() =>
+      this.callTool<ActionResult>('confirm-action', { action: 'cancel' })
+    );
   }
 
   async slideConfirm(): Promise<ActionResult> {
-    return this.callTool<ActionResult>('confirm-action', { action: 'slide' });
+    return this.withArmConnection(() =>
+      this.callTool<ActionResult>('confirm-action', { action: 'slide' })
+    );
   }
 
   async executeActionSequence(
     steps: Array<'confirm' | 'cancel' | 'slide'>,
     options?: { startDelayMs?: number; betweenStepsDelayMs?: number; returnFrame?: boolean }
   ): Promise<ActionSequenceResult> {
-    const { result, frame } = await this.callToolWithImage<ActionSequenceResult>(
-      'confirm-action-sequence',
-      {
+    const { result, frame } = await this.withArmConnection(() =>
+      this.callToolWithImage<ActionSequenceResult>('confirm-action-sequence', {
         steps,
         ...options,
-      }
+      })
     );
     return { ...result, frame };
   }
@@ -401,22 +466,23 @@ export class PhonePilotClient {
     betweenStepsDelayMs?: number;
     returnFrame?: boolean;
   }): Promise<AutomationPresetExecutionResult> {
-    const { result, frame } = await this.callToolWithImage<AutomationPresetExecutionResult>(
-      'execute-automation-preset',
-      input
+    const { result, frame } = await this.withArmConnection(() =>
+      this.callToolWithImage<AutomationPresetExecutionResult>('execute-automation-preset', input)
     );
     return { ...result, frame };
   }
 
   async inputPin(pin: string): Promise<ActionResult> {
-    return this.callTool<ActionResult>('input-pin', { pin });
+    return this.withArmConnection(() => this.callTool<ActionResult>('input-pin', { pin }));
   }
 
   async executeSequence(sequenceId: string): Promise<ExecuteSequenceResult> {
-    const { result, frame } = await this.callToolWithImage<ExecuteSequenceResult>(
-      'execute-sequence',
-      { sequenceId },
-      LONG_TIMEOUT_MS
+    const { result, frame } = await this.withArmConnection(() =>
+      this.callToolWithImage<ExecuteSequenceResult>(
+        'execute-sequence',
+        { sequenceId },
+        LONG_TIMEOUT_MS
+      )
     );
     return {
       ...result,

--- a/packages/connect-examples/expo-example/src/services/phonePilotMcp/types.ts
+++ b/packages/connect-examples/expo-example/src/services/phonePilotMcp/types.ts
@@ -220,6 +220,8 @@ export type AutomationScenarioId =
   | 'ok40090_slip39_import_33_1of1'
   | 'ok40090_slip39_import_33_2of3';
 
+export const STANDALONE_MODULE_SCENARIO_ID: AutomationScenarioId = 'bip39_import_12_api';
+
 export type Slip39DatasetId =
   | 'count20_one'
   | 'count20_two'

--- a/packages/connect-examples/expo-example/src/testTools/automationTest/useAutomationTest.ts
+++ b/packages/connect-examples/expo-example/src/testTools/automationTest/useAutomationTest.ts
@@ -3268,55 +3268,65 @@ export function useAutomationTest() {
       retrySelection?: RetryCaseSelection
     ): Promise<TestSuiteResult[]> => {
       const nextSuiteResults = [...suiteResults];
+      const runSdkBatchSuite = async (
+        suiteType: Extract<TestSuiteType, 'sdkAddressBatch' | 'sdkPubkeyBatch'>
+      ) => {
+        const retrySuiteFilter = getRetrySuiteFilter(retrySelection, scenario.id, suiteType);
+
+        if (scenario.walletType === 'bip39') {
+          if (scenario.flowType === 'import') {
+            return runBip39ImportSdkSuite(
+              suiteType,
+              scenario,
+              sdk,
+              connectId,
+              deviceId,
+              config.passphraseVariants,
+              retrySuiteFilter
+            );
+          }
+
+          return runBip39CreateDynamicSuite(
+            suiteType,
+            scenario,
+            sdk,
+            connectId,
+            deviceId,
+            config.passphraseVariants,
+            mnemonicStoreResult,
+            retrySuiteFilter
+          );
+        }
+
+        if (scenario.flowType === 'create') {
+          return runSlip39CreateDynamicSuite(
+            suiteType,
+            scenario,
+            sdk,
+            connectId,
+            deviceId,
+            config.passphraseVariants,
+            mnemonicStoreResult,
+            retrySuiteFilter
+          );
+        }
+
+        return runSlip39SdkSuite(
+          suiteType,
+          scenario,
+          sdk,
+          connectId,
+          deviceId,
+          config.passphraseVariants,
+          retrySuiteFilter
+        );
+      };
 
       if (
         selectedSuites.includes('sdkAddressBatch') &&
         !shouldStopBySuiteFailure(config.stopOnFirstError, nextSuiteResults)
       ) {
-        const bip39AddressResult =
-          scenario.flowType === 'import'
-            ? await runBip39ImportSdkSuite(
-                'sdkAddressBatch',
-                scenario,
-                sdk,
-                connectId,
-                deviceId,
-                config.passphraseVariants,
-                getRetrySuiteFilter(retrySelection, scenario.id, 'sdkAddressBatch')
-              )
-            : await runBip39CreateDynamicSuite(
-                'sdkAddressBatch',
-                scenario,
-                sdk,
-                connectId,
-                deviceId,
-                config.passphraseVariants,
-                mnemonicStoreResult,
-                getRetrySuiteFilter(retrySelection, scenario.id, 'sdkAddressBatch')
-              );
-        const slip39AddressResult =
-          scenario.flowType === 'create'
-            ? await runSlip39CreateDynamicSuite(
-                'sdkAddressBatch',
-                scenario,
-                sdk,
-                connectId,
-                deviceId,
-                config.passphraseVariants,
-                mnemonicStoreResult,
-                getRetrySuiteFilter(retrySelection, scenario.id, 'sdkAddressBatch')
-              )
-            : await runSlip39SdkSuite(
-                'sdkAddressBatch',
-                scenario,
-                sdk,
-                connectId,
-                deviceId,
-                config.passphraseVariants,
-                getRetrySuiteFilter(retrySelection, scenario.id, 'sdkAddressBatch')
-              );
-        const sdkAddressResult =
-          scenario.walletType === 'bip39' ? bip39AddressResult : slip39AddressResult;
+        const sdkAddressResult = await runSdkBatchSuite('sdkAddressBatch');
         nextSuiteResults.push(sdkAddressResult);
         if (liveScenarioCtxRef.current) {
           liveScenarioCtxRef.current.completedSuiteResults = [...nextSuiteResults];
@@ -3328,50 +3338,7 @@ export function useAutomationTest() {
         selectedSuites.includes('sdkPubkeyBatch') &&
         !shouldStopBySuiteFailure(config.stopOnFirstError, nextSuiteResults)
       ) {
-        const bip39PubkeyResult =
-          scenario.flowType === 'import'
-            ? await runBip39ImportSdkSuite(
-                'sdkPubkeyBatch',
-                scenario,
-                sdk,
-                connectId,
-                deviceId,
-                config.passphraseVariants,
-                getRetrySuiteFilter(retrySelection, scenario.id, 'sdkPubkeyBatch')
-              )
-            : await runBip39CreateDynamicSuite(
-                'sdkPubkeyBatch',
-                scenario,
-                sdk,
-                connectId,
-                deviceId,
-                config.passphraseVariants,
-                mnemonicStoreResult,
-                getRetrySuiteFilter(retrySelection, scenario.id, 'sdkPubkeyBatch')
-              );
-        const slip39PubkeyResult =
-          scenario.flowType === 'create'
-            ? await runSlip39CreateDynamicSuite(
-                'sdkPubkeyBatch',
-                scenario,
-                sdk,
-                connectId,
-                deviceId,
-                config.passphraseVariants,
-                mnemonicStoreResult,
-                getRetrySuiteFilter(retrySelection, scenario.id, 'sdkPubkeyBatch')
-              )
-            : await runSlip39SdkSuite(
-                'sdkPubkeyBatch',
-                scenario,
-                sdk,
-                connectId,
-                deviceId,
-                config.passphraseVariants,
-                getRetrySuiteFilter(retrySelection, scenario.id, 'sdkPubkeyBatch')
-              );
-        const sdkPubkeyResult =
-          scenario.walletType === 'bip39' ? bip39PubkeyResult : slip39PubkeyResult;
+        const sdkPubkeyResult = await runSdkBatchSuite('sdkPubkeyBatch');
         nextSuiteResults.push(sdkPubkeyResult);
         if (liveScenarioCtxRef.current) {
           liveScenarioCtxRef.current.completedSuiteResults = [...nextSuiteResults];

--- a/packages/connect-examples/expo-example/src/testTools/automationTest/useAutomationTest.ts
+++ b/packages/connect-examples/expo-example/src/testTools/automationTest/useAutomationTest.ts
@@ -51,6 +51,7 @@ import {
   type HealthCheckResponse,
   type MnemonicStoreResult,
   type PassphraseVariantId,
+  STANDALONE_MODULE_SCENARIO_ID,
   STANDALONE_TEST_SUITES,
   type ScenarioReportResult,
   type TestCaseResult,
@@ -106,7 +107,6 @@ const SLIP39_CREATE_ALLOWED_VARIANTS: PassphraseVariantId[] = ['normal', 'passph
 const RESET_SEQUENCE_LOCKED = 'reset-wallet-locked';
 const RESET_SEQUENCE_UNLOCKED = 'reset-wallet-unlocked';
 const DEBUG_SKIP_DEVICE_FLOW_REASON = 'debug mode skipped device flow';
-const STANDALONE_MODULE_SCENARIO_ID = 'bip39_import_12_api';
 
 /**
  * Timing constants — aligned with SLIP39 standalone test timings.
@@ -591,9 +591,11 @@ function buildEffectiveSelectedScenarios(
 ): AutomationScenario[] {
   const scenarioMap = new Map<AutomationScenario['id'], AutomationScenario>();
 
-  scenarioIds.forEach(id => {
-    scenarioMap.set(id, getAutomationScenario(id));
-  });
+  scenarioIds
+    .filter(id => id !== STANDALONE_MODULE_SCENARIO_ID)
+    .forEach(id => {
+      scenarioMap.set(id, getAutomationScenario(id));
+    });
 
   if (hasStandaloneSuiteSelection(selectedSuites)) {
     scenarioMap.set(
@@ -4255,7 +4257,9 @@ export function useAutomationTest() {
     connectionState,
     progress,
     logs,
-    scenarios: getAllAutomationScenarios(),
+    scenarios: getAllAutomationScenarios().filter(
+      scenario => scenario.id !== STANDALONE_MODULE_SCENARIO_ID
+    ),
     connectPhonePilot,
     disconnectPhonePilot,
     startAutomation,

--- a/packages/connect-examples/expo-example/src/testTools/automationTest/useAutomationTest.ts
+++ b/packages/connect-examples/expo-example/src/testTools/automationTest/useAutomationTest.ts
@@ -1501,13 +1501,13 @@ export function useAutomationTest() {
 
   const getCurrentDeviceEvmAddress = useCallback(
     async (sdk: CoreApi, connectId: string, deviceId: string): Promise<string> => {
-      const result = (await runWithRetry('evmGetAddress:current-wallet', () =>
+      const result = await runWithRetry('evmGetAddress:current-wallet', () =>
         sdk.evmGetAddress(connectId, deviceId, {
           path: EVM_ADDRESS_PATH,
           showOnOneKey: false,
           useEmptyPassphrase: true,
         })
-      )) as { success: boolean; payload?: unknown };
+      );
 
       if (!result.success) {
         throw new Error(
@@ -1669,60 +1669,56 @@ export function useAutomationTest() {
       }
 
       const suiteName = getSuiteName(suiteType);
-      const expectedTotal = filterTitles?.size ?? countSdkCasePaths(scenario, suiteType, selectedPassphraseVariants);
+      const expectedTotal =
+        filterTitles?.size ?? countSdkCasePaths(scenario, suiteType, selectedPassphraseVariants);
       const results: TestCaseResult[] = [];
       for (const slip39Case of slip39Cases) {
-        if (
-          !hasMatchingRetryTitle(
-            filterTitles,
-            title => title.startsWith(`${slip39Case.id} / `)
-          )
-        ) {
-          continue;
-        }
-        // Fetch fresh features per iteration to avoid stale passphrase_protection state
-        const deviceFeatures = await fetchDeviceFeatures(sdk, connectId);
-        const ppResult = await preparePassphraseIteration(
-          sdk,
-          connectId,
-          deviceFeatures,
-          slip39Case.passphrase,
-          'SLIP39',
-          results,
-          suiteType,
-          suiteName
-        );
-        if (ppResult.ok) {
-          const { passphraseState } = ppResult;
+        if (hasMatchingRetryTitle(filterTitles, title => title.startsWith(`${slip39Case.id} / `))) {
+          // Fetch fresh features per iteration to avoid stale passphrase_protection state
+          const deviceFeatures = await fetchDeviceFeatures(sdk, connectId);
+          const ppResult = await preparePassphraseIteration(
+            sdk,
+            connectId,
+            deviceFeatures,
+            slip39Case.passphrase,
+            'SLIP39',
+            results,
+            suiteType,
+            suiteName
+          );
+          if (ppResult.ok) {
+            const { passphraseState } = ppResult;
 
-          for (const methodData of slip39Case.data) {
-            const expectedMap =
-              caseType === 'address' ? methodData.expectedAddress : methodData.expectedPublicKey;
-            const expectedPaths = Object.keys(expectedMap || {});
+            for (const methodData of slip39Case.data) {
+              const expectedMap =
+                caseType === 'address' ? methodData.expectedAddress : methodData.expectedPublicKey;
+              const expectedPaths = Object.keys(expectedMap || {});
 
-            for (const expectedPath of expectedPaths) {
-              if (!runningRef.current) {
-                break;
+              for (const expectedPath of expectedPaths) {
+                if (!runningRef.current) {
+                  break;
+                }
+                const caseTitle = `${slip39Case.id} / ${
+                  methodData.name || methodData.method
+                } / ${expectedPath}`;
+                if (!filterTitles || filterTitles.has(caseTitle)) {
+                  const caseResult = await runSdkMethodCase(
+                    sdk,
+                    connectId,
+                    deviceId,
+                    scenario,
+                    slip39Case,
+                    methodData,
+                    expectedPath,
+                    caseType,
+                    passphraseState
+                  );
+                  results.push(caseResult);
+                  incrementCompletedTests();
+                  notifyLiveCaseUpdate(suiteType, suiteName, results, expectedTotal);
+                  await delay(SDK_CASE_DELAY_MS);
+                }
               }
-              const caseTitle = `${slip39Case.id} / ${methodData.name || methodData.method} / ${expectedPath}`;
-              if (filterTitles && !filterTitles.has(caseTitle)) {
-                continue;
-              }
-              const caseResult = await runSdkMethodCase(
-                sdk,
-                connectId,
-                deviceId,
-                scenario,
-                slip39Case,
-                methodData,
-                expectedPath,
-                caseType,
-                passphraseState
-              );
-              results.push(caseResult);
-              incrementCompletedTests();
-              notifyLiveCaseUpdate(suiteType, suiteName, results, expectedTotal);
-              await delay(SDK_CASE_DELAY_MS);
             }
           }
         }
@@ -1880,58 +1876,54 @@ export function useAutomationTest() {
       }
 
       const suiteName = getSuiteName(suiteType);
-      const expectedTotal = filterTitles?.size ?? countSdkCasePaths(scenario, suiteType, selectedPassphraseVariants);
+      const expectedTotal =
+        filterTitles?.size ?? countSdkCasePaths(scenario, suiteType, selectedPassphraseVariants);
 
       const results: TestCaseResult[] = [];
       for (const bip39Case of bip39Cases) {
-        if (
-          !hasMatchingRetryTitle(
-            filterTitles,
-            title => title.startsWith(`${bip39Case.id} / `)
-          )
-        ) {
-          continue;
-        }
-        // Fetch fresh features per iteration to avoid stale passphrase_protection state
-        const deviceFeatures2 = await fetchDeviceFeatures(sdk, connectId);
-        const ppResult = await preparePassphraseIteration(
-          sdk,
-          connectId,
-          deviceFeatures2,
-          bip39Case.passphrase,
-          'BIP39_IMPORT',
-          results,
-          suiteType,
-          suiteName
-        );
-        if (ppResult.ok) {
-          const { passphraseState } = ppResult;
+        if (hasMatchingRetryTitle(filterTitles, title => title.startsWith(`${bip39Case.id} / `))) {
+          // Fetch fresh features per iteration to avoid stale passphrase_protection state
+          const deviceFeatures2 = await fetchDeviceFeatures(sdk, connectId);
+          const ppResult = await preparePassphraseIteration(
+            sdk,
+            connectId,
+            deviceFeatures2,
+            bip39Case.passphrase,
+            'BIP39_IMPORT',
+            results,
+            suiteType,
+            suiteName
+          );
+          if (ppResult.ok) {
+            const { passphraseState } = ppResult;
 
-          for (const methodCase of bip39Case.data) {
-            const expectedPaths = Object.keys(methodCase.expectedByPath || {});
-            for (const expectedPath of expectedPaths) {
-              if (!runningRef.current) {
-                break;
+            for (const methodCase of bip39Case.data) {
+              const expectedPaths = Object.keys(methodCase.expectedByPath || {});
+              for (const expectedPath of expectedPaths) {
+                if (!runningRef.current) {
+                  break;
+                }
+                const caseTitle = `${bip39Case.id} / ${
+                  methodCase.name || methodCase.method
+                } / ${expectedPath}`;
+                if (!filterTitles || filterTitles.has(caseTitle)) {
+                  const caseResult = await runAutomationSdkBatchCase(
+                    sdk,
+                    connectId,
+                    deviceId,
+                    scenario,
+                    bip39Case,
+                    methodCase,
+                    expectedPath,
+                    caseType,
+                    passphraseState
+                  );
+                  results.push(caseResult);
+                  incrementCompletedTests();
+                  notifyLiveCaseUpdate(suiteType, suiteName, results, expectedTotal);
+                  await delay(SDK_CASE_DELAY_MS);
+                }
               }
-              const caseTitle = `${bip39Case.id} / ${methodCase.name || methodCase.method} / ${expectedPath}`;
-              if (filterTitles && !filterTitles.has(caseTitle)) {
-                continue;
-              }
-              const caseResult = await runAutomationSdkBatchCase(
-                sdk,
-                connectId,
-                deviceId,
-                scenario,
-                bip39Case,
-                methodCase,
-                expectedPath,
-                caseType,
-                passphraseState
-              );
-              results.push(caseResult);
-              incrementCompletedTests();
-              notifyLiveCaseUpdate(suiteType, suiteName, results, expectedTotal);
-              await delay(SDK_CASE_DELAY_MS);
             }
           }
         }
@@ -1981,140 +1973,137 @@ export function useAutomationTest() {
           : BIP39_CREATE_PUBKEY_PROBES;
 
       const suiteName = getSuiteName(suiteType);
-      const expectedTotal = filterTitles?.size ?? countSdkCasePaths(scenario, suiteType, selectedPassphraseVariants);
+      const expectedTotal =
+        filterTitles?.size ?? countSdkCasePaths(scenario, suiteType, selectedPassphraseVariants);
 
       const results: TestCaseResult[] = [];
       for (const variantId of selectedPassphraseVariants) {
         if (!runningRef.current) {
           break;
         }
-        if (!hasMatchingRetryTitle(filterTitles, title => title.endsWith(` / ${variantId}`))) {
-          continue;
-        }
+        if (hasMatchingRetryTitle(filterTitles, title => title.endsWith(` / ${variantId}`))) {
+          const passphraseLiteral = getScenarioPassphraseLiteral(scenario, variantId);
+          // Fetch fresh features per iteration to avoid stale passphrase_protection state
+          const deviceFeatures3 = await fetchDeviceFeatures(sdk, connectId);
+          const ppResult = await preparePassphraseIteration(
+            sdk,
+            connectId,
+            deviceFeatures3,
+            passphraseLiteral,
+            'BIP39_CREATE',
+            results,
+            suiteType,
+            suiteName
+          );
+          if (ppResult.ok) {
+            const { passphraseState } = ppResult;
 
-        const passphraseLiteral = getScenarioPassphraseLiteral(scenario, variantId);
-        // Fetch fresh features per iteration to avoid stale passphrase_protection state
-        const deviceFeatures3 = await fetchDeviceFeatures(sdk, connectId);
-        const ppResult = await preparePassphraseIteration(
-          sdk,
-          connectId,
-          deviceFeatures3,
-          passphraseLiteral,
-          'BIP39_CREATE',
-          results,
-          suiteType,
-          suiteName
-        );
-        if (!ppResult.ok) {
-          // skip this variant
-        } else {
-          const { passphraseState } = ppResult;
+            const passphraseDisplay = formatPassphraseDisplay(passphraseLiteral);
+            const seed = mnemonicToSeed(mnemonicWords.join(' '), passphraseLiteral);
+            for (const probe of probes) {
+              const caseTitle = `${scenario.id} / ${probe.caseName} / ${probe.path} / ${variantId}`;
+              if (!filterTitles || filterTitles.has(caseTitle)) {
+                const startedAtCase = Date.now();
+                let expected = '';
 
-          const passphraseDisplay = formatPassphraseDisplay(passphraseLiteral);
-          const seed = mnemonicToSeed(mnemonicWords.join(' '), passphraseLiteral);
-          for (const probe of probes) {
-            const caseTitle = `${scenario.id} / ${probe.caseName} / ${probe.path} / ${variantId}`;
-            if (filterTitles && !filterTitles.has(caseTitle)) {
-              continue;
-            }
-            const startedAtCase = Date.now();
-            let expected = '';
-
-            try {
-              expected = buildBip39CreateExpectedValue(
-                probe.method,
-                probe.caseName,
-                seed,
-                probe.path
-              );
-              if (!expected) {
-                throw new Error(`Missing expected ${caseType} value for ${probe.caseName}`);
-              }
-
-              const sdkParams: Record<string, unknown> = {
-                path: probe.path,
-                showOnOneKey: false,
-                passphraseState,
-                useEmptyPassphrase: !passphraseLiteral,
-              };
-
-              const result = (await runWithRetry(`${probe.method}:${probe.path}`, () => {
-                const method = (sdk as Record<string, unknown>)[probe.method];
-                if (typeof method !== 'function') {
-                  throw new Error(`SDK method not found: ${probe.method}`);
-                }
-                return (method as (...args: unknown[]) => Promise<unknown>)(
-                  connectId,
-                  deviceId,
-                  sdkParams
-                );
-              })) as { success: boolean; payload?: unknown };
-
-              if (!result.success) {
-                results.push({
-                  title: caseTitle,
-                  method: probe.method,
-                  expected,
-                  actual: '',
-                  passed: false,
-                  error:
-                    (result.payload as { error?: string } | undefined)?.error || 'Unknown error',
-                  duration: Date.now() - startedAtCase,
-                  metadata: {
-                    path: probe.path,
-                    passphrase: passphraseDisplay,
-                  },
-                });
-              } else {
-                const actual = extractComparisonValue(
-                  result.payload,
-                  caseType,
-                  probe.method,
-                  probe.caseName
-                );
-                const passed = actual === expected;
-                if (!passed) {
-                  addLog(
-                    `[MISMATCH] ${scenario.id} / ${probe.caseName} / ${probe.path} / ${variantId}`
+                try {
+                  expected = buildBip39CreateExpectedValue(
+                    probe.method,
+                    probe.caseName,
+                    seed,
+                    probe.path
                   );
-                  addLog(`  expected: ${expected}`);
-                  addLog(`  actual:   ${actual}`);
-                }
-                results.push({
-                  title: caseTitle,
-                  method: probe.method,
-                  expected,
-                  actual,
-                  passed,
-                  duration: Date.now() - startedAtCase,
-                  metadata: {
-                    path: probe.path,
-                    passphrase: passphraseDisplay,
-                    source: mnemonicStoreResult?.sequenceId || scenario.phonePilotSequenceId,
-                  },
-                });
-              }
-            } catch (error) {
-              results.push({
-                title: caseTitle,
-                method: probe.method,
-                expected,
-                actual: '',
-                passed: false,
-                error: error instanceof Error ? error.message : String(error),
-                duration: Date.now() - startedAtCase,
-                metadata: {
-                  path: probe.path,
-                  passphrase: passphraseDisplay,
-                },
-              });
-            }
+                  if (!expected) {
+                    throw new Error(`Missing expected ${caseType} value for ${probe.caseName}`);
+                  }
 
-            incrementCompletedTests();
-            notifyLiveCaseUpdate(suiteType, suiteName, results, expectedTotal);
-            await delay(SDK_CASE_DELAY_MS);
+                  const sdkParams: Record<string, unknown> = {
+                    path: probe.path,
+                    showOnOneKey: false,
+                    passphraseState,
+                    useEmptyPassphrase: !passphraseLiteral,
+                  };
+
+                  const result = (await runWithRetry(`${probe.method}:${probe.path}`, () => {
+                    const method = (sdk as Record<string, unknown>)[probe.method];
+                    if (typeof method !== 'function') {
+                      throw new Error(`SDK method not found: ${probe.method}`);
+                    }
+                    return (method as (...args: unknown[]) => Promise<unknown>)(
+                      connectId,
+                      deviceId,
+                      sdkParams
+                    );
+                  })) as { success: boolean; payload?: unknown };
+
+                  if (!result.success) {
+                    results.push({
+                      title: caseTitle,
+                      method: probe.method,
+                      expected,
+                      actual: '',
+                      passed: false,
+                      error:
+                        (result.payload as { error?: string } | undefined)?.error ||
+                        'Unknown error',
+                      duration: Date.now() - startedAtCase,
+                      metadata: {
+                        path: probe.path,
+                        passphrase: passphraseDisplay,
+                      },
+                    });
+                  } else {
+                    const actual = extractComparisonValue(
+                      result.payload,
+                      caseType,
+                      probe.method,
+                      probe.caseName
+                    );
+                    const passed = actual === expected;
+                    if (!passed) {
+                      addLog(
+                        `[MISMATCH] ${scenario.id} / ${probe.caseName} / ${probe.path} / ${variantId}`
+                      );
+                      addLog(`  expected: ${expected}`);
+                      addLog(`  actual:   ${actual}`);
+                    }
+                    results.push({
+                      title: caseTitle,
+                      method: probe.method,
+                      expected,
+                      actual,
+                      passed,
+                      duration: Date.now() - startedAtCase,
+                      metadata: {
+                        path: probe.path,
+                        passphrase: passphraseDisplay,
+                        source: mnemonicStoreResult?.sequenceId || scenario.phonePilotSequenceId,
+                      },
+                    });
+                  }
+                } catch (error) {
+                  results.push({
+                    title: caseTitle,
+                    method: probe.method,
+                    expected,
+                    actual: '',
+                    passed: false,
+                    error: error instanceof Error ? error.message : String(error),
+                    duration: Date.now() - startedAtCase,
+                    metadata: {
+                      path: probe.path,
+                      passphrase: passphraseDisplay,
+                    },
+                  });
+                }
+
+                incrementCompletedTests();
+                notifyLiveCaseUpdate(suiteType, suiteName, results, expectedTotal);
+                await delay(SDK_CASE_DELAY_MS);
+              }
+            }
           }
-        } // end else (!ppResult.ok)
+        }
       }
 
       cleanupPassphraseLoop();
@@ -2198,185 +2187,181 @@ export function useAutomationTest() {
       }
 
       const suiteName = getSuiteName(suiteType);
-      const expectedTotal = filterTitles?.size ?? countSdkCasePaths(scenario, suiteType, variantIds);
+      const expectedTotal =
+        filterTitles?.size ?? countSdkCasePaths(scenario, suiteType, variantIds);
 
       const results: TestCaseResult[] = [];
       for (const variantId of variantIds) {
         if (!runningRef.current) {
           break;
         }
-        if (
-          !hasMatchingRetryTitle(filterTitles, title => title.includes(` / ${variantId} / `))
-        ) {
-          continue;
-        }
+        if (hasMatchingRetryTitle(filterTitles, title => title.includes(` / ${variantId} / `))) {
+          const passphraseLiteral = getScenarioPassphraseLiteral(scenario, variantId);
+          // Fetch fresh features per iteration to avoid stale passphrase_protection state
+          const deviceFeatures4 = await fetchDeviceFeatures(sdk, connectId);
+          const ppResult = await preparePassphraseIteration(
+            sdk,
+            connectId,
+            deviceFeatures4,
+            passphraseLiteral,
+            'SLIP39_CREATE',
+            results,
+            suiteType,
+            suiteName
+          );
+          if (ppResult.ok) {
+            const { passphraseState } = ppResult;
 
-        const passphraseLiteral = getScenarioPassphraseLiteral(scenario, variantId);
-        // Fetch fresh features per iteration to avoid stale passphrase_protection state
-        const deviceFeatures4 = await fetchDeviceFeatures(sdk, connectId);
-        const ppResult = await preparePassphraseIteration(
-          sdk,
-          connectId,
-          deviceFeatures4,
-          passphraseLiteral,
-          'SLIP39_CREATE',
-          results,
-          suiteType,
-          suiteName
-        );
-        if (!ppResult.ok) {
-          // skip this variant
-        } else {
-          const { passphraseState } = ppResult;
+            const passphraseDisplay = formatPassphraseDisplay(passphraseLiteral);
+            for (const methodData of templateCase.data) {
+              const expectedMap =
+                caseType === 'address' ? methodData.expectedAddress : methodData.expectedPublicKey;
+              const expectedPaths = Object.keys(expectedMap || {});
 
-          const passphraseDisplay = formatPassphraseDisplay(passphraseLiteral);
-          for (const methodData of templateCase.data) {
-            const expectedMap =
-              caseType === 'address' ? methodData.expectedAddress : methodData.expectedPublicKey;
-            const expectedPaths = Object.keys(expectedMap || {});
-
-            for (const expectedPath of expectedPaths) {
-              if (!runningRef.current) {
-                break;
-              }
-              const caseTitle = `${scenario.id} / ${
-                methodData.name || methodData.method
-              } / ${variantId} / ${expectedPath}`;
-              if (filterTitles && !filterTitles.has(caseTitle)) {
-                continue;
-              }
-
-              const startedAtCase = Date.now();
-              let expected = '';
-
-              try {
-                const generatorParams = {
-                  ...(methodData.params || {}),
-                  path: expectedPath,
-                };
-                const generatorResult =
-                  caseType === 'address'
-                    ? await generateMultiChainAddressFromSLIP39({
-                        shares: shareMnemonics,
-                        passphrase: passphraseLiteral,
-                        method: methodData.method,
-                        params: generatorParams,
-                      })
-                    : await generateMultiChainPublicKeyFromSLIP39({
-                        shares: shareMnemonics,
-                        passphrase: passphraseLiteral,
-                        method: methodData.method,
-                        params: generatorParams,
-                      });
-
-                if (!generatorResult.success) {
-                  throw new Error(
-                    generatorResult.error || 'Failed to generate expected value from SLIP39 shares'
-                  );
+              for (const expectedPath of expectedPaths) {
+                if (!runningRef.current) {
+                  break;
                 }
+                const caseTitle = `${scenario.id} / ${
+                  methodData.name || methodData.method
+                } / ${variantId} / ${expectedPath}`;
+                if (!filterTitles || filterTitles.has(caseTitle)) {
+                  const startedAtCase = Date.now();
+                  let expected = '';
 
-                expected = extractComparisonValue(
-                  generatorResult.payload,
-                  caseType,
-                  methodData.method,
-                  methodData.name
-                );
-                if (!expected) {
-                  throw new Error('Generated expected value is empty');
-                }
+                  try {
+                    const generatorParams = {
+                      ...(methodData.params || {}),
+                      path: expectedPath,
+                    };
+                    const generatorResult =
+                      caseType === 'address'
+                        ? await generateMultiChainAddressFromSLIP39({
+                            shares: shareMnemonics,
+                            passphrase: passphraseLiteral,
+                            method: methodData.method,
+                            params: generatorParams,
+                          })
+                        : await generateMultiChainPublicKeyFromSLIP39({
+                            shares: shareMnemonics,
+                            passphrase: passphraseLiteral,
+                            method: methodData.method,
+                            params: generatorParams,
+                          });
 
-                const sdkMethodParams: Record<string, unknown> = {
-                  ...(methodData.params || {}),
-                  path: expectedPath,
-                  showOnOneKey: false,
-                  passphraseState,
-                  useEmptyPassphrase: !passphraseLiteral,
-                };
-
-                const sdkResult = (await runWithRetry(
-                  `${methodData.method}:${expectedPath}`,
-                  () => {
-                    const method = (sdk as Record<string, unknown>)[methodData.method];
-                    if (typeof method !== 'function') {
-                      throw new Error(`SDK method not found: ${methodData.method}`);
+                    if (!generatorResult.success) {
+                      throw new Error(
+                        generatorResult.error ||
+                          'Failed to generate expected value from SLIP39 shares'
+                      );
                     }
-                    return (method as (...args: unknown[]) => Promise<unknown>)(
-                      connectId,
-                      deviceId,
-                      sdkMethodParams
-                    );
-                  }
-                )) as { success: boolean; payload?: unknown };
 
-                if (!sdkResult.success) {
-                  results.push({
-                    title: caseTitle,
-                    method: methodData.method,
-                    expected,
-                    actual: '',
-                    passed: false,
-                    error:
-                      (sdkResult.payload as { error?: string } | undefined)?.error ||
-                      'Unknown error',
-                    duration: Date.now() - startedAtCase,
-                    metadata: {
-                      passphrase: passphraseDisplay,
-                      shares: String(shareMnemonics.length),
-                    },
-                  });
-                } else {
-                  const actual = extractComparisonValue(
-                    sdkResult.payload,
-                    caseType,
-                    methodData.method,
-                    methodData.name
-                  );
-                  const passed = actual === expected;
-                  if (!passed) {
-                    addLog(
-                      `[MISMATCH] ${scenario.id} / ${
-                        methodData.name || methodData.method
-                      } / ${variantId} / ${expectedPath}`
+                    expected = extractComparisonValue(
+                      generatorResult.payload,
+                      caseType,
+                      methodData.method,
+                      methodData.name
                     );
-                    addLog(`  expected: ${expected}`);
-                    addLog(`  actual:   ${actual}`);
+                    if (!expected) {
+                      throw new Error('Generated expected value is empty');
+                    }
+
+                    const sdkMethodParams: Record<string, unknown> = {
+                      ...(methodData.params || {}),
+                      path: expectedPath,
+                      showOnOneKey: false,
+                      passphraseState,
+                      useEmptyPassphrase: !passphraseLiteral,
+                    };
+
+                    const sdkResult = (await runWithRetry(
+                      `${methodData.method}:${expectedPath}`,
+                      () => {
+                        const method = (sdk as Record<string, unknown>)[methodData.method];
+                        if (typeof method !== 'function') {
+                          throw new Error(`SDK method not found: ${methodData.method}`);
+                        }
+                        return (method as (...args: unknown[]) => Promise<unknown>)(
+                          connectId,
+                          deviceId,
+                          sdkMethodParams
+                        );
+                      }
+                    )) as { success: boolean; payload?: unknown };
+
+                    if (!sdkResult.success) {
+                      results.push({
+                        title: caseTitle,
+                        method: methodData.method,
+                        expected,
+                        actual: '',
+                        passed: false,
+                        error:
+                          (sdkResult.payload as { error?: string } | undefined)?.error ||
+                          'Unknown error',
+                        duration: Date.now() - startedAtCase,
+                        metadata: {
+                          passphrase: passphraseDisplay,
+                          shares: String(shareMnemonics.length),
+                        },
+                      });
+                    } else {
+                      const actual = extractComparisonValue(
+                        sdkResult.payload,
+                        caseType,
+                        methodData.method,
+                        methodData.name
+                      );
+                      const passed = actual === expected;
+                      if (!passed) {
+                        addLog(
+                          `[MISMATCH] ${scenario.id} / ${
+                            methodData.name || methodData.method
+                          } / ${variantId} / ${expectedPath}`
+                        );
+                        addLog(`  expected: ${expected}`);
+                        addLog(`  actual:   ${actual}`);
+                      }
+                      results.push({
+                        title: caseTitle,
+                        method: methodData.method,
+                        expected,
+                        actual,
+                        passed,
+                        duration: Date.now() - startedAtCase,
+                        metadata: {
+                          passphrase: passphraseDisplay,
+                          shares: String(shareMnemonics.length),
+                          threshold: String(
+                            mnemonicStoreResult?.threshold || scenario.threshold || 0
+                          ),
+                        },
+                      });
+                    }
+                  } catch (error) {
+                    results.push({
+                      title: caseTitle,
+                      method: methodData.method,
+                      expected,
+                      actual: '',
+                      passed: false,
+                      error: error instanceof Error ? error.message : String(error),
+                      duration: Date.now() - startedAtCase,
+                      metadata: {
+                        passphrase: passphraseDisplay,
+                        shares: String(shareMnemonics.length),
+                      },
+                    });
                   }
-                  results.push({
-                    title: caseTitle,
-                    method: methodData.method,
-                    expected,
-                    actual,
-                    passed,
-                    duration: Date.now() - startedAtCase,
-                    metadata: {
-                      passphrase: passphraseDisplay,
-                      shares: String(shareMnemonics.length),
-                      threshold: String(mnemonicStoreResult?.threshold || scenario.threshold || 0),
-                    },
-                  });
+
+                  incrementCompletedTests();
+                  notifyLiveCaseUpdate(suiteType, suiteName, results, expectedTotal);
+                  await delay(SDK_CASE_DELAY_MS);
                 }
-              } catch (error) {
-                results.push({
-                  title: caseTitle,
-                  method: methodData.method,
-                  expected,
-                  actual: '',
-                  passed: false,
-                  error: error instanceof Error ? error.message : String(error),
-                  duration: Date.now() - startedAtCase,
-                  metadata: {
-                    passphrase: passphraseDisplay,
-                    shares: String(shareMnemonics.length),
-                  },
-                });
               }
-
-              incrementCompletedTests();
-              notifyLiveCaseUpdate(suiteType, suiteName, results, expectedTotal);
-              await delay(SDK_CASE_DELAY_MS);
             }
           }
-        } // end else (!ppResult.ok)
+        }
       }
 
       cleanupPassphraseLoop();
@@ -2445,157 +2430,165 @@ export function useAutomationTest() {
         }
 
         for (const passphrase of specialPassphrases) {
-          if (
-            !hasMatchingRetryTitle(filterTitles, title => title.endsWith(`「${passphrase}」`))
-          ) {
-            continue;
-          }
-          currentPassphraseRef.current = passphrase;
-          addLog(`Testing special passphrase: 「${passphrase}」`);
+          if (hasMatchingRetryTitle(filterTitles, title => title.endsWith(`「${passphrase}」`))) {
+            currentPassphraseRef.current = passphrase;
+            addLog(`Testing special passphrase: 「${passphrase}」`);
 
-          const psResult = (await runWithRetry(`getPassphraseState:special`, () =>
-            sdk.getPassphraseState(connectId, {
-              initSession: true,
-              useEmptyPassphrase: false,
-            })
-          )) as { success: boolean; payload?: string };
+            const psResult = await runWithRetry(`getPassphraseState:special`, () =>
+              sdk.getPassphraseState(connectId, {
+                initSession: true,
+                useEmptyPassphrase: false,
+              })
+            );
 
-          if (!psResult.success) {
-            results.push({
-              title: `getPassphraseState for 「${passphrase}」`,
-              passed: false,
-              error: 'getPassphraseState failed',
-              duration: Date.now() - startedAt,
-            });
-            notifyLiveCaseUpdate('specialPassphrase', 'Special Passphrase', results);
-          } else {
-            const passphraseState = psResult.payload || '';
+            if (!psResult.success) {
+              results.push({
+                title: `getPassphraseState for 「${passphrase}」`,
+                passed: false,
+                error: 'getPassphraseState failed',
+                duration: Date.now() - startedAt,
+              });
+              notifyLiveCaseUpdate('specialPassphrase', 'Special Passphrase', results);
+            } else {
+              const passphraseState = psResult.payload || '';
 
-            for (const method of methods) {
-              if (!runningRef.current) {
-                break;
-              }
+              for (const method of methods) {
+                if (!runningRef.current) {
+                  break;
+                }
 
-              const caseTitle = `${method} / 「${passphrase}」`;
-              if (filterTitles && !filterTitles.has(caseTitle)) {
-                continue;
-              }
-              const caseStart = Date.now();
-              try {
-                const mockFn = (mockDevice as Record<string, unknown>)[method];
-                if (typeof mockFn !== 'function') {
-                  results.push({
-                    title: caseTitle,
-                    method,
-                    passed: false,
-                    error: `mockDevice.${method} not found`,
-                    duration: Date.now() - caseStart,
-                  });
-                  notifyLiveCaseUpdate('specialPassphrase', 'Special Passphrase', results);
-                } else {
-                  const mockRes = (await mockFn('', '', {
-                    path: SPECIAL_PASSPHRASE_METHOD_PATHS[method],
-                    mnemonic: mnemonic.trim(),
-                    passphrase,
-                  })) as { payload?: { address?: string } };
-
-                  const expected = mockRes?.payload?.address || '';
-
-                  const sdkMethod = (sdk as Record<string, unknown>)[method];
-                  if (typeof sdkMethod !== 'function') {
-                    results.push({
-                      title: caseTitle,
-                      method,
-                      expected,
-                      passed: false,
-                      error: `SDK method ${method} not found`,
-                      duration: Date.now() - caseStart,
-                    });
-                    notifyLiveCaseUpdate('specialPassphrase', 'Special Passphrase', results);
-                  } else {
-                    const sdkResult = (await runWithRetry(`${method}:special`, () =>
-                      (sdkMethod as (...args: unknown[]) => Promise<unknown>)(connectId, deviceId, {
+                const caseTitle = `${method} / 「${passphrase}」`;
+                if (!filterTitles || filterTitles.has(caseTitle)) {
+                  const caseStart = Date.now();
+                  try {
+                    const mockFn = (mockDevice as Record<string, unknown>)[method];
+                    if (typeof mockFn !== 'function') {
+                      results.push({
+                        title: caseTitle,
+                        method,
+                        passed: false,
+                        error: `mockDevice.${method} not found`,
+                        duration: Date.now() - caseStart,
+                      });
+                      notifyLiveCaseUpdate('specialPassphrase', 'Special Passphrase', results);
+                    } else {
+                      const mockRes = (await mockFn('', '', {
                         path: SPECIAL_PASSPHRASE_METHOD_PATHS[method],
-                        showOnOneKey: false,
-                        passphraseState,
-                        useEmptyPassphrase: false,
-                      })
-                    )) as { success: boolean; payload?: { address?: string; error?: string } };
+                        mnemonic: mnemonic.trim(),
+                        passphrase,
+                      })) as { payload?: { address?: string } };
 
-                    if (!sdkResult.success) {
-                      // Check device compatibility
-                      let handledAsExpectedFail = false;
-                      if (deviceFeaturesRef.current) {
-                        const expectedOverride = compatibilityManager.getExpectedOverride(
-                          deviceFeaturesRef.current,
-                          method,
-                          SPECIAL_PASSPHRASE_METHOD_PATHS[method]
-                        );
-                        if (expectedOverride === false) {
-                          addLog(
-                            `[EXPECTED_FAIL] ${method} / 「${passphrase}」 — device does not support this method`
-                          );
-                          results.push({
-                            title: caseTitle,
-                            method,
-                            expected: '(expected failure)',
-                            actual: sdkResult.payload?.error || 'SDK call failed',
-                            passed: true,
-                            duration: Date.now() - caseStart,
-                            metadata: { passphrase, deviceCompat: 'expected failure' },
-                          });
-                          notifyLiveCaseUpdate('specialPassphrase', 'Special Passphrase', results);
-                          handledAsExpectedFail = true;
-                        }
-                      }
-                      if (!handledAsExpectedFail) {
+                      const expected = mockRes?.payload?.address || '';
+
+                      const sdkMethod = (sdk as Record<string, unknown>)[method];
+                      if (typeof sdkMethod !== 'function') {
                         results.push({
                           title: caseTitle,
                           method,
                           expected,
                           passed: false,
-                          error: sdkResult.payload?.error || 'SDK call failed',
+                          error: `SDK method ${method} not found`,
                           duration: Date.now() - caseStart,
-                          metadata: { passphrase },
                         });
                         notifyLiveCaseUpdate('specialPassphrase', 'Special Passphrase', results);
-                      }
-                    } else {
-                      const actual = sdkResult.payload?.address || '';
-                      const passed = actual.toLowerCase() === expected.toLowerCase();
-                      if (!passed) {
-                        addLog(`[MISMATCH] ${method} / 「${passphrase}」`);
-                        addLog(`  expected: ${expected}`);
-                        addLog(`  actual:   ${actual}`);
-                      }
+                      } else {
+                        const sdkResult = (await runWithRetry(`${method}:special`, () =>
+                          (sdkMethod as (...args: unknown[]) => Promise<unknown>)(
+                            connectId,
+                            deviceId,
+                            {
+                              path: SPECIAL_PASSPHRASE_METHOD_PATHS[method],
+                              showOnOneKey: false,
+                              passphraseState,
+                              useEmptyPassphrase: false,
+                            }
+                          )
+                        )) as { success: boolean; payload?: { address?: string; error?: string } };
 
-                      results.push({
-                        title: caseTitle,
-                        method,
-                        expected,
-                        actual,
-                        passed,
-                        duration: Date.now() - caseStart,
-                        metadata: { passphrase },
-                      });
-                    } // end else (!sdkResult.success)
-                  } // end else (typeof sdkMethod !== 'function')
-                } // end else (typeof mockFn !== 'function')
-              } catch (error) {
+                        if (!sdkResult.success) {
+                          // Check device compatibility
+                          let handledAsExpectedFail = false;
+                          if (deviceFeaturesRef.current) {
+                            const expectedOverride = compatibilityManager.getExpectedOverride(
+                              deviceFeaturesRef.current,
+                              method,
+                              SPECIAL_PASSPHRASE_METHOD_PATHS[method]
+                            );
+                            if (expectedOverride === false) {
+                              addLog(
+                                `[EXPECTED_FAIL] ${method} / 「${passphrase}」 — device does not support this method`
+                              );
+                              results.push({
+                                title: caseTitle,
+                                method,
+                                expected: '(expected failure)',
+                                actual: sdkResult.payload?.error || 'SDK call failed',
+                                passed: true,
+                                duration: Date.now() - caseStart,
+                                metadata: { passphrase, deviceCompat: 'expected failure' },
+                              });
+                              notifyLiveCaseUpdate(
+                                'specialPassphrase',
+                                'Special Passphrase',
+                                results
+                              );
+                              handledAsExpectedFail = true;
+                            }
+                          }
+                          if (!handledAsExpectedFail) {
+                            results.push({
+                              title: caseTitle,
+                              method,
+                              expected,
+                              passed: false,
+                              error: sdkResult.payload?.error || 'SDK call failed',
+                              duration: Date.now() - caseStart,
+                              metadata: { passphrase },
+                            });
+                            notifyLiveCaseUpdate(
+                              'specialPassphrase',
+                              'Special Passphrase',
+                              results
+                            );
+                          }
+                        } else {
+                          const actual = sdkResult.payload?.address || '';
+                          const passed = actual.toLowerCase() === expected.toLowerCase();
+                          if (!passed) {
+                            addLog(`[MISMATCH] ${method} / 「${passphrase}」`);
+                            addLog(`  expected: ${expected}`);
+                            addLog(`  actual:   ${actual}`);
+                          }
+
+                          results.push({
+                            title: caseTitle,
+                            method,
+                            expected,
+                            actual,
+                            passed,
+                            duration: Date.now() - caseStart,
+                            metadata: { passphrase },
+                          });
+                        } // end else (!sdkResult.success)
+                      } // end else (typeof sdkMethod !== 'function')
+                    } // end else (typeof mockFn !== 'function')
+                  } catch (error) {
                     results.push({
                       title: caseTitle,
-                  method,
-                  passed: false,
-                  error: error instanceof Error ? error.message : String(error),
-                  duration: Date.now() - caseStart,
-                });
-              }
+                      method,
+                      passed: false,
+                      error: error instanceof Error ? error.message : String(error),
+                      duration: Date.now() - caseStart,
+                    });
+                  }
 
-              incrementCompletedTests();
-              notifyLiveCaseUpdate('specialPassphrase', 'Special Passphrase', results);
-              await delay(SDK_CASE_DELAY_MS);
-            }
-          } // end else (!psResult.success)
+                  incrementCompletedTests();
+                  notifyLiveCaseUpdate('specialPassphrase', 'Special Passphrase', results);
+                  await delay(SDK_CASE_DELAY_MS);
+                }
+              }
+            } // end else (!psResult.success)
+          }
         }
       } catch (error) {
         results.push({
@@ -2772,112 +2765,111 @@ export function useAutomationTest() {
         addLog(`[SecurityCheck] Running ${testCases.length} test cases`);
 
         for (const testCase of testCases) {
-          if (filterTitles && !filterTitles.has(testCase.title)) {
-            continue;
-          }
-          const caseStart = Date.now();
-          const { method, params, expect: expectedResult, title } = testCase;
+          if (!filterTitles || filterTitles.has(testCase.title)) {
+            const caseStart = Date.now();
+            const { method, params, expect: expectedResult, title } = testCase;
 
-          try {
-            const sdkMethod = (sdk as Record<string, unknown>)[method];
-            if (typeof sdkMethod !== 'function') {
+            try {
+              const sdkMethod = (sdk as Record<string, unknown>)[method];
+              if (typeof sdkMethod !== 'function') {
+                results.push({
+                  title,
+                  method,
+                  passed: false,
+                  error: `SDK method ${method} not found`,
+                  duration: Date.now() - caseStart,
+                });
+                incrementCompletedTests();
+                notifyLiveCaseUpdate('securityCheck', 'Security Check', results);
+              } else {
+                setPendingUiActions(
+                  'securityCheck',
+                  title,
+                  expectedResult
+                    ? [
+                        ...Array<DeviceUiAction>(testCase.confirmCount ?? 1).fill('confirm'),
+                        ...(testCase.noSlide ? [] : (['slide'] as DeviceUiAction[])),
+                      ]
+                    : []
+                );
+
+                let sdkResult: { success: boolean; payload?: { error?: string } };
+                try {
+                  const resultOrTimeout = await Promise.race([
+                    (sdkMethod as (...args: unknown[]) => Promise<unknown>)(
+                      connectId,
+                      deviceId,
+                      withMainWalletCommonParams(params, forceUseEmptyPassphrase)
+                    ),
+                    new Promise<'timeout'>(resolve => {
+                      setTimeout(() => {
+                        resolve('timeout');
+                      }, 45_000);
+                    }),
+                  ]);
+                  if (resultOrTimeout === 'timeout') {
+                    sdk.cancel(connectId);
+                    await sdk.getFeatures(connectId, { retryCount: 1 });
+                    sdkResult = { success: false, payload: { error: 'timeout after 45s' } };
+                  } else {
+                    sdkResult = resultOrTimeout as typeof sdkResult;
+                  }
+                } catch (callError) {
+                  sdkResult = {
+                    success: false,
+                    payload: {
+                      error: callError instanceof Error ? callError.message : String(callError),
+                    },
+                  };
+                }
+
+                // Allow device-specific overrides (e.g. Pro doesn't support DNX)
+                const coinType = (() => {
+                  const path: string =
+                    ((params as Record<string, unknown>)?.path as string) ??
+                    ((
+                      (params as Record<string, unknown>)?.inputs as Array<Record<string, unknown>>
+                    )?.[0]?.path as string) ??
+                    '';
+                  return path.split('/')[2]?.replace(/'/g, '') ?? '';
+                })();
+                const deviceFeats = deviceFeaturesRef.current ?? {};
+                const expected = getDeviceExpected(deviceFeats, method, coinType, expectedResult, {
+                  securityChecksDisabled: false,
+                });
+
+                const actualSuccess = sdkResult.success;
+                const passed = expected ? actualSuccess : !actualSuccess;
+                const expectedLabel = expected ? 'success' : 'failure';
+                const actualLabel = actualSuccess
+                  ? 'success'
+                  : `failure(${sdkResult.payload?.error ?? ''})`;
+
+                results.push({
+                  title,
+                  method,
+                  expected: expectedLabel,
+                  actual: actualLabel,
+                  passed,
+                  duration: Date.now() - caseStart,
+                });
+              } // end else (typeof sdkMethod !== 'function')
+            } catch (error) {
               results.push({
                 title,
                 method,
                 passed: false,
-                error: `SDK method ${method} not found`,
+                error: error instanceof Error ? error.message : String(error),
                 duration: Date.now() - caseStart,
               });
-              incrementCompletedTests();
-              notifyLiveCaseUpdate('securityCheck', 'Security Check', results);
-            } else {
-              setPendingUiActions(
-                'securityCheck',
-                title,
-                expectedResult
-                  ? [
-                      ...Array<DeviceUiAction>(testCase.confirmCount ?? 1).fill('confirm'),
-                      ...(testCase.noSlide ? [] : (['slide'] as DeviceUiAction[])),
-                    ]
-                  : []
-              );
+            } finally {
+              clearPendingUiActions();
+            }
 
-              let sdkResult: { success: boolean; payload?: { error?: string } };
-              try {
-                const resultOrTimeout = await Promise.race([
-                  (sdkMethod as (...args: unknown[]) => Promise<unknown>)(
-                    connectId,
-                    deviceId,
-                    withMainWalletCommonParams(params, forceUseEmptyPassphrase)
-                  ),
-                  new Promise<'timeout'>(resolve => {
-                    setTimeout(() => {
-                      resolve('timeout');
-                    }, 45_000);
-                  }),
-                ]);
-                if (resultOrTimeout === 'timeout') {
-                  sdk.cancel(connectId);
-                  await sdk.getFeatures(connectId, { retryCount: 1 });
-                  sdkResult = { success: false, payload: { error: 'timeout after 45s' } };
-                } else {
-                  sdkResult = resultOrTimeout as typeof sdkResult;
-                }
-              } catch (callError) {
-                sdkResult = {
-                  success: false,
-                  payload: {
-                    error: callError instanceof Error ? callError.message : String(callError),
-                  },
-                };
-              }
-
-              // Allow device-specific overrides (e.g. Pro doesn't support DNX)
-              const coinType = (() => {
-                const path: string =
-                  ((params as Record<string, unknown>)?.path as string) ??
-                  ((
-                    (params as Record<string, unknown>)?.inputs as Array<Record<string, unknown>>
-                  )?.[0]?.path as string) ??
-                  '';
-                return path.split('/')[2]?.replace(/'/g, '') ?? '';
-              })();
-              const deviceFeats = deviceFeaturesRef.current ?? {};
-              const expected = getDeviceExpected(deviceFeats, method, coinType, expectedResult, {
-                securityChecksDisabled: false,
-              });
-
-              const actualSuccess = sdkResult.success;
-              const passed = expected ? actualSuccess : !actualSuccess;
-              const expectedLabel = expected ? 'success' : 'failure';
-              const actualLabel = actualSuccess
-                ? 'success'
-                : `failure(${sdkResult.payload?.error ?? ''})`;
-
-              results.push({
-                title,
-                method,
-                expected: expectedLabel,
-                actual: actualLabel,
-                passed,
-                duration: Date.now() - caseStart,
-              });
-            } // end else (typeof sdkMethod !== 'function')
-          } catch (error) {
-            results.push({
-              title,
-              method,
-              passed: false,
-              error: error instanceof Error ? error.message : String(error),
-              duration: Date.now() - caseStart,
-            });
-          } finally {
-            clearPendingUiActions();
+            incrementCompletedTests();
+            notifyLiveCaseUpdate('securityCheck', 'Security Check', results);
+            await delay(SDK_CASE_DELAY_MS);
           }
-
-          incrementCompletedTests();
-          notifyLiveCaseUpdate('securityCheck', 'Security Check', results);
-          await delay(SDK_CASE_DELAY_MS);
         }
       } catch (error) {
         results.push({
@@ -2928,68 +2920,67 @@ export function useAutomationTest() {
             for (const presuppose of entry.presupposes ?? []) {
               const caseStart = Date.now();
               const caseTitle = `${chain.symbol} / ${entry.method} / ${presuppose.title}`;
-              if (filterTitles && !filterTitles.has(caseTitle)) {
-                continue;
-              }
-              setPendingUiActions('chainMethodBatch', caseTitle, [
-                ...Array<DeviceUiAction>(entry.confirmCount ?? 0).fill('confirm'),
-                ...(entry.noSlide || !entry.confirmCount ? [] : (['slide'] as DeviceUiAction[])),
-              ]);
-              try {
-                const sdkMethod = (sdk as Record<string, unknown>)[entry.method];
-                if (typeof sdkMethod !== 'function') {
-                  results.push({
-                    title: caseTitle,
-                    method: entry.method,
-                    passed: false,
-                    error: `SDK method ${entry.method} not found`,
-                    duration: Date.now() - caseStart,
-                  });
-                  incrementCompletedTests();
-                  notifyLiveCaseUpdate('chainMethodBatch', 'Chain Method Batch', results);
-                } else {
-                  const sdkResult = await (
-                    sdkMethod as (
-                      ...args: unknown[]
-                    ) => Promise<{ success: boolean; payload?: { error?: string } }>
-                  )(
-                    connectId,
-                    deviceId,
-                    withMainWalletCommonParams(presuppose.value, forceUseEmptyPassphrase)
-                  );
-
-                  if (sdkResult.success) {
-                    results.push({
-                      title: caseTitle,
-                      method: entry.method,
-                      passed: true,
-                      duration: Date.now() - caseStart,
-                    });
-                  } else {
+              if (!filterTitles || filterTitles.has(caseTitle)) {
+                setPendingUiActions('chainMethodBatch', caseTitle, [
+                  ...Array<DeviceUiAction>(entry.confirmCount ?? 0).fill('confirm'),
+                  ...(entry.noSlide || !entry.confirmCount ? [] : (['slide'] as DeviceUiAction[])),
+                ]);
+                try {
+                  const sdkMethod = (sdk as Record<string, unknown>)[entry.method];
+                  if (typeof sdkMethod !== 'function') {
                     results.push({
                       title: caseTitle,
                       method: entry.method,
                       passed: false,
-                      error: sdkResult.payload?.error ?? 'unknown error',
+                      error: `SDK method ${entry.method} not found`,
                       duration: Date.now() - caseStart,
                     });
-                  }
-                }
-              } catch (err) {
-                results.push({
-                  title: caseTitle,
-                  method: entry.method,
-                  passed: false,
-                  error: err instanceof Error ? err.message : String(err),
-                  duration: Date.now() - caseStart,
-                });
-              } finally {
-                clearPendingUiActions();
-              }
+                    incrementCompletedTests();
+                    notifyLiveCaseUpdate('chainMethodBatch', 'Chain Method Batch', results);
+                  } else {
+                    const sdkResult = await (
+                      sdkMethod as (
+                        ...args: unknown[]
+                      ) => Promise<{ success: boolean; payload?: { error?: string } }>
+                    )(
+                      connectId,
+                      deviceId,
+                      withMainWalletCommonParams(presuppose.value, forceUseEmptyPassphrase)
+                    );
 
-              incrementCompletedTests();
-              notifyLiveCaseUpdate('chainMethodBatch', 'Chain Method Batch', results);
-              await delay(SDK_CASE_DELAY_MS);
+                    if (sdkResult.success) {
+                      results.push({
+                        title: caseTitle,
+                        method: entry.method,
+                        passed: true,
+                        duration: Date.now() - caseStart,
+                      });
+                    } else {
+                      results.push({
+                        title: caseTitle,
+                        method: entry.method,
+                        passed: false,
+                        error: sdkResult.payload?.error ?? 'unknown error',
+                        duration: Date.now() - caseStart,
+                      });
+                    }
+                  }
+                } catch (err) {
+                  results.push({
+                    title: caseTitle,
+                    method: entry.method,
+                    passed: false,
+                    error: err instanceof Error ? err.message : String(err),
+                    duration: Date.now() - caseStart,
+                  });
+                } finally {
+                  clearPendingUiActions();
+                }
+
+                incrementCompletedTests();
+                notifyLiveCaseUpdate('chainMethodBatch', 'Chain Method Batch', results);
+                await delay(SDK_CASE_DELAY_MS);
+              }
             }
           }
         }
@@ -3052,7 +3043,11 @@ export function useAutomationTest() {
             );
           }
         } else {
-          const preparation = await prepareStandaloneMainWallet(SDK, ctx.connectId, 'SecurityCheck');
+          const preparation = await prepareStandaloneMainWallet(
+            SDK,
+            ctx.connectId,
+            'SecurityCheck'
+          );
           forceUseEmptyPassphrase = preparation.forceUseEmptyPassphrase;
 
           setPendingUiActions('deviceSettings', 'disable safety checks', ['confirm']);
@@ -3719,10 +3714,9 @@ export function useAutomationTest() {
       const totalSuites = selectedScenarios.reduce(
         (sum, scenario) =>
           sum +
-          (
-            retrySelection
-              ? Array.from(retrySelection.get(scenario.id)?.keys() || [])
-              : buildSelectedSuites(scenario, effectiveRequestedSuites)
+          (retrySelection
+            ? Array.from(retrySelection.get(scenario.id)?.keys() || [])
+            : buildSelectedSuites(scenario, effectiveRequestedSuites)
           ).length,
         0
       );
@@ -3760,12 +3754,13 @@ export function useAutomationTest() {
         }
       }
 
+      const startLogMessage = retrySelection
+        ? '=== Retry Failed Cases Started ==='
+        : '=== Automation Test Started ===';
       addLog(
-        retrySelection
-          ? '=== Retry Failed Cases Started ==='
-          : mode === 'debug'
-            ? '=== Automation Debug Test Started ==='
-            : '=== Automation Test Started ==='
+        mode === 'debug' && !retrySelection
+          ? '=== Automation Debug Test Started ==='
+          : startLogMessage
       );
       addLog(`Scenario count: ${selectedScenarios.length}`);
       if (retrySelection) {
@@ -4116,12 +4111,13 @@ export function useAutomationTest() {
         currentPassphrase: null,
       }));
 
+      const completedLogMessage = retrySelection
+        ? '=== Retry Failed Cases Completed ==='
+        : '=== Automation Test Completed ===';
       addLog(
-        retrySelection
-          ? '=== Retry Failed Cases Completed ==='
-          : mode === 'debug'
-            ? '=== Automation Debug Test Completed ==='
-            : '=== Automation Test Completed ==='
+        mode === 'debug' && !retrySelection
+          ? '=== Automation Debug Test Completed ==='
+          : completedLogMessage
       );
       addLog(`Passed scenarios: ${report.passedScenarios}/${report.totalScenarios}`);
       addLog(`Failed scenarios: ${report.failedScenarios}`);

--- a/packages/connect-examples/expo-example/src/testTools/automationTest/useAutomationTest.ts
+++ b/packages/connect-examples/expo-example/src/testTools/automationTest/useAutomationTest.ts
@@ -29,6 +29,7 @@ import {
   automationReportAtom,
   cameraFrameAtom,
   clearLogsAtom,
+  effectiveReportAtom,
   initLiveReportAtom,
   liveReportAtom,
   phonePilotConnectionStateAtom,
@@ -122,6 +123,7 @@ const DEVICE_FLOW_ONLY_SUITES: TestSuiteType[] = ['deviceFlow'];
 type DeviceUiAction = 'confirm' | 'slide';
 
 type AutomationRunMode = 'full' | 'debug';
+type RetryCaseSelection = Map<AutomationScenario['id'], Map<TestSuiteType, Set<string>>>;
 
 interface PreparationResult {
   success: boolean;
@@ -332,7 +334,7 @@ function normalizeComparisonValue(
     ) {
       return `0x${value}`;
     }
-    if (method === 'suiGetPublicKey' && !value.startsWith('00')) {
+    if (method === 'suiGetPublicKey' && value.length === 64) {
       return `00${value}`;
     }
   }
@@ -481,6 +483,17 @@ async function fetchDeviceFeatures(
 ): Promise<Record<string, unknown> | undefined> {
   const result = await sdk.getFeatures(connectId);
   return result.success ? result.payload : undefined;
+}
+
+function withMainWalletCommonParams<T>(params: T, forceUseEmptyPassphrase: boolean): T {
+  if (!forceUseEmptyPassphrase || !params || typeof params !== 'object') {
+    return params;
+  }
+
+  return {
+    ...(params as Record<string, unknown>),
+    useEmptyPassphrase: true,
+  } as T;
 }
 
 function getBip39ImportProbeAddress(scenario: AutomationScenario): string {
@@ -683,9 +696,61 @@ function shouldStopBySuiteFailure(
   return stopOnFirstError && suiteResults.some(item => item.status === 'failed');
 }
 
+function buildFailedCaseSelection(report: TestReport): RetryCaseSelection {
+  const selection: RetryCaseSelection = new Map();
+
+  report.scenarioResults.forEach(scenario => {
+    scenario.suiteResults.forEach(suite => {
+      const failedTitles = suite.results
+        .filter(item => !item.passed && !item.skipped)
+        .map(item => item.title);
+
+      if (failedTitles.length === 0) {
+        return;
+      }
+
+      const suiteSelection = selection.get(scenario.scenarioId) ?? new Map();
+      suiteSelection.set(suite.suiteType, new Set(failedTitles));
+      selection.set(scenario.scenarioId, suiteSelection);
+    });
+  });
+
+  return selection;
+}
+
+function getRetrySuiteFilter(
+  retrySelection: RetryCaseSelection | undefined,
+  scenarioId: AutomationScenario['id'],
+  suiteType: TestSuiteType
+): Set<string> | undefined {
+  return retrySelection?.get(scenarioId)?.get(suiteType);
+}
+
+function countRetrySelectionTests(retrySelection: RetryCaseSelection): number {
+  let total = 0;
+  retrySelection.forEach(suiteSelection => {
+    suiteSelection.forEach(caseTitles => {
+      total += caseTitles.size;
+    });
+  });
+  return total;
+}
+
+function hasMatchingRetryTitle(
+  filterTitles: Set<string> | undefined,
+  predicate: (title: string) => boolean
+): boolean {
+  if (!filterTitles) {
+    return true;
+  }
+
+  return Array.from(filterTitles).some(predicate);
+}
+
 export function useAutomationTest() {
   const [connectionState, setConnectionState] = useAtom(phonePilotConnectionStateAtom);
   const config = useAtomValue(automationConfigAtom);
+  const currentReport = useAtomValue(effectiveReportAtom);
   const [progress, setProgress] = useAtom(automationProgressAtom);
   const setReport = useSetAtom(automationReportAtom);
   const setLiveReport = useSetAtom(liveReportAtom);
@@ -1381,6 +1446,33 @@ export function useAutomationTest() {
     [addLog, ensurePassphraseState, notifyLiveCaseUpdate, setProgress]
   );
 
+  const prepareStandaloneMainWallet = useCallback(
+    async (
+      sdk: CoreApi,
+      connectId: string,
+      suiteLabel: 'SecurityCheck' | 'ChainMethodBatch'
+    ): Promise<{ forceUseEmptyPassphrase: boolean }> => {
+      const featuresBefore = await fetchDeviceFeatures(sdk, connectId);
+      let featuresAfter = featuresBefore;
+
+      if (featuresBefore?.passphrase_protection) {
+        addLog(`[${suiteLabel}] Disabling passphrase_protection`);
+        await sdk.deviceSettings(connectId, { usePassphrase: false });
+        featuresAfter = await fetchDeviceFeatures(sdk, connectId);
+      }
+
+      const forceUseEmptyPassphrase = featuresAfter?.passphrase_protection === true;
+      if (forceUseEmptyPassphrase) {
+        addLog(
+          `[${suiteLabel}] passphrase_protection is still enabled; forcing useEmptyPassphrase for main-wallet SDK calls`
+        );
+      }
+
+      return { forceUseEmptyPassphrase };
+    },
+    [addLog]
+  );
+
   const cleanupPassphraseLoop = useCallback(() => {
     // Flush any pending live update before closing the suite
     flushLiveUpdate();
@@ -1558,7 +1650,8 @@ export function useAutomationTest() {
       sdk: CoreApi,
       connectId: string,
       deviceId: string,
-      selectedPassphraseVariants: PassphraseVariantId[]
+      selectedPassphraseVariants: PassphraseVariantId[],
+      filterTitles?: Set<string>
     ): Promise<TestSuiteResult> => {
       updateSuiteProgress(suiteType, scenario);
       const startedAt = Date.now();
@@ -1574,9 +1667,17 @@ export function useAutomationTest() {
       }
 
       const suiteName = getSuiteName(suiteType);
-      const expectedTotal = countSdkCasePaths(scenario, suiteType, selectedPassphraseVariants);
+      const expectedTotal = filterTitles?.size ?? countSdkCasePaths(scenario, suiteType, selectedPassphraseVariants);
       const results: TestCaseResult[] = [];
       for (const slip39Case of slip39Cases) {
+        if (
+          !hasMatchingRetryTitle(
+            filterTitles,
+            title => title.startsWith(`${slip39Case.id} / `)
+          )
+        ) {
+          continue;
+        }
         // Fetch fresh features per iteration to avoid stale passphrase_protection state
         const deviceFeatures = await fetchDeviceFeatures(sdk, connectId);
         const ppResult = await preparePassphraseIteration(
@@ -1600,6 +1701,10 @@ export function useAutomationTest() {
             for (const expectedPath of expectedPaths) {
               if (!runningRef.current) {
                 break;
+              }
+              const caseTitle = `${slip39Case.id} / ${methodData.name || methodData.method} / ${expectedPath}`;
+              if (filterTitles && !filterTitles.has(caseTitle)) {
+                continue;
               }
               const caseResult = await runSdkMethodCase(
                 sdk,
@@ -1756,7 +1861,8 @@ export function useAutomationTest() {
       sdk: CoreApi,
       connectId: string,
       deviceId: string,
-      selectedPassphraseVariants: PassphraseVariantId[]
+      selectedPassphraseVariants: PassphraseVariantId[],
+      filterTitles?: Set<string>
     ): Promise<TestSuiteResult> => {
       updateSuiteProgress(suiteType, scenario);
       const startedAt = Date.now();
@@ -1772,10 +1878,18 @@ export function useAutomationTest() {
       }
 
       const suiteName = getSuiteName(suiteType);
-      const expectedTotal = countSdkCasePaths(scenario, suiteType, selectedPassphraseVariants);
+      const expectedTotal = filterTitles?.size ?? countSdkCasePaths(scenario, suiteType, selectedPassphraseVariants);
 
       const results: TestCaseResult[] = [];
       for (const bip39Case of bip39Cases) {
+        if (
+          !hasMatchingRetryTitle(
+            filterTitles,
+            title => title.startsWith(`${bip39Case.id} / `)
+          )
+        ) {
+          continue;
+        }
         // Fetch fresh features per iteration to avoid stale passphrase_protection state
         const deviceFeatures2 = await fetchDeviceFeatures(sdk, connectId);
         const ppResult = await preparePassphraseIteration(
@@ -1796,6 +1910,10 @@ export function useAutomationTest() {
             for (const expectedPath of expectedPaths) {
               if (!runningRef.current) {
                 break;
+              }
+              const caseTitle = `${bip39Case.id} / ${methodCase.name || methodCase.method} / ${expectedPath}`;
+              if (filterTitles && !filterTitles.has(caseTitle)) {
+                continue;
               }
               const caseResult = await runAutomationSdkBatchCase(
                 sdk,
@@ -1839,7 +1957,8 @@ export function useAutomationTest() {
       connectId: string,
       deviceId: string,
       selectedPassphraseVariants: PassphraseVariantId[],
-      mnemonicStoreResult: MnemonicStoreResult | null
+      mnemonicStoreResult: MnemonicStoreResult | null,
+      filterTitles?: Set<string>
     ): Promise<TestSuiteResult> => {
       updateSuiteProgress(suiteType, scenario);
       const startedAt = Date.now();
@@ -1860,12 +1979,15 @@ export function useAutomationTest() {
           : BIP39_CREATE_PUBKEY_PROBES;
 
       const suiteName = getSuiteName(suiteType);
-      const expectedTotal = countSdkCasePaths(scenario, suiteType, selectedPassphraseVariants);
+      const expectedTotal = filterTitles?.size ?? countSdkCasePaths(scenario, suiteType, selectedPassphraseVariants);
 
       const results: TestCaseResult[] = [];
       for (const variantId of selectedPassphraseVariants) {
         if (!runningRef.current) {
           break;
+        }
+        if (!hasMatchingRetryTitle(filterTitles, title => title.endsWith(` / ${variantId}`))) {
+          continue;
         }
 
         const passphraseLiteral = getScenarioPassphraseLiteral(scenario, variantId);
@@ -1889,6 +2011,10 @@ export function useAutomationTest() {
           const passphraseDisplay = formatPassphraseDisplay(passphraseLiteral);
           const seed = mnemonicToSeed(mnemonicWords.join(' '), passphraseLiteral);
           for (const probe of probes) {
+            const caseTitle = `${scenario.id} / ${probe.caseName} / ${probe.path} / ${variantId}`;
+            if (filterTitles && !filterTitles.has(caseTitle)) {
+              continue;
+            }
             const startedAtCase = Date.now();
             let expected = '';
 
@@ -1924,7 +2050,7 @@ export function useAutomationTest() {
 
               if (!result.success) {
                 results.push({
-                  title: `${scenario.id} / ${probe.caseName} / ${probe.path} / ${variantId}`,
+                  title: caseTitle,
                   method: probe.method,
                   expected,
                   actual: '',
@@ -1953,7 +2079,7 @@ export function useAutomationTest() {
                   addLog(`  actual:   ${actual}`);
                 }
                 results.push({
-                  title: `${scenario.id} / ${probe.caseName} / ${probe.path} / ${variantId}`,
+                  title: caseTitle,
                   method: probe.method,
                   expected,
                   actual,
@@ -1968,7 +2094,7 @@ export function useAutomationTest() {
               }
             } catch (error) {
               results.push({
-                title: `${scenario.id} / ${probe.caseName} / ${probe.path} / ${variantId}`,
+                title: caseTitle,
                 method: probe.method,
                 expected,
                 actual: '',
@@ -2012,7 +2138,8 @@ export function useAutomationTest() {
       connectId: string,
       deviceId: string,
       selectedPassphraseVariants: PassphraseVariantId[],
-      mnemonicStoreResult: MnemonicStoreResult | null
+      mnemonicStoreResult: MnemonicStoreResult | null,
+      filterTitles?: Set<string>
     ): Promise<TestSuiteResult> => {
       updateSuiteProgress(suiteType, scenario);
       const startedAt = Date.now();
@@ -2069,12 +2196,17 @@ export function useAutomationTest() {
       }
 
       const suiteName = getSuiteName(suiteType);
-      const expectedTotal = countSdkCasePaths(scenario, suiteType, variantIds);
+      const expectedTotal = filterTitles?.size ?? countSdkCasePaths(scenario, suiteType, variantIds);
 
       const results: TestCaseResult[] = [];
       for (const variantId of variantIds) {
         if (!runningRef.current) {
           break;
+        }
+        if (
+          !hasMatchingRetryTitle(filterTitles, title => title.includes(` / ${variantId} / `))
+        ) {
+          continue;
         }
 
         const passphraseLiteral = getScenarioPassphraseLiteral(scenario, variantId);
@@ -2104,6 +2236,12 @@ export function useAutomationTest() {
             for (const expectedPath of expectedPaths) {
               if (!runningRef.current) {
                 break;
+              }
+              const caseTitle = `${scenario.id} / ${
+                methodData.name || methodData.method
+              } / ${variantId} / ${expectedPath}`;
+              if (filterTitles && !filterTitles.has(caseTitle)) {
+                continue;
               }
 
               const startedAtCase = Date.now();
@@ -2170,9 +2308,7 @@ export function useAutomationTest() {
 
                 if (!sdkResult.success) {
                   results.push({
-                    title: `${scenario.id} / ${
-                      methodData.name || methodData.method
-                    } / ${variantId} / ${expectedPath}`,
+                    title: caseTitle,
                     method: methodData.method,
                     expected,
                     actual: '',
@@ -2204,9 +2340,7 @@ export function useAutomationTest() {
                     addLog(`  actual:   ${actual}`);
                   }
                   results.push({
-                    title: `${scenario.id} / ${
-                      methodData.name || methodData.method
-                    } / ${variantId} / ${expectedPath}`,
+                    title: caseTitle,
                     method: methodData.method,
                     expected,
                     actual,
@@ -2221,9 +2355,7 @@ export function useAutomationTest() {
                 }
               } catch (error) {
                 results.push({
-                  title: `${scenario.id} / ${
-                    methodData.name || methodData.method
-                  } / ${variantId} / ${expectedPath}`,
+                  title: caseTitle,
                   method: methodData.method,
                   expected,
                   actual: '',
@@ -2265,7 +2397,8 @@ export function useAutomationTest() {
       scenario: AutomationScenario,
       sdk: CoreApi,
       connectId: string,
-      deviceId: string
+      deviceId: string,
+      filterTitles?: Set<string>
     ): Promise<TestSuiteResult> => {
       updateSuiteProgress('specialPassphrase', scenario);
       const startedAt = Date.now();
@@ -2310,6 +2443,11 @@ export function useAutomationTest() {
         }
 
         for (const passphrase of specialPassphrases) {
+          if (
+            !hasMatchingRetryTitle(filterTitles, title => title.endsWith(`「${passphrase}」`))
+          ) {
+            continue;
+          }
           currentPassphraseRef.current = passphrase;
           addLog(`Testing special passphrase: 「${passphrase}」`);
 
@@ -2336,12 +2474,16 @@ export function useAutomationTest() {
                 break;
               }
 
+              const caseTitle = `${method} / 「${passphrase}」`;
+              if (filterTitles && !filterTitles.has(caseTitle)) {
+                continue;
+              }
               const caseStart = Date.now();
               try {
                 const mockFn = (mockDevice as Record<string, unknown>)[method];
                 if (typeof mockFn !== 'function') {
                   results.push({
-                    title: `${method} / 「${passphrase}」`,
+                    title: caseTitle,
                     method,
                     passed: false,
                     error: `mockDevice.${method} not found`,
@@ -2360,7 +2502,7 @@ export function useAutomationTest() {
                   const sdkMethod = (sdk as Record<string, unknown>)[method];
                   if (typeof sdkMethod !== 'function') {
                     results.push({
-                      title: `${method} / 「${passphrase}」`,
+                      title: caseTitle,
                       method,
                       expected,
                       passed: false,
@@ -2392,7 +2534,7 @@ export function useAutomationTest() {
                             `[EXPECTED_FAIL] ${method} / 「${passphrase}」 — device does not support this method`
                           );
                           results.push({
-                            title: `${method} / 「${passphrase}」`,
+                            title: caseTitle,
                             method,
                             expected: '(expected failure)',
                             actual: sdkResult.payload?.error || 'SDK call failed',
@@ -2406,7 +2548,7 @@ export function useAutomationTest() {
                       }
                       if (!handledAsExpectedFail) {
                         results.push({
-                          title: `${method} / 「${passphrase}」`,
+                          title: caseTitle,
                           method,
                           expected,
                           passed: false,
@@ -2426,7 +2568,7 @@ export function useAutomationTest() {
                       }
 
                       results.push({
-                        title: `${method} / 「${passphrase}」`,
+                        title: caseTitle,
                         method,
                         expected,
                         actual,
@@ -2438,8 +2580,8 @@ export function useAutomationTest() {
                   } // end else (typeof sdkMethod !== 'function')
                 } // end else (typeof mockFn !== 'function')
               } catch (error) {
-                results.push({
-                  title: `${method} / 「${passphrase}」`,
+                    results.push({
+                      title: caseTitle,
                   method,
                   passed: false,
                   error: error instanceof Error ? error.message : String(error),
@@ -2602,20 +2744,23 @@ export function useAutomationTest() {
   );
 
   const runSecurityCheckSuite = useCallback(
-    async (sdk: CoreApi, connectId: string, deviceId: string): Promise<TestSuiteResult> => {
+    async (
+      sdk: CoreApi,
+      connectId: string,
+      deviceId: string,
+      filterTitles?: Set<string>
+    ): Promise<TestSuiteResult> => {
       const startedAt = Date.now();
       const results: TestCaseResult[] = [];
       addLog('[SecurityCheck] Starting blind signature security check suite');
       setupUIListener(sdk, executeNextPendingUiAction);
 
       try {
-        // Disable passphrase_protection and set safetyChecks: 0 (strict).
-        // The device first requires a button confirm, then a final slide confirm.
-        const featuresBeforeCheck = await fetchDeviceFeatures(sdk, connectId);
-        if (featuresBeforeCheck?.passphrase_protection) {
-          addLog('[SecurityCheck] Disabling passphrase_protection');
-          await sdk.deviceSettings(connectId, { usePassphrase: false });
-        }
+        const { forceUseEmptyPassphrase } = await prepareStandaloneMainWallet(
+          sdk,
+          connectId,
+          'SecurityCheck'
+        );
         setPendingUiActions('deviceSettings', 'disable safety checks', ['confirm']);
         // @ts-expect-error safetyChecks not in type definitions yet
         await sdk.deviceSettings(connectId, { safetyChecks: 0 });
@@ -2625,6 +2770,9 @@ export function useAutomationTest() {
         addLog(`[SecurityCheck] Running ${testCases.length} test cases`);
 
         for (const testCase of testCases) {
+          if (filterTitles && !filterTitles.has(testCase.title)) {
+            continue;
+          }
           const caseStart = Date.now();
           const { method, params, expect: expectedResult, title } = testCase;
 
@@ -2658,7 +2806,7 @@ export function useAutomationTest() {
                   (sdkMethod as (...args: unknown[]) => Promise<unknown>)(
                     connectId,
                     deviceId,
-                    params
+                    withMainWalletCommonParams(params, forceUseEmptyPassphrase)
                   ),
                   new Promise<'timeout'>(resolve => {
                     setTimeout(() => {
@@ -2749,24 +2897,38 @@ export function useAutomationTest() {
       executeNextPendingUiAction,
       incrementCompletedTests,
       notifyLiveCaseUpdate,
+      prepareStandaloneMainWallet,
       setPendingUiActions,
       setupUIListener,
     ]
   );
 
   const runChainMethodBatchSuite = useCallback(
-    async (sdk: CoreApi, connectId: string, deviceId: string): Promise<TestSuiteResult> => {
+    async (
+      sdk: CoreApi,
+      connectId: string,
+      deviceId: string,
+      filterTitles?: Set<string>
+    ): Promise<TestSuiteResult> => {
       const startedAt = Date.now();
       const results: TestCaseResult[] = [];
       addLog('[ChainMethodBatch] Starting chain method batch suite');
       setupUIListener(sdk, executeNextPendingUiAction);
 
       try {
+        const { forceUseEmptyPassphrase } = await prepareStandaloneMainWallet(
+          sdk,
+          connectId,
+          'ChainMethodBatch'
+        );
         for (const chain of chainTestData) {
           for (const entry of chain.data) {
             for (const presuppose of entry.presupposes ?? []) {
               const caseStart = Date.now();
               const caseTitle = `${chain.symbol} / ${entry.method} / ${presuppose.title}`;
+              if (filterTitles && !filterTitles.has(caseTitle)) {
+                continue;
+              }
               setPendingUiActions('chainMethodBatch', caseTitle, [
                 ...Array<DeviceUiAction>(entry.confirmCount ?? 0).fill('confirm'),
                 ...(entry.noSlide || !entry.confirmCount ? [] : (['slide'] as DeviceUiAction[])),
@@ -2788,7 +2950,11 @@ export function useAutomationTest() {
                     sdkMethod as (
                       ...args: unknown[]
                     ) => Promise<{ success: boolean; payload?: { error?: string } }>
-                  )(connectId, deviceId, presuppose.value);
+                  )(
+                    connectId,
+                    deviceId,
+                    withMainWalletCommonParams(presuppose.value, forceUseEmptyPassphrase)
+                  );
 
                   if (sdkResult.success) {
                     results.push({
@@ -2850,6 +3016,7 @@ export function useAutomationTest() {
       executeNextPendingUiAction,
       incrementCompletedTests,
       notifyLiveCaseUpdate,
+      prepareStandaloneMainWallet,
       setPendingUiActions,
       setupUIListener,
     ]
@@ -2871,15 +3038,20 @@ export function useAutomationTest() {
         const preparedContext = singleSecurityCheckPreparedRef.current;
         const canReusePreparation =
           preparedContext?.connectId === ctx.connectId && preparedContext.deviceId === ctx.deviceId;
+        let forceUseEmptyPassphrase = false;
 
         if (canReusePreparation) {
           addLog('[SecurityCheck] Reusing existing single-case device preparation');
-        } else {
-          const featuresBeforeCheck = await fetchDeviceFeatures(SDK, ctx.connectId);
-          if (featuresBeforeCheck?.passphrase_protection) {
-            addLog('[SecurityCheck] Disabling passphrase_protection');
-            await SDK.deviceSettings(ctx.connectId, { usePassphrase: false });
+          const featuresAfterPreparation = await fetchDeviceFeatures(SDK, ctx.connectId);
+          forceUseEmptyPassphrase = featuresAfterPreparation?.passphrase_protection === true;
+          if (forceUseEmptyPassphrase) {
+            addLog(
+              '[SecurityCheck] passphrase_protection remains enabled; forcing useEmptyPassphrase for this case'
+            );
           }
+        } else {
+          const preparation = await prepareStandaloneMainWallet(SDK, ctx.connectId, 'SecurityCheck');
+          forceUseEmptyPassphrase = preparation.forceUseEmptyPassphrase;
 
           setPendingUiActions('deviceSettings', 'disable safety checks', ['confirm']);
           // @ts-expect-error safetyChecks not in type definitions yet
@@ -2918,7 +3090,7 @@ export function useAutomationTest() {
               (sdkMethod as (...args: unknown[]) => Promise<unknown>)(
                 ctx.connectId,
                 ctx.deviceId,
-                testCase.params
+                withMainWalletCommonParams(testCase.params, forceUseEmptyPassphrase)
               ),
               new Promise<'timeout'>(resolve => {
                 setTimeout(() => {
@@ -2991,6 +3163,7 @@ export function useAutomationTest() {
       clearPendingUiActions,
       executeNextPendingUiAction,
       finalizeSingleSdkRun,
+      prepareStandaloneMainWallet,
       prepareSingleSdkRun,
       setPendingUiActions,
       setupUIListener,
@@ -3010,6 +3183,11 @@ export function useAutomationTest() {
       addLog(`[Single][ChainMethodBatch] ${testCase.title}`);
 
       try {
+        const { forceUseEmptyPassphrase } = await prepareStandaloneMainWallet(
+          SDK,
+          ctx.connectId,
+          'ChainMethodBatch'
+        );
         setPendingUiActions('chainMethodBatch', testCase.title, [
           ...Array<DeviceUiAction>(testCase.confirmCount).fill('confirm'),
           ...Array<DeviceUiAction>(testCase.slideCount).fill('slide'),
@@ -3028,7 +3206,11 @@ export function useAutomationTest() {
             sdkMethod as (
               ...args: unknown[]
             ) => Promise<{ success: boolean; payload?: { error?: string } }>
-          )(ctx.connectId, ctx.deviceId, testCase.params);
+          )(
+            ctx.connectId,
+            ctx.deviceId,
+            withMainWalletCommonParams(testCase.params, forceUseEmptyPassphrase)
+          );
 
           results.push({
             title: testCase.title,
@@ -3065,6 +3247,7 @@ export function useAutomationTest() {
       clearPendingUiActions,
       executeNextPendingUiAction,
       finalizeSingleSdkRun,
+      prepareStandaloneMainWallet,
       prepareSingleSdkRun,
       setPendingUiActions,
       setupUIListener,
@@ -3079,7 +3262,8 @@ export function useAutomationTest() {
       sdk: CoreApi,
       connectId: string,
       deviceId: string,
-      mnemonicStoreResult: MnemonicStoreResult | null
+      mnemonicStoreResult: MnemonicStoreResult | null,
+      retrySelection?: RetryCaseSelection
     ): Promise<TestSuiteResult[]> => {
       const nextSuiteResults = [...suiteResults];
 
@@ -3095,7 +3279,8 @@ export function useAutomationTest() {
                 sdk,
                 connectId,
                 deviceId,
-                config.passphraseVariants
+                config.passphraseVariants,
+                getRetrySuiteFilter(retrySelection, scenario.id, 'sdkAddressBatch')
               )
             : await runBip39CreateDynamicSuite(
                 'sdkAddressBatch',
@@ -3104,7 +3289,8 @@ export function useAutomationTest() {
                 connectId,
                 deviceId,
                 config.passphraseVariants,
-                mnemonicStoreResult
+                mnemonicStoreResult,
+                getRetrySuiteFilter(retrySelection, scenario.id, 'sdkAddressBatch')
               );
         const slip39AddressResult =
           scenario.flowType === 'create'
@@ -3115,7 +3301,8 @@ export function useAutomationTest() {
                 connectId,
                 deviceId,
                 config.passphraseVariants,
-                mnemonicStoreResult
+                mnemonicStoreResult,
+                getRetrySuiteFilter(retrySelection, scenario.id, 'sdkAddressBatch')
               )
             : await runSlip39SdkSuite(
                 'sdkAddressBatch',
@@ -3123,7 +3310,8 @@ export function useAutomationTest() {
                 sdk,
                 connectId,
                 deviceId,
-                config.passphraseVariants
+                config.passphraseVariants,
+                getRetrySuiteFilter(retrySelection, scenario.id, 'sdkAddressBatch')
               );
         const sdkAddressResult =
           scenario.walletType === 'bip39' ? bip39AddressResult : slip39AddressResult;
@@ -3146,7 +3334,8 @@ export function useAutomationTest() {
                 sdk,
                 connectId,
                 deviceId,
-                config.passphraseVariants
+                config.passphraseVariants,
+                getRetrySuiteFilter(retrySelection, scenario.id, 'sdkPubkeyBatch')
               )
             : await runBip39CreateDynamicSuite(
                 'sdkPubkeyBatch',
@@ -3155,7 +3344,8 @@ export function useAutomationTest() {
                 connectId,
                 deviceId,
                 config.passphraseVariants,
-                mnemonicStoreResult
+                mnemonicStoreResult,
+                getRetrySuiteFilter(retrySelection, scenario.id, 'sdkPubkeyBatch')
               );
         const slip39PubkeyResult =
           scenario.flowType === 'create'
@@ -3166,7 +3356,8 @@ export function useAutomationTest() {
                 connectId,
                 deviceId,
                 config.passphraseVariants,
-                mnemonicStoreResult
+                mnemonicStoreResult,
+                getRetrySuiteFilter(retrySelection, scenario.id, 'sdkPubkeyBatch')
               )
             : await runSlip39SdkSuite(
                 'sdkPubkeyBatch',
@@ -3174,7 +3365,8 @@ export function useAutomationTest() {
                 sdk,
                 connectId,
                 deviceId,
-                config.passphraseVariants
+                config.passphraseVariants,
+                getRetrySuiteFilter(retrySelection, scenario.id, 'sdkPubkeyBatch')
               );
         const sdkPubkeyResult =
           scenario.walletType === 'bip39' ? bip39PubkeyResult : slip39PubkeyResult;
@@ -3194,7 +3386,8 @@ export function useAutomationTest() {
           scenario,
           sdk,
           connectId,
-          deviceId
+          deviceId,
+          getRetrySuiteFilter(retrySelection, scenario.id, 'specialPassphrase')
         );
         nextSuiteResults.push(specialPassphraseResult);
         if (liveScenarioCtxRef.current) {
@@ -3208,7 +3401,12 @@ export function useAutomationTest() {
         scenario.supportedSuites.includes('securityCheck') &&
         !shouldStopBySuiteFailure(config.stopOnFirstError, nextSuiteResults)
       ) {
-        const securityCheckResult = await runSecurityCheckSuite(sdk, connectId, deviceId);
+        const securityCheckResult = await runSecurityCheckSuite(
+          sdk,
+          connectId,
+          deviceId,
+          getRetrySuiteFilter(retrySelection, scenario.id, 'securityCheck')
+        );
         nextSuiteResults.push(securityCheckResult);
         if (liveScenarioCtxRef.current) {
           liveScenarioCtxRef.current.completedSuiteResults = [...nextSuiteResults];
@@ -3221,7 +3419,12 @@ export function useAutomationTest() {
         scenario.supportedSuites.includes('chainMethodBatch') &&
         !shouldStopBySuiteFailure(config.stopOnFirstError, nextSuiteResults)
       ) {
-        const chainMethodBatchResult = await runChainMethodBatchSuite(sdk, connectId, deviceId);
+        const chainMethodBatchResult = await runChainMethodBatchSuite(
+          sdk,
+          connectId,
+          deviceId,
+          getRetrySuiteFilter(retrySelection, scenario.id, 'chainMethodBatch')
+        );
         nextSuiteResults.push(chainMethodBatchResult);
         if (liveScenarioCtxRef.current) {
           liveScenarioCtxRef.current.completedSuiteResults = [...nextSuiteResults];
@@ -3502,7 +3705,7 @@ export function useAutomationTest() {
   );
 
   const runAutomation = useCallback(
-    async (mode: AutomationRunMode): Promise<void> => {
+    async (mode: AutomationRunMode, retrySelection?: RetryCaseSelection): Promise<void> => {
       if (runningRef.current) {
         addLog('Automation is already running');
         return;
@@ -3539,24 +3742,33 @@ export function useAutomationTest() {
         config.devicePreparationMode === 'deviceFlowOnly'
           ? DEVICE_FLOW_ONLY_SUITES
           : config.testSuites;
-      const selectedScenarios = buildEffectiveSelectedScenarios(
-        config.scenarioIds,
-        effectiveRequestedSuites
-      );
+      const selectedScenarios = retrySelection
+        ? currentReport?.scenarioResults
+            .filter(scenarioResult => retrySelection.has(scenarioResult.scenarioId))
+            .map(scenarioResult => getAutomationScenario(scenarioResult.scenarioId)) || []
+        : buildEffectiveSelectedScenarios(config.scenarioIds, effectiveRequestedSuites);
       const totalSuites = selectedScenarios.reduce(
-        (sum, scenario) => sum + buildSelectedSuites(scenario, effectiveRequestedSuites).length,
-        0
-      );
-      const totalTests = selectedScenarios.reduce(
         (sum, scenario) =>
           sum +
-          countScenarioTotalTests(
-            scenario,
-            buildSelectedSuites(scenario, effectiveRequestedSuites),
-            config.passphraseVariants
-          ),
+          (
+            retrySelection
+              ? Array.from(retrySelection.get(scenario.id)?.keys() || [])
+              : buildSelectedSuites(scenario, effectiveRequestedSuites)
+          ).length,
         0
       );
+      const totalTests = retrySelection
+        ? countRetrySelectionTests(retrySelection)
+        : selectedScenarios.reduce(
+            (sum, scenario) =>
+              sum +
+              countScenarioTotalTests(
+                scenario,
+                buildSelectedSuites(scenario, effectiveRequestedSuites),
+                config.passphraseVariants
+              ),
+            0
+          );
       const { connectId } = selectedDevice;
       const startTime = Date.now();
       initLiveReport({ totalScenarios: selectedScenarios.length, startTime });
@@ -3580,11 +3792,16 @@ export function useAutomationTest() {
       }
 
       addLog(
-        mode === 'debug'
-          ? '=== Automation Debug Test Started ==='
-          : '=== Automation Test Started ==='
+        retrySelection
+          ? '=== Retry Failed Cases Started ==='
+          : mode === 'debug'
+            ? '=== Automation Debug Test Started ==='
+            : '=== Automation Test Started ==='
       );
       addLog(`Scenario count: ${selectedScenarios.length}`);
+      if (retrySelection) {
+        addLog(`Retry failed cases: ${totalTests}`);
+      }
       addLog(`Device preparation mode: ${config.devicePreparationMode}`);
       if (health) {
         addLog(`PhonePilot MCP ready: ${health.mcpReady ? 'yes' : 'no'}`);
@@ -3638,7 +3855,9 @@ export function useAutomationTest() {
             `\n--- Scenario ${scenarioIndex + 1}/${selectedScenarios.length}: ${scenario.title} ---`
           );
           // deviceFlowOnly: only run deviceFlow suite regardless of testSuites config
-          const selectedSuites = buildSelectedSuites(scenario, effectiveRequestedSuites);
+          const selectedSuites = retrySelection
+            ? Array.from(retrySelection.get(scenario.id)?.keys() || [])
+            : buildSelectedSuites(scenario, effectiveRequestedSuites);
           const scenarioStartedAt = Date.now();
           liveScenarioCtxRef.current = {
             scenario,
@@ -3697,7 +3916,8 @@ export function useAutomationTest() {
                 SDK,
                 connectId,
                 debugRunContext.deviceId,
-                debugRunContext.mnemonicStoreResult
+                debugRunContext.mnemonicStoreResult,
+                retrySelection
               );
               scenarioReport = buildScenarioReport(
                 scenario,
@@ -3857,7 +4077,8 @@ export function useAutomationTest() {
                       SDK,
                       connectId,
                       deviceId,
-                      preparation.mnemonicStoreResult
+                      preparation.mnemonicStoreResult,
+                      retrySelection
                     );
                   }
 
@@ -3927,9 +4148,11 @@ export function useAutomationTest() {
       }));
 
       addLog(
-        mode === 'debug'
-          ? '=== Automation Debug Test Completed ==='
-          : '=== Automation Test Completed ==='
+        retrySelection
+          ? '=== Retry Failed Cases Completed ==='
+          : mode === 'debug'
+            ? '=== Automation Debug Test Completed ==='
+            : '=== Automation Test Completed ==='
       );
       addLog(`Passed scenarios: ${report.passedScenarios}/${report.totalScenarios}`);
       addLog(`Failed scenarios: ${report.failedScenarios}`);
@@ -3948,6 +4171,7 @@ export function useAutomationTest() {
       executeScenarioPreparation,
       markScenarioCompleted,
       markSuiteCompleted,
+      currentReport,
       refreshDeviceId,
       refreshPhonePilotHealth,
       resetProgress,
@@ -3971,6 +4195,25 @@ export function useAutomationTest() {
     }
   }, [config.devicePreparationMode, runAutomation]);
   // Note: deviceFlowOnly uses 'full' run mode — SDK suites are skipped inside runAutomation
+
+  const retryFailedCases = useCallback(async (): Promise<void> => {
+    if (!currentReport) {
+      addLog('No report available for retry');
+      return;
+    }
+
+    const retrySelection = buildFailedCaseSelection(currentReport);
+    if (retrySelection.size === 0) {
+      addLog('No failed cases to retry');
+      return;
+    }
+
+    if (config.devicePreparationMode === 'sdkOnly') {
+      await runAutomation('debug', retrySelection);
+    } else {
+      await runAutomation('full', retrySelection);
+    }
+  }, [addLog, config.devicePreparationMode, currentReport, runAutomation]);
 
   const stopAutomation = useCallback(async () => {
     runningRef.current = false;
@@ -4016,6 +4259,7 @@ export function useAutomationTest() {
     connectPhonePilot,
     disconnectPhonePilot,
     startAutomation,
+    retryFailedCases,
     stopAutomation,
     captureFrame,
     runSingleSecurityCheckCase,

--- a/packages/connect-examples/expo-example/src/testTools/chainMethodTest/data/eth.ts
+++ b/packages/connect-examples/expo-example/src/testTools/chainMethodTest/data/eth.ts
@@ -246,7 +246,7 @@ const ethData: ChainMethodEntry[] = [
               {
                 chainId: 1,
                 address: '0x4Cd241E8d1510e30b2076397afc7508Ae59C66c9',
-                nonce: '0x5',
+                nonce: '0x6',
               },
             ],
           },

--- a/packages/connect-examples/expo-example/src/testTools/slip39Test/SLIP39BatchAddressTest.tsx
+++ b/packages/connect-examples/expo-example/src/testTools/slip39Test/SLIP39BatchAddressTest.tsx
@@ -475,7 +475,7 @@ function ExecuteView({
         const { method } = item;
         if (method === 'evmGetPublicKey' && publicKey && !publicKey.startsWith('0x')) {
           publicKey = `0x${publicKey}`;
-        } else if (method === 'suiGetPublicKey' && publicKey && !publicKey.startsWith('00')) {
+        } else if (method === 'suiGetPublicKey' && publicKey && publicKey.length === 64) {
           publicKey = `00${publicKey}`;
         }
 

--- a/packages/connect-examples/expo-example/src/views/AutomationTest/index.tsx
+++ b/packages/connect-examples/expo-example/src/views/AutomationTest/index.tsx
@@ -44,6 +44,10 @@ function AutomationTestContent() {
   const progressPercentage = useAtomValue(progressPercentageAtom);
   const report = useAtomValue(effectiveReportAtom);
   const [activeTab, setActiveTab] = useState('report');
+  const hasFailedCases =
+    report?.scenarioResults.some(scenario =>
+      scenario.suiteResults.some(suite => suite.results.some(item => !item.passed && !item.skipped))
+    ) ?? false;
 
   const downloadJson = useCallback((data: unknown, filename: string) => {
     const json = JSON.stringify(data, null, 2);
@@ -127,6 +131,17 @@ function AutomationTestContent() {
                 disabled={!canStart || isRunning}
               >
                 开始
+              </Button>
+              <Button
+                size="$3"
+                theme="red"
+                height={34}
+                borderRadius="$2"
+                paddingHorizontal="$3"
+                onPress={automation.retryFailedCases}
+                disabled={!hasFailedCases || isRunning}
+              >
+                重跑失败
               </Button>
               <Button
                 size="$3"

--- a/packages/connect-examples/expo-example/src/views/AutomationTest/index.tsx
+++ b/packages/connect-examples/expo-example/src/views/AutomationTest/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useAtom, useAtomValue } from 'jotai';
 import { Button, ScrollView, Separator, Stack, Text, XStack, YStack } from 'tamagui';
 
@@ -16,6 +16,7 @@ import {
   phonePilotConnectionStateAtom,
   progressPercentageAtom,
 } from '../../atoms/automationAtoms';
+import { STANDALONE_MODULE_SCENARIO_ID } from '../../services/phonePilotMcp/types';
 import { getConnectionColor } from './utils';
 import { ProgressBar } from './components/ProgressBar';
 import { ConnectionConfig } from './components/ConnectionConfig';
@@ -48,6 +49,17 @@ function AutomationTestContent() {
     report?.scenarioResults.some(scenario =>
       scenario.suiteResults.some(suite => suite.results.some(item => !item.passed && !item.skipped))
     ) ?? false;
+
+  useEffect(() => {
+    if (!config.scenarioIds.includes(STANDALONE_MODULE_SCENARIO_ID)) {
+      return;
+    }
+
+    setConfig(prev => ({
+      ...prev,
+      scenarioIds: prev.scenarioIds.filter(id => id !== STANDALONE_MODULE_SCENARIO_ID),
+    }));
+  }, [config.scenarioIds, setConfig]);
 
   const downloadJson = useCallback((data: unknown, filename: string) => {
     const json = JSON.stringify(data, null, 2);


### PR DESCRIPTION
## Summary
- avoid running both BIP39 and SLIP39 SDK suites before selecting the matching wallet type result
- share the address/pubkey batch suite selection logic across standalone automation flows

## Tests
- git diff --check
- yarn eslint packages/connect-examples/expo-example/src/testTools/automationTest/useAutomationTest.ts (fails: existing lint issues remain in this file outside the current diff)
- yarn tsc --noEmit --pretty false (fails: existing TypeScript parse errors in packages/hd-transport/scripts/protobuf-patches/*.js)