### PR TITLE
[codex] fix developer portal mdx comments

### DIFF
--- a/packages/connect-examples/developer-portal/content/en/hardware-sdk/index.mdx
+++ b/packages/connect-examples/developer-portal/content/en/hardware-sdk/index.mdx
@@ -163,7 +163,7 @@ import { DeviceCompatibilityTable } from '../../../components/DeviceCompatibilit
 
 - Low-level transport & message protocol (for debugging or custom adapters): [Low-Level Transport Plugin](/en/hardware-sdk/concepts/low-level-plugin)
 - Migration from the legacy `hd-web-sdk` flow: [Migration Guide](/en/hardware-sdk/legacy-guides)
-<!-- - AI agent integration via OneKey skills: [AI Agent Integration](/en/hardware-sdk/agent-integration) -->
+{/* - AI agent integration via OneKey skills: [AI Agent Integration](/en/hardware-sdk/agent-integration) */}
 
 ## Support
 

--- a/packages/connect-examples/developer-portal/content/zh/hardware-sdk/index.mdx
+++ b/packages/connect-examples/developer-portal/content/zh/hardware-sdk/index.mdx
@@ -163,7 +163,7 @@ import { DeviceCompatibilityTable } from '../../../components/DeviceCompatibilit
 
 - 底层传输与消息协议（调试 / 自定义适配器场景）：[底层传输插件](/zh/hardware-sdk/concepts/low-level-plugin)
 - 从老的 `hd-web-sdk` 方案迁移：[迁移指引](/zh/hardware-sdk/legacy-guides)
-<!-- - AI Agent 集成 OneKey skills：[AI Agent 集成](/zh/hardware-sdk/agent-integration) -->
+{/* - AI Agent 集成 OneKey skills：[AI Agent 集成](/zh/hardware-sdk/agent-integration) */}
 
 ## 支持
 


### PR DESCRIPTION
## Summary
- Replace HTML comments in the English and Chinese hardware SDK index MDX pages with MDX comments.
- Keep the AI Agent integration links hidden while making the files valid for Turbopack/MDX parsing.

## Root Cause
- Turbopack/MDX treats `<!-- ... -->` as invalid JSX-like syntax in these MDX files, causing `Unexpected character !` during `next build`.

## Validation
- `yarn install` in `packages/connect-examples/developer-portal`
- `NEXT_PUBLIC_SDK_VERSION=$(node -p "require('../../core/package.json').version") NEXT_PUBLIC_COMMIT_ID=$(git rev-parse HEAD) NEXT_PUBLIC_COMMIT_SHORT=$(git rev-parse HEAD) NEXT_PUBLIC_BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ) yarn build` in `packages/connect-examples/developer-portal`
- `git diff --check`
- Remote `Build Developer Portal` workflow passed: https://github.com/OneKeyHQ/hardware-js-sdk/actions/runs/26215435517
- PR checks passed: CodeQL, build (22), lint (22), Socket, Snyk