### PR TITLE
fix: throttle firmware upload BLE writes

### DIFF
--- a/packages/connect-examples/electron-example/package.json
+++ b/packages/connect-examples/electron-example/package.json
@@ -2,7 +2,7 @@
   "name": "hardware-example",
   "productName": "HardwareExample",
   "executableName": "onekey-hardware-example",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "author": "OneKey",
   "description": "End-to-end encrypted workspaces for teams",
   "main": "dist/index.js",
@@ -22,7 +22,7 @@
     "ts:check": "yarn tsc --noEmit"
   },
   "dependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.27-alpha.5",
+    "@onekeyfe/hd-transport-electron": "1.1.27-alpha.6",
     "@stoprocent/noble": "2.3.16",
     "debug": "4.3.4",
     "electron-is-dev": "^3.0.1",

--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "scripts": {
     "start": "cross-env CONNECT_SRC=https://localhost:8087/ yarn expo start --dev-client",
     "android": "yarn expo run:android",
@@ -19,10 +19,10 @@
     "@noble/ed25519": "^2.1.0",
     "@noble/hashes": "^1.3.3",
     "@noble/secp256k1": "^1.7.1",
-    "@onekeyfe/hd-ble-sdk": "1.1.27-alpha.5",
-    "@onekeyfe/hd-common-connect-sdk": "1.1.27-alpha.5",
-    "@onekeyfe/hd-core": "1.1.27-alpha.5",
-    "@onekeyfe/hd-web-sdk": "1.1.27-alpha.5",
+    "@onekeyfe/hd-ble-sdk": "1.1.27-alpha.6",
+    "@onekeyfe/hd-common-connect-sdk": "1.1.27-alpha.6",
+    "@onekeyfe/hd-core": "1.1.27-alpha.6",
+    "@onekeyfe/hd-web-sdk": "1.1.27-alpha.6",
     "@onekeyfe/react-native-ble-utils": "^0.1.3",
     "@polkadot/util-crypto": "13.1.1",
     "@react-native-async-storage/async-storage": "1.21.0",

--- a/packages/connect-examples/expo-playground/package.json
+++ b/packages/connect-examples/expo-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onekey-hardware-playground",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "private": true,
   "sideEffects": [
     "app/utils/shim.js",
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0",
-    "@onekeyfe/hd-common-connect-sdk": "1.1.27-alpha.5",
-    "@onekeyfe/hd-core": "1.1.27-alpha.5",
-    "@onekeyfe/hd-shared": "1.1.27-alpha.5",
+    "@onekeyfe/hd-common-connect-sdk": "1.1.27-alpha.6",
+    "@onekeyfe/hd-core": "1.1.27-alpha.6",
+    "@onekeyfe/hd-shared": "1.1.27-alpha.6",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "description": "Core processes and APIs for communicating with OneKey hardware devices.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.27-alpha.5",
-    "@onekeyfe/hd-transport": "1.1.27-alpha.5",
+    "@onekeyfe/hd-shared": "1.1.27-alpha.6",
+    "@onekeyfe/hd-transport": "1.1.27-alpha.6",
     "axios": "1.15.2",
     "bignumber.js": "^9.0.2",
     "bytebuffer": "^5.0.1",

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.27-alpha.5",
-    "@onekeyfe/hd-shared": "1.1.27-alpha.5",
-    "@onekeyfe/hd-transport-react-native": "1.1.27-alpha.5"
+    "@onekeyfe/hd-core": "1.1.27-alpha.6",
+    "@onekeyfe/hd-shared": "1.1.27-alpha.6",
+    "@onekeyfe/hd-transport-react-native": "1.1.27-alpha.6"
   }
 }

--- a/packages/hd-cli/package.json
+++ b/packages/hd-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hardware-cli",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "description": "OneKey hardware wallet CLI for testing device communication",
   "author": "OneKey",
   "license": "Apache-2.0",
@@ -30,10 +30,10 @@
     "test": "jest"
   },
   "dependencies": {
-    "@onekeyfe/hd-common-connect-sdk": "1.1.27-alpha.5",
-    "@onekeyfe/hd-core": "1.1.27-alpha.5",
-    "@onekeyfe/hd-shared": "1.1.27-alpha.5",
-    "@onekeyfe/hd-transport-usb": "1.1.27-alpha.5",
+    "@onekeyfe/hd-common-connect-sdk": "1.1.27-alpha.6",
+    "@onekeyfe/hd-core": "1.1.27-alpha.6",
+    "@onekeyfe/hd-shared": "1.1.27-alpha.6",
+    "@onekeyfe/hd-transport-usb": "1.1.27-alpha.6",
     "commander": "^12.0.0"
   }
 }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,12 +20,12 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.27-alpha.5",
-    "@onekeyfe/hd-shared": "1.1.27-alpha.5",
-    "@onekeyfe/hd-transport-emulator": "1.1.27-alpha.5",
-    "@onekeyfe/hd-transport-http": "1.1.27-alpha.5",
-    "@onekeyfe/hd-transport-lowlevel": "1.1.27-alpha.5",
-    "@onekeyfe/hd-transport-usb": "1.1.27-alpha.5",
-    "@onekeyfe/hd-transport-web-device": "1.1.27-alpha.5"
+    "@onekeyfe/hd-core": "1.1.27-alpha.6",
+    "@onekeyfe/hd-shared": "1.1.27-alpha.6",
+    "@onekeyfe/hd-transport-emulator": "1.1.27-alpha.6",
+    "@onekeyfe/hd-transport-http": "1.1.27-alpha.6",
+    "@onekeyfe/hd-transport-lowlevel": "1.1.27-alpha.6",
+    "@onekeyfe/hd-transport-usb": "1.1.27-alpha.6",
+    "@onekeyfe/hd-transport-web-device": "1.1.27-alpha.6"
   }
 }

