### PR TITLE
fix: throttle firmware upload BLE writes

### DIFF
--- a/packages/hd-transport-react-native/src/__tests__/bleStrategy.test.ts
+++ b/packages/hd-transport-react-native/src/__tests__/bleStrategy.test.ts
@@ -1,7 +1,11 @@
 import {
   hasWritableCapability,
+  isGattCongestedError,
+  resolveFirmwareUploadRetryDelay,
   resolveBleWriteMode,
+  resolveProtocolV1HighVolumePacketCapacity,
   resolveProtocolV2PacketCapacity,
+  shouldRetryFirmwareUploadWrite,
 } from '../bleStrategy';
 
 describe('React Native BLE strategy', () => {
@@ -43,5 +47,53 @@ describe('React Native BLE strategy', () => {
         mtu: 256,
       })
     ).toBe(244);
+  });
+
+  test('keeps Protocol V1 firmware upload packets aligned to 64-byte frames', () => {
+    expect(
+      resolveProtocolV1HighVolumePacketCapacity({
+        platform: 'android',
+        androidPacketLength: 192,
+        mtu: 256,
+      })
+    ).toBe(192);
+
+    expect(
+      resolveProtocolV1HighVolumePacketCapacity({
+        platform: 'android',
+        androidPacketLength: 192,
+        mtu: 100,
+      })
+    ).toBe(64);
+  });
+
+  test('does not shrink Protocol V1 firmware upload packets without negotiated Android MTU', () => {
+    expect(
+      resolveProtocolV1HighVolumePacketCapacity({
+        platform: 'android',
+        androidPacketLength: 192,
+        mtu: null,
+      })
+    ).toBe(192);
+  });
+
+  test('detects Android GATT congestion errors for firmware upload retry', () => {
+    expect(isGattCongestedError({ androidErrorCode: 143 })).toBe(true);
+    expect(isGattCongestedError({ reason: 'status 143 (GATT_CONGESTED)' })).toBe(true);
+    expect(isGattCongestedError({ androidErrorCode: 133 })).toBe(false);
+  });
+
+  test('retries firmware upload writes only within congestion retry budget', () => {
+    const error = { reason: 'status 143 (GATT_CONGESTED)' };
+
+    expect(shouldRetryFirmwareUploadWrite(error, 0, 3)).toBe(true);
+    expect(shouldRetryFirmwareUploadWrite(error, 3, 3)).toBe(false);
+    expect(shouldRetryFirmwareUploadWrite({ androidErrorCode: 133 }, 0, 3)).toBe(false);
+  });
+
+  test('uses capped exponential backoff for firmware upload retries', () => {
+    expect(resolveFirmwareUploadRetryDelay(0)).toBe(200);
+    expect(resolveFirmwareUploadRetryDelay(1)).toBe(400);
+    expect(resolveFirmwareUploadRetryDelay(10)).toBe(1200);
   });
 });

--- a/packages/hd-transport-react-native/src/bleStrategy.ts
+++ b/packages/hd-transport-react-native/src/bleStrategy.ts
@@ -1,6 +1,8 @@
 import { ANDROID_DEFAULT_MTU, ANDROID_PACKET_LENGTH, IOS_PACKET_LENGTH } from './constants';
 
 export type BlePlatform = 'ios' | 'android' | string;