--- a/packages/hd-transport-electron/package.json
+++ b/packages/hd-transport-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-electron",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -25,9 +25,9 @@
     "electron-log": ">=4.0.0"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.27-alpha.5",
-    "@onekeyfe/hd-shared": "1.1.27-alpha.5",
-    "@onekeyfe/hd-transport": "1.1.27-alpha.5",
+    "@onekeyfe/hd-core": "1.1.27-alpha.6",
+    "@onekeyfe/hd-shared": "1.1.27-alpha.6",
+    "@onekeyfe/hd-transport": "1.1.27-alpha.6",
     "@stoprocent/noble": "2.3.16",
     "p-retry": "^4.6.2"
   },

--- a/packages/hd-transport-emulator/package.json
+++ b/packages/hd-transport-emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-emulator",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "description": "hardware emulator transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.27-alpha.5",
-    "@onekeyfe/hd-transport": "1.1.27-alpha.5",
+    "@onekeyfe/hd-shared": "1.1.27-alpha.6",
+    "@onekeyfe/hd-transport": "1.1.27-alpha.6",
     "axios": "1.15.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.27-alpha.5",
-    "@onekeyfe/hd-transport": "1.1.27-alpha.5",
+    "@onekeyfe/hd-shared": "1.1.27-alpha.6",
+    "@onekeyfe/hd-transport": "1.1.27-alpha.6",
     "axios": "1.15.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.27-alpha.5",
-    "@onekeyfe/hd-transport": "1.1.27-alpha.5"
+    "@onekeyfe/hd-shared": "1.1.27-alpha.6",
+    "@onekeyfe/hd-transport": "1.1.27-alpha.6"
   }
 }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,9 +19,9 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.1.27-alpha.5",
-    "@onekeyfe/hd-shared": "1.1.27-alpha.5",
-    "@onekeyfe/hd-transport": "1.1.27-alpha.5",
+    "@onekeyfe/hd-core": "1.1.27-alpha.6",
+    "@onekeyfe/hd-shared": "1.1.27-alpha.6",
+    "@onekeyfe/hd-transport": "1.1.27-alpha.6",
     "@onekeyfe/react-native-ble-utils": "^0.1.4",
     "react-native-ble-plx": "3.5.1"
   }

--- a/packages/hd-transport-react-native/src/index.ts
+++ b/packages/hd-transport-react-native/src/index.ts
@@ -38,72 +38,59 @@ const { check, buildBuffers, receiveOne, parseConfigure } = transport;
 const Log = getLogger(LoggerNames.HdBleTransport);
 
 const transportCache: Record<string, BleTransport> = {};
-const FIRMWARE_UPLOAD_WRITE_BURST_SIZE = Platform.OS === 'ios' ? 4 : 6;
+const FIRMWARE_UPLOAD_WRITE_BURST_SIZE = Platform.OS === 'ios' ? 4 : 5;
 const FIRMWARE_UPLOAD_WRITE_PAUSE_MS = Platform.OS === 'ios' ? 8 : 10;
-const FIRMWARE_UPLOAD_WRITE_FLUSH_DELAY_MS = Platform.OS === 'ios' ? 24 : 24;
-const FIRMWARE_UPLOAD_WRITE_MAX_RETRIES = 3;
-const PROTOCOL_V1_BLE_PACKET_LENGTH = 64;
-const ANDROID_DEFAULT_MTU = 23;
+const FIRMWARE_UPLOAD_WRITE_FLUSH_DELAY_MS = Platform.OS === 'ios' ? 24 : 30;
+const FIRMWARE_UPLOAD_WRITE_MAX_RETRIES = 8;
+const FIRMWARE_UPLOAD_RECONNECT_RETRY_DELAY_MS = 2000;
+const ANDROID_FIRMWARE_UPLOAD_PACKET_LENGTH = 192;
+const FIRMWARE_UPLOAD_WRITE_PACKET_CAPACITY =
+  Platform.OS === 'ios' ? IOS_PACKET_LENGTH : ANDROID_FIRMWARE_UPLOAD_PACKET_LENGTH;
 const ANDROID_GATT_CONGESTED_STATUS = 143;
+
+type FirmwareUploadWriteRetryType = 'congested' | 'reconnectable';
+type ResolvedBleCharacteristics = {
+  writeCharacteristic: Characteristic;
+  notifyCharacteristic: Characteristic;
+};
 
 const delay = (ms: number) =>
   new Promise<void>(resolve => {
     setTimeout(resolve, ms);
   });
 
-const resolveProtocolV1HighVolumePacketCapacity = ({
-  mtu,
-}: {
-  mtu?: number | null;
-}) => {
-  if (Platform.OS === 'ios') return IOS_PACKET_LENGTH;
-  if (Platform.OS !== 'android' || !mtu || mtu <= ANDROID_DEFAULT_MTU) {
-    return ANDROID_PACKET_LENGTH;
-  }
-
-  const attPayloadLength = Math.max(mtu - 3, PROTOCOL_V1_BLE_PACKET_LENGTH);
-  const cappedLength = Math.min(ANDROID_PACKET_LENGTH, attPayloadLength);
-  return Math.max(
-    PROTOCOL_V1_BLE_PACKET_LENGTH,
-    Math.floor(cappedLength / PROTOCOL_V1_BLE_PACKET_LENGTH) * PROTOCOL_V1_BLE_PACKET_LENGTH
-  );
-};
-
-const getErrorText = (error: unknown) => {
-  if (!error || typeof error !== 'object') return '';
-  const maybeError = error as {
+const getFirmwareUploadWriteRetryType = (
+  error: unknown
+): FirmwareUploadWriteRetryType | null => {
+  if (!error || typeof error !== 'object') return null;
+  const bleWriteError = error as {
+    androidErrorCode?: unknown;
+    status?: unknown;
+    errorCode?: unknown;
     reason?: unknown;
     message?: unknown;
     name?: unknown;
   };
-  return [maybeError.reason, maybeError.message, maybeError.name]
-    .filter(value => typeof value === 'string')
-    .join(' ');
-};
-
-const isGattCongestedError = (error: unknown) => {
-  if (!error || typeof error !== 'object') return false;
-  const maybeError = error as {
-    androidErrorCode?: unknown;
-    status?: unknown;
-  };
 
   if (
-    maybeError.androidErrorCode === ANDROID_GATT_CONGESTED_STATUS ||
-    maybeError.status === ANDROID_GATT_CONGESTED_STATUS
+    bleWriteError.errorCode === BleErrorCode.DeviceDisconnected ||
+    bleWriteError.errorCode === BleErrorCode.CharacteristicNotFound
   ) {
-    return true;
+    return 'reconnectable';
   }
 
-  const text = getErrorText(error);
-  return text.includes('GATT_CONGESTED') || text.includes('status 143');
-};
+  if (
+    bleWriteError.androidErrorCode === ANDROID_GATT_CONGESTED_STATUS ||
+    bleWriteError.status === ANDROID_GATT_CONGESTED_STATUS
+  ) {
+    return 'congested';
+  }
 
-const shouldRetryFirmwareUploadWrite = (
-  error: unknown,
-  attempt: number,
-  maxRetries: number
-) => attempt < maxRetries && isGattCongestedError(error);
+  const text = [bleWriteError.reason, bleWriteError.message, bleWriteError.name]
+    .filter(value => typeof value === 'string')
+    .join(' ');
+  return /GATT_CONGESTED|status\s*[:=]?\s*143/.test(text) ? 'congested' : null;
+};
 
 const resolveFirmwareUploadRetryDelay = (
   attempt: number,
@@ -176,6 +163,8 @@ export default class ReactNativeBleTransport {
 
   emitter?: EventEmitter;
 
+  firmwareUploadWriteRecoveryIds = new Set<string>();
+
   constructor(options: TransportOptions) {
     this.scanTimeout = options.scanTimeout ?? 3000;
   }
@@ -198,6 +187,142 @@ export default class ReactNativeBleTransport {
     if (this.blePlxManager) return Promise.resolve(this.blePlxManager);
     this.blePlxManager = new BlePlxManager();
     return Promise.resolve(this.blePlxManager);
+  }
+
+  async resolveCharacteristics(device: Device): Promise<ResolvedBleCharacteristics> {
+    await device.discoverAllServicesAndCharacteristics();
+    let infos = tryToGetConfiguration(device);
+    let characteristics: Characteristic[] | undefined;
+
+    if (!infos) {
+      for (const serviceUuid of getBluetoothServiceUuids()) {
+        try {
+          characteristics = await device.characteristicsForService(serviceUuid);
+          infos = getInfosForServiceUuid(serviceUuid, 'classic');
+          break;
+        } catch (e) {
+          Log?.error(e);
+        }
+      }
+    }
+
+    if (!infos) {
+      try {
+        Log?.debug('cancel connection when service not found');
+        await device.cancelConnection();
+      } catch (e) {
+        Log?.debug('cancel connection error when service not found: ', e.message || e.reason);
+      }
+      throw ERRORS.TypedError(HardwareErrorCode.BleServiceNotFound);
+    }
+
+    const { serviceUuid, writeUuid, notifyUuid } = infos;
+
+    if (!characteristics) {
+      characteristics = await device.characteristicsForService(serviceUuid);
+    }
+
+    if (!characteristics) {
+      throw ERRORS.TypedError(HardwareErrorCode.BleCharacteristicNotFound);
+    }
+
+    let writeCharacteristic;
+    let notifyCharacteristic;
+    for (const c of characteristics) {
+      if (c.uuid === writeUuid) {
+        writeCharacteristic = c;
+      } else if (c.uuid === notifyUuid) {
+        notifyCharacteristic = c;
+      }
+    }
+
+    if (!writeCharacteristic) {
+      throw ERRORS.TypedError('BLECharacteristicNotFound: write characteristic not found');
+    }
+
+    if (!notifyCharacteristic) {
+      throw ERRORS.TypedError('BLECharacteristicNotFound: notify characteristic not found');
+    }
+
+    if (!writeCharacteristic.isWritableWithResponse) {
+      throw ERRORS.TypedError('BLECharacteristicNotWritable: write characteristic not writable');
+    }
+
+    if (!notifyCharacteristic.isNotifiable) {
+      throw ERRORS.TypedError(
+        'BLECharacteristicNotNotifiable: notify characteristic not notifiable'
+      );
+    }
+
+    return {
+      writeCharacteristic,
+      notifyCharacteristic,
+    };
+  }
+
+  attachDisconnectSubscription(transport: BleTransport, device: Device, uuid: string) {
+    transport.disconnectSubscription?.remove();
+    transport.disconnectSubscription = device.onDisconnected(() => {
+      if (this.firmwareUploadWriteRecoveryIds.has(uuid)) {
+        Log?.debug('device disconnect ignored during FirmwareUpload write recovery: ', uuid);
+        return;
+      }
+
+      try {
+        Log?.debug('device disconnect: ', device?.id);
+        this.emitter?.emit('device-disconnect', {
+          name: device?.name,
+          id: device?.id,
+          connectId: device?.id,
+        });
+        if (this.runPromise) {
+          this.runPromise.reject(ERRORS.TypedError(HardwareErrorCode.BleConnectedError));
+        }
+      } catch (e) {
+        Log?.debug('device disconnect error: ', e);
+      } finally {
+        this.release(uuid);
+      }
+    });
+  }
+
+  async reconnectFirmwareUploadTransport(uuid: string, transport: BleTransport) {
+    this.firmwareUploadWriteRecoveryIds.add(uuid);
+    try {
+      transport.disconnectSubscription?.remove();
+      transport.disconnectSubscription = undefined;
+      transport.notifySubscription?.remove();
+      transport.notifySubscription = undefined;
+
+      let { device } = transport;
+      const isConnected = await device.isConnected().catch(() => false);
+      if (!isConnected) {
+        try {
+          device = await device.connect(connectOptions);
+        } catch (e) {
+          if (
+            e.errorCode === BleErrorCode.DeviceMTUChangeFailed ||
+            e.errorCode === BleErrorCode.OperationCancelled
+          ) {
+            connectOptions = {};
+            device = await device.connect();
+          } else if (e.errorCode !== BleErrorCode.DeviceAlreadyConnected) {
+            throw e;
+          }
+        }
+      }
+
+      const { writeCharacteristic, notifyCharacteristic } =
+        await this.resolveCharacteristics(device);
+
+      transport.device = device;
+      transport.writeCharacteristic = writeCharacteristic;
+      transport.notifyCharacteristic = notifyCharacteristic;
+      transport.notifySubscription = this._monitorCharacteristic(notifyCharacteristic, uuid);
+      this.attachDisconnectSubscription(transport, device, uuid);
+    } finally {
+      this.firmwareUploadWriteRecoveryIds.delete(uuid);
+    }
   }
 
   /**
@@ -406,69 +531,8 @@ export default class ReactNativeBleTransport {
       }
     }
 
-    await device.discoverAllServicesAndCharacteristics();
-    let infos = tryToGetConfiguration(device);
-    let characteristics;
-
-    if (!infos) {
-      for (const serviceUuid of getBluetoothServiceUuids()) {
-        try {
-          characteristics = await device.characteristicsForService(serviceUuid);
-          infos = getInfosForServiceUuid(serviceUuid, 'classic');
-          break;
-        } catch (e) {
-          Log?.error(e);
-        }
-      }
-    }
-
-    if (!infos) {
-      try {
-        Log?.debug('cancel connection when service not found');
-        await device.cancelConnection();
-      } catch (e) {
-        Log?.debug('cancel connection error when service not found: ', e.message || e.reason);
-      }
-      throw ERRORS.TypedError(HardwareErrorCode.BleServiceNotFound);
-    }
-
-    const { serviceUuid, writeUuid, notifyUuid } = infos;
-
-    if (!characteristics) {
-      characteristics = await device.characteristicsForService(serviceUuid);
-    }
-
-    if (!characteristics) {
-      throw ERRORS.TypedError(HardwareErrorCode.BleCharacteristicNotFound);
-    }
-
-    let writeCharacteristic;
-    let notifyCharacteristic;
-    for (const c of characteristics) {
-      if (c.uuid === writeUuid) {
-        writeCharacteristic = c;
-      } else if (c.uuid === notifyUuid) {
-        notifyCharacteristic = c;
-      }
-    }
-
-    if (!writeCharacteristic) {
-      throw ERRORS.TypedError('BLECharacteristicNotFound: write characteristic not found');
-    }
-
-    if (!notifyCharacteristic) {
-      throw ERRORS.TypedError('BLECharacteristicNotFound: notify characteristic not found');
-    }
-
-    if (!writeCharacteristic.isWritableWithResponse) {
-      throw ERRORS.TypedError('BLECharacteristicNotWritable: write characteristic not writable');
-    }
-
-    if (!notifyCharacteristic.isNotifiable) {
-      throw ERRORS.TypedError(
-        'BLECharacteristicNotNotifiable: notify characteristic not notifiable'
-      );
-    }
+    const { writeCharacteristic, notifyCharacteristic } =
+      await this.resolveCharacteristics(device);
 
     // release transport before new transport instance
     await this.release(uuid);
@@ -486,23 +550,7 @@ export default class ReactNativeBleTransport {
       connectId: device.id,
     });
 
-    transport.disconnectSubscription = device.onDisconnected(() => {
-      try {
-        Log?.debug('device disconnect: ', device?.id);
-        this.emitter?.emit('device-disconnect', {
-          name: device?.name,
-          id: device?.id,
-          connectId: device?.id,
-        });
-        if (this.runPromise) {
-          this.runPromise.reject(ERRORS.TypedError(HardwareErrorCode.BleConnectedError));
-        }
-      } catch (e) {
-        Log?.debug('device disconnect error: ', e);
-      } finally {
-        this.release(uuid);
-      }
-    });
+    this.attachDisconnectSubscription(transport, device, uuid);
 
     return { uuid };
   }
@@ -517,6 +565,10 @@ export default class ReactNativeBleTransport {
             error as unknown as string
           }`
         );
+        if (this.firmwareUploadWriteRecoveryIds.has(uuid)) {
+          Log?.debug('notify error ignored during FirmwareUpload write recovery: ', uuid);
+          return;
+        }
         if (this.runPromise) {
           let ERROR:
             | typeof HardwareErrorCode.BleDeviceBondError
@@ -658,19 +710,10 @@ export default class ReactNativeBleTransport {
     async function writeChunkedData(
       buffers: ByteBuffer[],
       writeFunction: (data: string) => Promise<void>,
-      onError: (e: any) => void,
-      chunkOptions?: {
-        packetCapacity?: number;
-        burstSize?: number;
-        pauseMs?: number;
-        flushDelayMs?: number;
-      }
+      onError: (e: any) => void
     ) {
-      const packetCapacity =
-        chunkOptions?.packetCapacity ??
-        (Platform.OS === 'ios' ? IOS_PACKET_LENGTH : ANDROID_PACKET_LENGTH);
+      const packetCapacity = Platform.OS === 'ios' ? IOS_PACKET_LENGTH : ANDROID_PACKET_LENGTH;
       let index = 0;
-      let packetsWritten = 0;
       let chunk = ByteBuffer.allocate(packetCapacity);
 
       while (index < buffers.length) {
@@ -682,15 +725,40 @@ export default class ReactNativeBleTransport {
           chunk.reset();
           try {
             await writeFunction(chunk.toString('base64'));
-            packetsWritten += 1;
             chunk = ByteBuffer.allocate(packetCapacity);
+          } catch (e) {
+            onError(e);
+            throw ERRORS.TypedError(HardwareErrorCode.BleWriteCharacteristicError);
+          }
+        }
+      }
+    }
+
+    async function writeFirmwareUploadChunkedData(
+      buffers: ByteBuffer[],
+      writeFunction: (data: string) => Promise<void>,
+      onError: (e: any) => void
+    ) {
+      let index = 0;
+      let packetsWritten = 0;
+      let chunk = ByteBuffer.allocate(FIRMWARE_UPLOAD_WRITE_PACKET_CAPACITY);
+
+      while (index < buffers.length) {
+        const buffer = buffers[index].toBuffer();
+        chunk.append(buffer);
+        index += 1;
+
+        if (chunk.offset === FIRMWARE_UPLOAD_WRITE_PACKET_CAPACITY || index >= buffers.length) {
+          chunk.reset();
+          try {
+            await writeFunction(chunk.toString('base64'));
+            packetsWritten += 1;
+            chunk = ByteBuffer.allocate(FIRMWARE_UPLOAD_WRITE_PACKET_CAPACITY);
             if (
-              chunkOptions?.burstSize &&
-              chunkOptions.pauseMs &&
-              packetsWritten % chunkOptions.burstSize === 0 &&
+              packetsWritten % FIRMWARE_UPLOAD_WRITE_BURST_SIZE === 0 &&
               index < buffers.length
             ) {
-              await delay(chunkOptions.pauseMs);
+              await delay(FIRMWARE_UPLOAD_WRITE_PAUSE_MS);
             }
           } catch (e) {
             onError(e);
@@ -699,8 +767,8 @@ export default class ReactNativeBleTransport {
         }
       }
 
-      if (chunkOptions?.flushDelayMs && packetsWritten > 0) {
-        await delay(chunkOptions.flushDelayMs);
+      if (packetsWritten > 0) {
+        await delay(FIRMWARE_UPLOAD_WRITE_FLUSH_DELAY_MS);
       }
     }
 
@@ -714,18 +782,15 @@ export default class ReactNativeBleTransport {
         }
       );
     } else if (name === 'FirmwareUpload') {
-      const packetCapacity = resolveProtocolV1HighVolumePacketCapacity({
-        mtu: Platform.OS === 'android' ? transport.mtuSize : undefined,
-      });
       Log?.debug('[ReactNativeBleTransport] FirmwareUpload write uses throttled BLE packets:', {
-        packetCapacity,
+        packetCapacity: FIRMWARE_UPLOAD_WRITE_PACKET_CAPACITY,
         burstSize: FIRMWARE_UPLOAD_WRITE_BURST_SIZE,
         pauseMs: FIRMWARE_UPLOAD_WRITE_PAUSE_MS,
         flushDelayMs: FIRMWARE_UPLOAD_WRITE_FLUSH_DELAY_MS,
         maxRetries: FIRMWARE_UPLOAD_WRITE_MAX_RETRIES,
       });
 
-      await writeChunkedData(
+      await writeFirmwareUploadChunkedData(
         buffers,
         async data => {
           let attempt = 0;
@@ -737,18 +802,36 @@ export default class ReactNativeBleTransport {
               await transport.writeCharacteristic.writeWithoutResponse(data);
               return;
             } catch (error) {
-              if (
-                !shouldRetryFirmwareUploadWrite(error, attempt, FIRMWARE_UPLOAD_WRITE_MAX_RETRIES)
-              ) {
+              const retryType = getFirmwareUploadWriteRetryType(error);
+              if (!retryType || attempt >= FIRMWARE_UPLOAD_WRITE_MAX_RETRIES) {
                 throw error;
               }
-              const delayMs = resolveFirmwareUploadRetryDelay(attempt);
+              const shouldReconnect = retryType === 'reconnectable';
+              const delayMs = shouldReconnect
+                ? FIRMWARE_UPLOAD_RECONNECT_RETRY_DELAY_MS
+                : resolveFirmwareUploadRetryDelay(attempt);
               Log?.debug('[ReactNativeBleTransport] FirmwareUpload write retry:', {
                 attempt: attempt + 1,
                 delayMs,
+                reconnect: shouldReconnect,
                 error,
               });
+              if (shouldReconnect) {
+                this.firmwareUploadWriteRecoveryIds.add(uuid);
+              }
               await delay(delayMs);
+              if (shouldReconnect) {
+                try {
+                  await this.reconnectFirmwareUploadTransport(uuid, transport);
+                } catch (e) {
+                  Log?.debug('[ReactNativeBleTransport] FirmwareUpload reconnect error:', e);
+                  attempt += 1;
+                  if (attempt >= FIRMWARE_UPLOAD_WRITE_MAX_RETRIES) {
+                    throw e;
+                  }
+                  continue;
+                }
+              }
               attempt += 1;
             }
           }
@@ -756,12 +839,6 @@ export default class ReactNativeBleTransport {
         e => {
           this.runPromise = null;
           Log?.error('writeCharacteristic write error: ', e);
-        },
-        {
-          packetCapacity,
-          burstSize: FIRMWARE_UPLOAD_WRITE_BURST_SIZE,
-          pauseMs: FIRMWARE_UPLOAD_WRITE_PAUSE_MS,
-          flushDelayMs: FIRMWARE_UPLOAD_WRITE_FLUSH_DELAY_MS,
         }
       );
     } else {

--- a/packages/hd-transport-react-native/src/index.ts
+++ b/packages/hd-transport-react-native/src/index.ts
@@ -38,6 +38,78 @@ const { check, buildBuffers, receiveOne, parseConfigure } = transport;
 const Log = getLogger(LoggerNames.HdBleTransport);
 
 const transportCache: Record<string, BleTransport> = {};
+const FIRMWARE_UPLOAD_WRITE_BURST_SIZE = Platform.OS === 'ios' ? 4 : 6;
+const FIRMWARE_UPLOAD_WRITE_PAUSE_MS = Platform.OS === 'ios' ? 8 : 10;
+const FIRMWARE_UPLOAD_WRITE_FLUSH_DELAY_MS = Platform.OS === 'ios' ? 24 : 24;
+const FIRMWARE_UPLOAD_WRITE_MAX_RETRIES = 3;
+const PROTOCOL_V1_BLE_PACKET_LENGTH = 64;
+const ANDROID_DEFAULT_MTU = 23;
+const ANDROID_GATT_CONGESTED_STATUS = 143;
+
+const delay = (ms: number) =>
+  new Promise<void>(resolve => {
+    setTimeout(resolve, ms);
+  });
+
+const resolveProtocolV1HighVolumePacketCapacity = ({
+  mtu,
+}: {
+  mtu?: number | null;
+}) => {
+  if (Platform.OS === 'ios') return IOS_PACKET_LENGTH;
+  if (Platform.OS !== 'android' || !mtu || mtu <= ANDROID_DEFAULT_MTU) {
+    return ANDROID_PACKET_LENGTH;
+  }
+
+  const attPayloadLength = Math.max(mtu - 3, PROTOCOL_V1_BLE_PACKET_LENGTH);
+  const cappedLength = Math.min(ANDROID_PACKET_LENGTH, attPayloadLength);
+  return Math.max(
+    PROTOCOL_V1_BLE_PACKET_LENGTH,
+    Math.floor(cappedLength / PROTOCOL_V1_BLE_PACKET_LENGTH) * PROTOCOL_V1_BLE_PACKET_LENGTH
+  );
+};
+
+const getErrorText = (error: unknown) => {
+  if (!error || typeof error !== 'object') return '';
+  const maybeError = error as {
+    reason?: unknown;
+    message?: unknown;
+    name?: unknown;
+  };
+  return [maybeError.reason, maybeError.message, maybeError.name]
+    .filter(value => typeof value === 'string')
+    .join(' ');
+};
+
+const isGattCongestedError = (error: unknown) => {
+  if (!error || typeof error !== 'object') return false;
+  const maybeError = error as {
+    androidErrorCode?: unknown;
+    status?: unknown;
+  };
+
+  if (
+    maybeError.androidErrorCode === ANDROID_GATT_CONGESTED_STATUS ||
+    maybeError.status === ANDROID_GATT_CONGESTED_STATUS
+  ) {
+    return true;
+  }
+
+  const text = getErrorText(error);
+  return text.includes('GATT_CONGESTED') || text.includes('status 143');
+};
+
+const shouldRetryFirmwareUploadWrite = (
+  error: unknown,
+  attempt: number,
+  maxRetries: number
+) => attempt < maxRetries && isGattCongestedError(error);
+
+const resolveFirmwareUploadRetryDelay = (
+  attempt: number,
+  baseDelayMs = 200,
+  maxDelayMs = 1200
+) => Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
 
 let connectOptions: Record<string, unknown> = {
   requestMTU: 256,
@@ -586,10 +658,19 @@ export default class ReactNativeBleTransport {
     async function writeChunkedData(
       buffers: ByteBuffer[],
       writeFunction: (data: string) => Promise<void>,
-      onError: (e: any) => void
+      onError: (e: any) => void,
+      chunkOptions?: {
+        packetCapacity?: number;
+        burstSize?: number;
+        pauseMs?: number;
+        flushDelayMs?: number;
+      }
     ) {
-      const packetCapacity = Platform.OS === 'ios' ? IOS_PACKET_LENGTH : ANDROID_PACKET_LENGTH;
+      const packetCapacity =
+        chunkOptions?.packetCapacity ??
+        (Platform.OS === 'ios' ? IOS_PACKET_LENGTH : ANDROID_PACKET_LENGTH);
       let index = 0;
+      let packetsWritten = 0;
       let chunk = ByteBuffer.allocate(packetCapacity);
 
       while (index < buffers.length) {
@@ -601,12 +682,25 @@ export default class ReactNativeBleTransport {
           chunk.reset();
           try {
             await writeFunction(chunk.toString('base64'));
+            packetsWritten += 1;
             chunk = ByteBuffer.allocate(packetCapacity);
+            if (
+              chunkOptions?.burstSize &&
+              chunkOptions.pauseMs &&
+              packetsWritten % chunkOptions.burstSize === 0 &&
+              index < buffers.length
+            ) {
+              await delay(chunkOptions.pauseMs);
+            }
           } catch (e) {
             onError(e);
             throw ERRORS.TypedError(HardwareErrorCode.BleWriteCharacteristicError);
           }
         }
+      }
+
+      if (chunkOptions?.flushDelayMs && packetsWritten > 0) {
+        await delay(chunkOptions.flushDelayMs);
       }
     }
 
@@ -620,14 +714,54 @@ export default class ReactNativeBleTransport {
         }
       );
     } else if (name === 'FirmwareUpload') {
+      const packetCapacity = resolveProtocolV1HighVolumePacketCapacity({
+        mtu: Platform.OS === 'android' ? transport.mtuSize : undefined,
+      });
+      Log?.debug('[ReactNativeBleTransport] FirmwareUpload write uses throttled BLE packets:', {
+        packetCapacity,
+        burstSize: FIRMWARE_UPLOAD_WRITE_BURST_SIZE,
+        pauseMs: FIRMWARE_UPLOAD_WRITE_PAUSE_MS,
+        flushDelayMs: FIRMWARE_UPLOAD_WRITE_FLUSH_DELAY_MS,
+        maxRetries: FIRMWARE_UPLOAD_WRITE_MAX_RETRIES,
+      });
+
       await writeChunkedData(
         buffers,
         async data => {
-          await transport.writeCharacteristic.writeWithoutResponse(data);
+          let attempt = 0;
+          // Retry only congestion. Other write errors should surface immediately.
+          // GATT_CONGESTED is usually transient backpressure from the Android BLE queue.
+          // eslint-disable-next-line no-constant-condition
+          while (true) {
+            try {
+              await transport.writeCharacteristic.writeWithoutResponse(data);
+              return;
+            } catch (error) {
+              if (
+                !shouldRetryFirmwareUploadWrite(error, attempt, FIRMWARE_UPLOAD_WRITE_MAX_RETRIES)
+              ) {
+                throw error;
+              }
+              const delayMs = resolveFirmwareUploadRetryDelay(attempt);
+              Log?.debug('[ReactNativeBleTransport] FirmwareUpload write retry:', {
+                attempt: attempt + 1,
+                delayMs,
+                error,
+              });
+              await delay(delayMs);
+              attempt += 1;
+            }
+          }
         },
         e => {
           this.runPromise = null;
           Log?.error('writeCharacteristic write error: ', e);
+        },
+        {
+          packetCapacity,
+          burstSize: FIRMWARE_UPLOAD_WRITE_BURST_SIZE,
+          pauseMs: FIRMWARE_UPLOAD_WRITE_PAUSE_MS,
+          flushDelayMs: FIRMWARE_UPLOAD_WRITE_FLUSH_DELAY_MS,
         }
       );
     } else {

--- a/packages/hd-transport-react-native/src/index.ts
+++ b/packages/hd-transport-react-native/src/index.ts
@@ -59,9 +59,7 @@ const delay = (ms: number) =>
     setTimeout(resolve, ms);
   });
 
-const getFirmwareUploadWriteRetryType = (
-  error: unknown
-): FirmwareUploadWriteRetryType | null => {
+const getFirmwareUploadWriteRetryType = (error: unknown): FirmwareUploadWriteRetryType | null => {
   if (!error || typeof error !== 'object') return null;
   const bleWriteError = error as {
     androidErrorCode?: unknown;
@@ -92,11 +90,8 @@ const getFirmwareUploadWriteRetryType = (
   return /GATT_CONGESTED|status\s*[:=]?\s*143/.test(text) ? 'congested' : null;
 };
 
-const resolveFirmwareUploadRetryDelay = (
-  attempt: number,
-  baseDelayMs = 200,
-  maxDelayMs = 1200
-) => Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
+const resolveFirmwareUploadRetryDelay = (attempt: number, baseDelayMs = 200, maxDelayMs = 1200) =>
+  Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
 
 let connectOptions: Record<string, unknown> = {
   requestMTU: 256,
@@ -312,8 +307,9 @@ export default class ReactNativeBleTransport {
         }
       }
 
-      const { writeCharacteristic, notifyCharacteristic } =
-        await this.resolveCharacteristics(device);
+      const { writeCharacteristic, notifyCharacteristic } = await this.resolveCharacteristics(
+        device
+      );
 
       transport.device = device;
       transport.writeCharacteristic = writeCharacteristic;
@@ -531,8 +527,7 @@ export default class ReactNativeBleTransport {
       }
     }
 
-    const { writeCharacteristic, notifyCharacteristic } =
-      await this.resolveCharacteristics(device);
+    const { writeCharacteristic, notifyCharacteristic } = await this.resolveCharacteristics(device);
 
     // release transport before new transport instance
     await this.release(uuid);
@@ -754,10 +749,7 @@ export default class ReactNativeBleTransport {
             await writeFunction(chunk.toString('base64'));
             packetsWritten += 1;
             chunk = ByteBuffer.allocate(FIRMWARE_UPLOAD_WRITE_PACKET_CAPACITY);
-            if (
-              packetsWritten % FIRMWARE_UPLOAD_WRITE_BURST_SIZE === 0 &&
-              index < buffers.length
-            ) {
+            if (packetsWritten % FIRMWARE_UPLOAD_WRITE_BURST_SIZE === 0 && index < buffers.length) {
               await delay(FIRMWARE_UPLOAD_WRITE_PAUSE_MS);
             }
           } catch (e) {
@@ -820,19 +812,17 @@ export default class ReactNativeBleTransport {
                 this.firmwareUploadWriteRecoveryIds.add(uuid);
               }
               await delay(delayMs);
+              attempt += 1;
               if (shouldReconnect) {
                 try {
                   await this.reconnectFirmwareUploadTransport(uuid, transport);
                 } catch (e) {
                   Log?.debug('[ReactNativeBleTransport] FirmwareUpload reconnect error:', e);
-                  attempt += 1;
                   if (attempt >= FIRMWARE_UPLOAD_WRITE_MAX_RETRIES) {
                     throw e;
                   }
-                  continue;
                 }
               }
-              attempt += 1;
             }
           }
         },

--- a/packages/hd-transport-usb/package.json
+++ b/packages/hd-transport-usb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-usb",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "description": "OneKey hardware wallet direct USB transport plugin (libusb)",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.27-alpha.5",
-    "@onekeyfe/hd-transport": "1.1.27-alpha.5",
+    "@onekeyfe/hd-shared": "1.1.27-alpha.6",
+    "@onekeyfe/hd-transport": "1.1.27-alpha.6",
     "bytebuffer": "^5.0.1",
     "usb": "^2.14.0"
   }

--- a/packages/hd-transport-web-device/package.json
+++ b/packages/hd-transport-web-device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-web-device",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -20,11 +20,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.1.27-alpha.5",
-    "@onekeyfe/hd-transport": "1.1.27-alpha.5"
+    "@onekeyfe/hd-shared": "1.1.27-alpha.6",
+    "@onekeyfe/hd-transport": "1.1.27-alpha.6"
   },
   "devDependencies": {
-    "@onekeyfe/hd-transport-electron": "1.1.27-alpha.5",
+    "@onekeyfe/hd-transport-electron": "1.1.27-alpha.6",
     "@types/w3c-web-usb": "^1.0.6",
     "@types/web-bluetooth": "^0.0.17"
   }

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "description": "Transport layer abstractions and utilities for OneKey hardware SDK.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "2.2.67",
-    "@onekeyfe/hd-core": "1.1.27-alpha.5",
-    "@onekeyfe/hd-shared": "1.1.27-alpha.5",
-    "@onekeyfe/hd-transport-http": "1.1.27-alpha.5",
-    "@onekeyfe/hd-transport-web-device": "1.1.27-alpha.5"
+    "@onekeyfe/hd-core": "1.1.27-alpha.6",
+    "@onekeyfe/hd-shared": "1.1.27-alpha.6",
+    "@onekeyfe/hd-transport-http": "1.1.27-alpha.6",
+    "@onekeyfe/hd-transport-web-device": "1.1.27-alpha.6"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/hwk-adapter-core/package.json
+++ b/packages/hwk-adapter-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-adapter-core",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "description": "Shared types and utilities for OneKey hardware wallet kit",
   "author": "OneKey",
   "license": "MIT",

--- a/packages/hwk-ledger-adapter/package.json
+++ b/packages/hwk-ledger-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-adapter",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "description": "Ledger hardware wallet adapter for OneKey",
   "author": "OneKey",
   "license": "MIT",
@@ -50,7 +50,7 @@
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/hw-app-trx": "^6.34.1",
     "@ledgerhq/hw-transport": "^6.34.1",
-    "@onekeyfe/hwk-adapter-core": "1.1.27-alpha.5",
+    "@onekeyfe/hwk-adapter-core": "1.1.27-alpha.6",
     "bitcoinjs-lib": "npm:@onekeyfe/bitcoinjs-lib@7.0.1"
   },
   "devDependencies": {

--- a/packages/hwk-ledger-connector-ble/package.json
+++ b/packages/hwk-ledger-connector-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-connector-ble",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "description": "IConnector implementation for Ledger hardware wallets via React Native BLE",
   "author": "OneKey",
   "license": "MIT",
@@ -51,8 +51,8 @@
     "@ledgerhq/device-signer-kit-ethereum": "^1.9.0",
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/device-transport-kit-react-native-ble": "^1.0.0",
-    "@onekeyfe/hwk-adapter-core": "1.1.27-alpha.5",
-    "@onekeyfe/hwk-ledger-adapter": "1.1.27-alpha.5"
+    "@onekeyfe/hwk-adapter-core": "1.1.27-alpha.6",
+    "@onekeyfe/hwk-ledger-adapter": "1.1.27-alpha.6"
   },
   "peerDependencies": {
     "react-native": "*"

--- a/packages/hwk-ledger-connector-webhid/package.json
+++ b/packages/hwk-ledger-connector-webhid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-connector-webhid",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "description": "IConnector implementation for Ledger hardware wallets via WebHID (DMK)",
   "author": "OneKey",
   "license": "MIT",
@@ -49,8 +49,8 @@
     "@ledgerhq/device-signer-kit-ethereum": "^1.9.0",
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/device-transport-kit-web-hid": "^1.0.0",
-    "@onekeyfe/hwk-adapter-core": "1.1.27-alpha.5",
-    "@onekeyfe/hwk-ledger-adapter": "1.1.27-alpha.5"
+    "@onekeyfe/hwk-adapter-core": "1.1.27-alpha.6",
+    "@onekeyfe/hwk-ledger-adapter": "1.1.27-alpha.6"
   },
   "devDependencies": {
     "rimraf": "^5.0.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.1.27-alpha.5",
+  "version": "1.1.27-alpha.6",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",


### PR DESCRIPTION
## Summary
- throttle Protocol V1 FirmwareUpload BLE writes for Android BLE congestion: 192-byte packets, burstSize=5, pauseMs=10, flushDelayMs=30
- retry Android GATT_CONGESTED/status 143 write failures with bounded exponential backoff
- retry reconnectable firmware write failures by reconnecting, rediscovering services, refreshing write/notify characteristics, and rebuilding notify monitoring before resending the same packet
- bump SDK packages to 1.1.27-alpha.6 for a new alpha build

## Verification
- yarn build
- yarn check-versions
- yarn lerna run build --scope=@onekeyfe/hd-transport-react-native
- real Classic1s Pure BLE firmware upload smoke test: 8034 writes of 192 bytes completed from 16:57:06.975 to 16:58:26.168, about 19 KB/s
- no FirmwareUpload write retry, GATT_CONGESTED/status 143, or BleWriteCharacteristicError observed in the successful run

## Notes
- PR is based on OneKeyHQ:onekey and updates OneKeyHQ:fix/firmware-upload-ble-congestion.
- Local firmware URL override used during manual testing was removed from the SDK diff.