+const PROTOCOL_V1_BLE_PACKET_LENGTH = 64;
+const ANDROID_GATT_CONGESTED_STATUS = 143;
 
 export type BleWriteCapability = {
   isWritableWithResponse?: boolean | null;
@@ -10,9 +12,7 @@ export type BleWriteCapability = {
 export type BleWriteMode = 'withResponse' | 'withoutResponse';
 
 export function hasWritableCapability(characteristic: BleWriteCapability) {
-  return !!(
-    characteristic.isWritableWithResponse || characteristic.isWritableWithoutResponse
-  );
+  return !!(characteristic.isWritableWithResponse || characteristic.isWritableWithoutResponse);
 }
 
 export function resolveBleWriteMode(
@@ -59,4 +59,79 @@ export function resolveProtocolV2PacketCapacity({
   }
 
   return androidPacketLength;
+}
+
+export function resolveProtocolV1HighVolumePacketCapacity({
+  platform,
+  iosPacketLength = IOS_PACKET_LENGTH,
+  androidPacketLength = ANDROID_PACKET_LENGTH,
+  mtu,
+  protocolPacketLength = PROTOCOL_V1_BLE_PACKET_LENGTH,
+}: {
+  platform: BlePlatform;
+  iosPacketLength?: number;
+  androidPacketLength?: number;
+  mtu?: number | null;
+  protocolPacketLength?: number;
+}) {
+  if (platform === 'ios') {
+    return iosPacketLength;
+  }
+
+  if (platform !== 'android' || !mtu || mtu <= ANDROID_DEFAULT_MTU) {
+    return androidPacketLength;
+  }
+
+  const attPayloadLength = Math.max(mtu - 3, protocolPacketLength);
+  const cappedLength = Math.min(androidPacketLength, attPayloadLength);
+  return Math.max(
+    protocolPacketLength,
+    Math.floor(cappedLength / protocolPacketLength) * protocolPacketLength
+  );
+}
+
+function getErrorText(error: unknown) {
+  if (!error || typeof error !== 'object') return '';
+  const maybeError = error as {
+    reason?: unknown;
+    message?: unknown;
+    name?: unknown;
+  };
+  return [maybeError.reason, maybeError.message, maybeError.name]
+    .filter(value => typeof value === 'string')
+    .join(' ');
+}
+
+export function isGattCongestedError(error: unknown) {
+  if (!error || typeof error !== 'object') return false;
+  const maybeError = error as {
+    androidErrorCode?: unknown;
+    status?: unknown;
+  };
+
+  if (
+    maybeError.androidErrorCode === ANDROID_GATT_CONGESTED_STATUS ||
+    maybeError.status === ANDROID_GATT_CONGESTED_STATUS
+  ) {
+    return true;
+  }
+
+  const text = getErrorText(error);
+  return text.includes('GATT_CONGESTED') || text.includes('status 143');
+}
+
+export function shouldRetryFirmwareUploadWrite(
+  error: unknown,
+  attempt: number,
+  maxRetries: number
+) {
+  return attempt < maxRetries && isGattCongestedError(error);
+}
+
+export function resolveFirmwareUploadRetryDelay(
+  attempt: number,
+  baseDelayMs = 200,
+  maxDelayMs = 1200
+) {
+  return Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
 }

--- a/packages/hd-transport-react-native/src/index.ts
+++ b/packages/hd-transport-react-native/src/index.ts
@@ -25,7 +25,10 @@ import { getConnectedDeviceIds, onDeviceBondState, pairDevice } from './BleManag
 import {
   hasWritableCapability,
   resolveBleWriteMode,
+  resolveFirmwareUploadRetryDelay,
+  resolveProtocolV1HighVolumePacketCapacity,
   resolveProtocolV2PacketCapacity,
+  shouldRetryFirmwareUploadWrite,
 } from './bleStrategy';
 import { subscribeBleOn } from './subscribeBleOn';
 import {
@@ -60,6 +63,10 @@ const ANDROID_NOTIFY_READY_DELAY_MS = 300;
 const HIGH_VOLUME_WRITE_BURST_SIZE = Platform.OS === 'ios' ? 4 : 6;
 const HIGH_VOLUME_WRITE_PAUSE_MS = Platform.OS === 'ios' ? 6 : 2;
 const HIGH_VOLUME_WRITE_FLUSH_DELAY_MS = Platform.OS === 'ios' ? 20 : 8;
+const FIRMWARE_UPLOAD_WRITE_BURST_SIZE = Platform.OS === 'ios' ? 4 : 6;
+const FIRMWARE_UPLOAD_WRITE_PAUSE_MS = Platform.OS === 'ios' ? 8 : 10;
+const FIRMWARE_UPLOAD_WRITE_FLUSH_DELAY_MS = Platform.OS === 'ios' ? 24 : 24;
+const FIRMWARE_UPLOAD_WRITE_MAX_RETRIES = 3;
 
 const delay = (ms: number) =>
   new Promise<void>(resolve => {
@@ -435,11 +442,7 @@ export default class ReactNativeBleTransport {
         cachedProtocol &&
         (!expectedProtocol || cachedProtocol === expectedProtocol)
       ) {
-        Log?.debug(
-          '[ReactNativeBleTransport] reuse cached BLE transport:',
-          uuid,
-          cachedProtocol
-        );
+        Log?.debug('[ReactNativeBleTransport] reuse cached BLE transport:', uuid, cachedProtocol);
         return { uuid, protocolType: cachedProtocol };
       }
 
@@ -971,10 +974,19 @@ export default class ReactNativeBleTransport {
     async function writeChunkedData(
       buffers: ByteBuffer[],
       writeFunction: (data: string) => Promise<void>,
-      onError: (e: any) => void
+      onError: (e: any) => void,
+      chunkOptions?: {
+        packetCapacity?: number;
+        burstSize?: number;
+        pauseMs?: number;
+        flushDelayMs?: number;
+      }
     ) {
-      const packetCapacity = Platform.OS === 'ios' ? IOS_PACKET_LENGTH : ANDROID_PACKET_LENGTH;
+      const packetCapacity =
+        chunkOptions?.packetCapacity ??
+        (Platform.OS === 'ios' ? IOS_PACKET_LENGTH : ANDROID_PACKET_LENGTH);
       let index = 0;
+      let packetsWritten = 0;
       let chunk = ByteBuffer.allocate(packetCapacity);
 
       while (index < buffers.length) {
@@ -986,12 +998,25 @@ export default class ReactNativeBleTransport {
           chunk.reset();
           try {
             await writeFunction(chunk.toString('base64'));
+            packetsWritten += 1;
             chunk = ByteBuffer.allocate(packetCapacity);
+            if (
+              chunkOptions?.burstSize &&
+              chunkOptions.pauseMs &&
+              packetsWritten % chunkOptions.burstSize === 0 &&
+              index < buffers.length
+            ) {
+              await delay(chunkOptions.pauseMs);
+            }
           } catch (e) {
             onError(e);
             throw ERRORS.TypedError(HardwareErrorCode.BleWriteCharacteristicError);
           }
         }
+      }
+
+      if (chunkOptions?.flushDelayMs && packetsWritten > 0) {
+        await delay(chunkOptions.flushDelayMs);
       }
     }
 
@@ -1005,14 +1030,57 @@ export default class ReactNativeBleTransport {
         }
       );
     } else if (name === 'FirmwareUpload') {
+      const packetCapacity = resolveProtocolV1HighVolumePacketCapacity({
+        platform: Platform.OS,
+        iosPacketLength: IOS_PACKET_LENGTH,
+        androidPacketLength: ANDROID_PACKET_LENGTH,
+        mtu: Platform.OS === 'android' ? transport.mtuSize : undefined,
+      });
+      Log?.debug('[ReactNativeBleTransport] FirmwareUpload write uses throttled BLE packets:', {
+        packetCapacity,
+        burstSize: FIRMWARE_UPLOAD_WRITE_BURST_SIZE,
+        pauseMs: FIRMWARE_UPLOAD_WRITE_PAUSE_MS,
+        flushDelayMs: FIRMWARE_UPLOAD_WRITE_FLUSH_DELAY_MS,
+        maxRetries: FIRMWARE_UPLOAD_WRITE_MAX_RETRIES,
+      });
+
       await writeChunkedData(
         buffers,
         async data => {
-          await transport.writeCharacteristic.writeWithoutResponse(data);
+          let attempt = 0;
+          // Retry only congestion. Other write errors should surface immediately.
+          // GATT_CONGESTED is usually transient backpressure from the Android BLE queue.
+          // eslint-disable-next-line no-constant-condition
+          while (true) {
+            try {
+              await transport.writeCharacteristic.writeWithoutResponse(data);
+              return;
+            } catch (error) {
+              if (
+                !shouldRetryFirmwareUploadWrite(error, attempt, FIRMWARE_UPLOAD_WRITE_MAX_RETRIES)
+              ) {
+                throw error;
+              }
+              const delayMs = resolveFirmwareUploadRetryDelay(attempt);
+              Log?.debug('[ReactNativeBleTransport] FirmwareUpload write retry:', {
+                attempt: attempt + 1,
+                delayMs,
+                error,
+              });
+              await delay(delayMs);
+              attempt += 1;
+            }
+          }
         },
         e => {
           this.runPromise = null;
           Log?.error('writeCharacteristic write error: ', e);
+        },
+        {
+          packetCapacity,
+          burstSize: FIRMWARE_UPLOAD_WRITE_BURST_SIZE,
+          pauseMs: FIRMWARE_UPLOAD_WRITE_PAUSE_MS,
+          flushDelayMs: FIRMWARE_UPLOAD_WRITE_FLUSH_DELAY_MS,
         }
       );
     } else {


### PR DESCRIPTION
## Summary
- throttle Protocol V1 FirmwareUpload BLE writes with burst pauses and flush delay
- retry only Android GATT_CONGESTED write failures with bounded backoff
- cap Android high-volume Protocol V1 packet size to negotiated MTU while keeping 64-byte frame alignment

## Verification
- yarn jest packages/hd-transport-react-native/src/__tests__/bleStrategy.test.ts --runInBand
- yarn eslint packages/hd-transport-react-native/src/bleStrategy.ts packages/hd-transport-react-native/src/index.ts
- yarn lerna run build --scope=@onekeyfe/hd-transport-react-native

Note: package-level lint still has pre-existing failures because it scans generated dist files and unrelated BleManager.ts issues.