### PR TITLE
fix: stabilize protocol v2 firmware update

### DIFF
--- a/packages/core/__tests__/protocol-v2.test.ts
+++ b/packages/core/__tests__/protocol-v2.test.ts
@@ -47,10 +47,7 @@ import {
   PROTOCOL_V2_DEVICE_INFO_TIMEOUT_MS,
   requestProtocolV2DeviceInfo,
 } from '../src/protocols/protocol-v2/features';
-import {
-  buildProfileFromProtocolV2,
-  buildProtocolV2FeaturesPayload,
-} from '../src/deviceProfile';
+import { buildProfileFromProtocolV2, buildProtocolV2FeaturesPayload } from '../src/deviceProfile';
 import {
   getDeviceType,
   getFirmwareType,
@@ -95,8 +92,7 @@ function stubDevice<T extends Record<string, any>>(device: T): T {
   d.getCurrentSafetyChecks ??= () => d.features?.safetyChecks;
   d.getCurrentDeviceId ??= () => d.features?.deviceId || undefined;
   d.getCurrentSerialNo ??= () => d.features?.serialNo || '';
-  d.getCurrentPassphraseProtection ??= () =>
-    d.features?.passphraseProtection;
+  d.getCurrentPassphraseProtection ??= () => d.features?.passphraseProtection;
   d.getCurrentMethodVersionRange ??= (fn: (model: any) => any) => {
     const deviceType = d.getCurrentDeviceType();
     const range = fn(deviceType);
@@ -114,6 +110,18 @@ function stubDevice<T extends Record<string, any>>(device: T): T {
 function normalizeProtocolV2Features(_descriptor: unknown, deviceInfo?: ProtocolV2DeviceInfo) {
   return buildProtocolV2FeaturesPayload(deviceInfo);
 }
+
+const protocolV2BootloaderDeviceInfo: ProtocolV2DeviceInfo = {
+  protocol_version: 1,
+  hw: {
+    serial_no: 'PR9999999999',
+  },
+  fw: {
+    bootloader: {
+      version: '0.0.1',
+    },
+  },
+};
 
 async function requestProtocolV2Features({
   commands,
@@ -207,6 +215,28 @@ describe('Protocol V2 feature adapter', () => {
     expect(features.attachToPinEnabled).toBe(true);
     expect(features.unlockedAttachPin).toBe(true);
     expect(features.bleEnabled).toBeNull();
+  });
+
+  test('marks Protocol V2 DeviceInfo without status as bootloader mode', () => {
+    const deviceInfo = {
+      protocol_version: 1,
+      hw: {
+        serial_no: 'PR2BOOT',
+      },
+      fw: {
+        bootloader: {
+          version: '0.2.0',
+        },
+      },
+    };
+    const features = normalizeProtocolV2Features(descriptor as any, deviceInfo);
+    const profile = buildProfileFromProtocolV2({ deviceInfo });
+
+    expect(features.mode).toBe('bootloader');
+    expect(features.bootloaderMode).toBe(true);
+    expect(features.initialized).toBeNull();
+    expect(profile.status.mode).toBe('bootloader');
+    expect(profile.status.bootloaderMode).toBe(true);
   });
 
   test('uses DeviceSessionGet for Protocol V2 passphrase sessions', async () => {
@@ -1718,7 +1748,13 @@ describe('Protocol V2 firmware update targets', () => {
       originalDescriptor: { id: 'ble-id', path: 'ble-path', protocolType: 'V2' },
       deviceConnector: { acquire },
       getCommands: () => commands,
-      _updateFeatures: jest.fn(),
+      updateProtocolV2Features: jest.fn(() => ({
+        bootloaderMode: false,
+        mode: 'normal',
+        firmwareVersion: '0.0.0',
+        bootloaderVersion: '0.0.0',
+        bleVersion: '0.0.0',
+      })),
     });
 
     const versions = await (method as any).waitForProtocolV2FinalFeatures();
@@ -1756,7 +1792,7 @@ describe('Protocol V2 firmware update targets', () => {
     });
   });
 
-  test('skips automatic Protocol V2 bootloader entry before upload while boot flow is disabled', async () => {
+  test('enters Protocol V2 bootloader before upload', async () => {
     const method = new FirmwareUpdateV4({
       id: 1,
       payload: {
@@ -1791,6 +1827,7 @@ describe('Protocol V2 firmware update targets', () => {
 
     await method.run();
 
+    expect((method as any).enterProtocolV2BootloaderMode).toHaveBeenCalledTimes(1);
     expect((method as any).executeProtocolV2Update).toHaveBeenCalledWith({
       resourceBinary: null,
       fwBinaryMap: [
@@ -1802,7 +1839,6 @@ describe('Protocol V2 firmware update targets', () => {
       ],
       bootloaderBinary: null,
     });
-    expect((method as any).enterProtocolV2BootloaderMode).not.toHaveBeenCalled();
   });
 
   test('reboots Protocol V2 normal-mode device to bootloader before transfer', async () => {
@@ -1812,19 +1848,25 @@ describe('Protocol V2 firmware update targets', () => {
         method: 'firmwareUpdateV4',
       },
     });
-    const acquire = jest.fn().mockResolvedValue(undefined);
     (method as any).device = stubDevice({
       originalDescriptor: { id: 'usb-id', path: 'usb-path', protocolType: 'V2' },
       features: { bootloader_mode: false, capabilities: [] },
       isBootloader: () => false,
-      acquire,
     });
     (method as any).protocolV2Reboot = jest.fn().mockResolvedValue({
       message: 'Device rebooted successfully',
     });
-    (method as any).checkDeviceToBootloader = jest.fn(() => {
-      (method as any).checkPromise = { promise: Promise.resolve(true) };
+    (method as any).checkDeviceToBootloader = jest.fn();
+    const typedCall = jest.fn().mockResolvedValue({
+      type: 'DeviceInfo',
+      message: protocolV2BootloaderDeviceInfo,
     });
+    const reconnectProtocolV2Device = jest.fn().mockImplementation(() => {
+      (method as any).device.isBootloader = () => true;
+      return Promise.resolve();
+    });
+    (method as any).reconnectProtocolV2Device = reconnectProtocolV2Device;
+    (method as any).device.getCommands = () => ({ typedCall });
     method.postTipMessage = jest.fn();
 
     await (method as any).enterProtocolV2BootloaderMode();
@@ -1832,11 +1874,44 @@ describe('Protocol V2 firmware update targets', () => {
     expect(method.postTipMessage).toHaveBeenCalledWith('AutoRebootToBootloader');
     expect((method as any).protocolV2Reboot).toHaveBeenCalledWith(DeviceRebootType.Bootloader);
     expect(method.postTipMessage).toHaveBeenCalledWith('GoToBootloaderSuccess');
-    expect((method as any).checkDeviceToBootloader).toHaveBeenCalledWith(undefined);
-    expect(acquire).toHaveBeenCalledTimes(1);
+    expect((method as any).checkDeviceToBootloader).not.toHaveBeenCalled();
+    expect(reconnectProtocolV2Device).toHaveBeenCalledTimes(1);
   });
 
-  test('reboots Protocol V2 firmware flow back to normal before final feature polling', async () => {
+  test('polls until Protocol V2 bootloader descriptor is ready after reboot', async () => {
+    const method = new FirmwareUpdateV4({
+      id: 1,
+      payload: {
+        method: 'firmwareUpdateV4',
+      },
+    });
+    (method as any).device = stubDevice({
+      originalDescriptor: { id: 'usb-id', path: 'app-path', protocolType: 'V2' },
+      features: { bootloader_mode: false, capabilities: [] },
+      isBootloader: () => false,
+    });
+    const typedCall = jest.fn().mockResolvedValue({
+      type: 'DeviceInfo',
+      message: protocolV2BootloaderDeviceInfo,
+    });
+    const reconnectProtocolV2Device = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Device not found'))
+      .mockRejectedValueOnce(new Error('Device not found'))
+      .mockImplementation(() => {
+        (method as any).device.isBootloader = () => true;
+        return Promise.resolve();
+      });
+    (method as any).reconnectProtocolV2Device = reconnectProtocolV2Device;
+    (method as any).device.getCommands = () => ({ typedCall });
+
+    await (method as any).waitForProtocolV2BootloaderMode(60 * 1000, 0);
+
+    expect(reconnectProtocolV2Device).toHaveBeenCalledTimes(3);
+    expect(typedCall).toHaveBeenCalledTimes(1);
+  });
+
+  test('reboots Protocol V2 firmware flow back to normal after install status is finished', async () => {
     const method = new FirmwareUpdateV4({
       id: 1,
       payload: {
@@ -1926,6 +2001,29 @@ describe('Protocol V2 firmware update targets', () => {
     expect(method.postTipMessage).toHaveBeenCalledWith('FirmwareUpdating');
   });
 
+  test('continues Protocol V2 install polling when update request transfer times out', async () => {
+    const method = new FirmwareUpdateV4({
+      id: 1,
+      payload: {
+        method: 'firmwareUpdateV4',
+      },
+    });
+    const typedCall = jest.fn().mockRejectedValue(new Error('LIBUSB_TRANSFER_TIMED_OUT'));
+
+    (method as any).device = stubDevice({
+      getCommands: () => ({ typedCall }),
+    });
+    method.postTipMessage = jest.fn();
+
+    await expect(
+      (method as any).protocolV2StartFirmwareUpdate({
+        targets: [{ target_id: 10, path: 'vol1:resource.bin' }],
+      })
+    ).resolves.toBeUndefined();
+
+    expect(method.postTipMessage).toHaveBeenCalledWith('FirmwareUpdating');
+  });
+
   test('continues Protocol V2 install polling through temporary expected V2 probe failures', async () => {
     const method = new FirmwareUpdateV4({
       id: 1,
@@ -1974,15 +2072,33 @@ describe('Protocol V2 firmware update targets', () => {
     const expectedTargetIds = new Set([3]);
 
     expect(
+      (method as any).assertProtocolV2TargetStatus([{ target_id: 3, status: 2 }], expectedTargetIds)
+    ).toBe(true);
+    expect(
       (method as any).assertProtocolV2TargetStatus(
-        [{ target_id: 3, status: 2 }],
+        [{ target_id: 3, status: 'FW_MGMT_UPDATER_TASK_STATUS_FINISHED' }],
         expectedTargetIds
+      )
+    ).toBe(true);
+    expect(
+      (method as any).assertProtocolV2TargetStatus(
+        [
+          {
+            target_id: 'FW_MGMT_TARGET_RESOURCE',
+            status: 'FW_MGMT_UPDATER_TASK_STATUS_FINISHED',
+          },
+          { target_id: 'FW_MGMT_TARGET_SE04', status: 'FW_MGMT_UPDATER_TASK_STATUS_FINISHED' },
+        ],
+        new Set([10, 9])
       )
     ).toBe(true);
 
     expect(
+      (method as any).assertProtocolV2TargetStatus([{ target_id: 3, status: 1 }], expectedTargetIds)
+    ).toBe(false);
+    expect(
       (method as any).assertProtocolV2TargetStatus(
-        [{ target_id: 3, status: 1 }],
+        [{ target_id: 3, status: 'FW_MGMT_UPDATER_TASK_STATUS_IN_PROGRESS' }],
         expectedTargetIds
       )
     ).toBe(false);
@@ -1991,6 +2107,16 @@ describe('Protocol V2 firmware update targets', () => {
     try {
       (method as any).assertProtocolV2TargetStatus(
         [{ target_id: 3, status: 3 }],
+        expectedTargetIds
+      );
+      throw new Error('Expected Protocol V2 failed firmware status to throw');
+    } catch (error: any) {
+      expect(error.errorCode).toBe(HardwareErrorCode.FirmwareError);
+    }
+
+    try {
+      (method as any).assertProtocolV2TargetStatus(
+        [{ target_id: 3, status: 'FW_MGMT_UPDATER_TASK_STATUS_FAILED_VERIFY' }],
         expectedTargetIds
       );
       throw new Error('Expected Protocol V2 failed firmware status to throw');
@@ -2129,7 +2255,10 @@ describe('Protocol V2 firmware update targets', () => {
         'se02',
         'se03',
         'se04',
-      ].map((key, index) => [`https://example.com/${key}.pp.bin`, new Uint8Array([index + 1]).buffer])
+      ].map((key, index) => [
+        `https://example.com/${key}.pp.bin`,
+        new Uint8Array([index + 1]).buffer,
+      ])
     );
     const getSysResourceBinarySpy = jest
       .spyOn(firmwareBinaryApi, 'getSysResourceBinary')
@@ -2185,12 +2314,14 @@ describe('Protocol V2 firmware update targets', () => {
         },
       });
 
-    const remoteBinaries = await (method as any).prepareRemoteProtocolV2Binaries(
-      'universal',
-      { deviceType: 'pro2', firmwareVersion: '0.0.0' }
-    );
+    const remoteBinaries = await (method as any).prepareRemoteProtocolV2Binaries('universal', {
+      deviceType: 'pro2',
+      firmwareVersion: '0.0.0',
+    });
 
-    expect(remoteBinaries.bootloaderBinary).toBe(binaries.get('https://example.com/bootloader.pp.bin'));
+    expect(remoteBinaries.bootloaderBinary).toBe(
+      binaries.get('https://example.com/bootloader.pp.bin')
+    );
     expect(remoteBinaries.fwBinaryMap).toEqual([
       { fileName: 'application_p1.bin', binary: expect.anything(), targetId: 3 },
       { fileName: 'application_p2.bin', binary: expect.anything(), targetId: 4 },
@@ -2243,6 +2374,7 @@ describe('Protocol V2 firmware update targets', () => {
     });
     (method as any).prepareResourceBinary = jest.fn().mockResolvedValue(null);
     (method as any).prepareRemoteProtocolV2Binaries = jest.fn().mockResolvedValue(remoteBinaries);
+    (method as any).enterProtocolV2BootloaderMode = jest.fn().mockResolvedValue(true);
     (method as any).executeProtocolV2Update = jest.fn().mockResolvedValue(undefined);
     (method as any).exitProtocolV2BootloaderToNormal = jest.fn().mockResolvedValue(undefined);
     (method as any).waitForProtocolV2FinalFeatures = jest.fn().mockResolvedValue({
@@ -2279,6 +2411,7 @@ describe('Protocol V2 firmware update targets', () => {
     });
     (method as any).prepareResourceBinary = jest.fn().mockResolvedValue(null);
     (method as any).prepareRemoteProtocolV2Binaries = jest.fn();
+    (method as any).enterProtocolV2BootloaderMode = jest.fn().mockResolvedValue(true);
     (method as any).executeProtocolV2Update = jest.fn().mockResolvedValue(undefined);
     (method as any).exitProtocolV2BootloaderToNormal = jest.fn().mockResolvedValue(undefined);
     (method as any).waitForProtocolV2FinalFeatures = jest.fn().mockResolvedValue({
@@ -2332,8 +2465,8 @@ describe('Protocol V2 firmware update targets', () => {
     });
 
     const writePayloads = typedCall.mock.calls.map(call => call[2]);
-    expect(writePayloads.map(payload => payload.file.offset)).toEqual([0, 4096]);
-    expect(writePayloads.map(payload => payload.file.data.byteLength)).toEqual([4096, 1]);
+    expect(writePayloads.map(payload => payload.file.offset)).toEqual([0, 4000]);
+    expect(writePayloads.map(payload => payload.file.data.byteLength)).toEqual([4000, 97]);
     expect(writePayloads.map(payload => payload.overwrite)).toEqual([true, false]);
     expect(writePayloads.every(payload => payload.append === false)).toBe(true);
   });
@@ -2356,6 +2489,14 @@ describe('Protocol V2 firmware update targets', () => {
       }
       if (name === 'DeviceFirmwareUpdateRequest') {
         return Promise.resolve({ type: 'Success', message: { message: 'ok' } });
+      }
+      if (name === 'DeviceFirmwareUpdateStatusGet') {
+        return Promise.resolve({
+          type: 'DeviceFirmwareUpdateStatus',
+          message: {
+            records: [{ target_id: 3, status: 2 }],
+          },
+        });
       }
       return Promise.reject(new Error(`unexpected call ${name}`));
     });
@@ -2822,17 +2963,22 @@ describe('Protocol V2 file write method', () => {
     method.init();
     await method.run();
 
-    expect(typedCall).toHaveBeenCalledWith('FilesystemFileWrite', 'FilesystemFile', {
-      file: {
-        path: 'vol1:test.bin',
-        offset: 1,
-        total_size: 2,
-        data: new Uint8Array([1]),
+    expect(typedCall).toHaveBeenCalledWith(
+      'FilesystemFileWrite',
+      'FilesystemFile',
+      {
+        file: {
+          path: 'vol1:test.bin',
+          offset: 1,
+          total_size: 2,
+          data: new Uint8Array([1]),
+        },
+        overwrite: false,
+        append: false,
+        ui_percentage: 99,
       },
-      overwrite: false,
-      append: false,
-      ui_percentage: 99,
-    }, { timeoutMs: undefined });
+      { timeoutMs: undefined }
+    );
     expect(method.postMessage).toHaveBeenCalledWith({
       event: 'UI_EVENT',
       type: UI_REQUEST.DEVICE_PROGRESS,
@@ -2865,28 +3011,40 @@ describe('Protocol V2 file write method', () => {
     const result = await method.run();
 
     expect(typedCall).toHaveBeenCalledTimes(2);
-    expect(typedCall).toHaveBeenNthCalledWith(1, 'FilesystemFileWrite', 'FilesystemFile', {
-      file: {
-        path: 'vol1:test.bin',
-        offset: 0,
-        total_size: 4097,
-        data: data.slice(0, 4096),
+    expect(typedCall).toHaveBeenNthCalledWith(
+      1,
+      'FilesystemFileWrite',
+      'FilesystemFile',
+      {
+        file: {
+          path: 'vol1:test.bin',
+          offset: 0,
+          total_size: 4097,
+          data: data.slice(0, 4000),
+        },
+        overwrite: true,
+        append: false,
+        ui_percentage: 98,
       },
-      overwrite: true,
-      append: false,
-      ui_percentage: 99,
-    }, { timeoutMs: undefined });
-    expect(typedCall).toHaveBeenNthCalledWith(2, 'FilesystemFileWrite', 'FilesystemFile', {
-      file: {
-        path: 'vol1:test.bin',
-        offset: 4096,
-        total_size: 4097,
-        data: data.slice(4096),
+      { timeoutMs: undefined }
+    );
+    expect(typedCall).toHaveBeenNthCalledWith(
+      2,
+      'FilesystemFileWrite',
+      'FilesystemFile',
+      {
+        file: {
+          path: 'vol1:test.bin',
+          offset: 4000,
+          total_size: 4097,
+          data: data.slice(4000),
+        },
+        overwrite: false,
+        append: false,
+        ui_percentage: 99,
       },
-      overwrite: false,
-      append: false,
-      ui_percentage: 99,
-    }, { timeoutMs: undefined });
+      { timeoutMs: undefined }
+    );
     expect(result).toMatchObject({
       path: 'vol1:test.bin',
       processed_byte: 4097,
@@ -2896,8 +3054,8 @@ describe('Protocol V2 file write method', () => {
       event: 'UI_EVENT',
       type: UI_REQUEST.DEVICE_PROGRESS,
       payload: expect.objectContaining({
-        progress: 99,
-        transferredBytes: 4096,
+        progress: 97,
+        transferredBytes: 4000,
         totalBytes: 4097,
         elapsedMs: expect.any(Number),
       }),

--- a/packages/core/src/api/FirmwareUpdateV4.ts
+++ b/packages/core/src/api/FirmwareUpdateV4.ts
@@ -49,10 +49,14 @@ const PROTOCOL_V2_TARGET_STATUS_FAILED_MIN = 3;
 const PROTOCOL_V2_CONNECT_PROTOCOL = 'V2';
 const PROTOCOL_V2_FIRMWARE_STAGING_VOLUME = 'vol1:';
 const PROTOCOL_V2_MIN_FILE_CHUNK_SIZE = 64;
+const PROTOCOL_V2_CONNECT_RETRY_COUNT = 10;
+const PROTOCOL_V2_CONNECT_POLL_INTERVAL = 500;
+const PROTOCOL_V2_CONNECT_SINGLE_TIMEOUT = 75 * 1000;
+const PROTOCOL_V2_DEVICE_INFO_READY_TIMEOUT = 60 * 1000;
 
 type ProtocolV2FirmwareUpdateStatusTarget = {
-  target_id: number;
-  status?: number;
+  target_id: number | string;
+  status?: number | string;
   payload_version?: number;
   path?: string;
 };
@@ -125,6 +129,23 @@ const PROTOCOL_V2_REMOTE_COMPONENT_TARGETS: Readonly<
   },
 };
 
+const PROTOCOL_V2_TARGET_ID_VALUES = new Map<string, number>(
+  Object.entries(ProtocolV2FirmwareTargetType).map(([key, value]) => [key, value])
+);
+const PROTOCOL_V2_TARGET_STATUS_VALUES = new Map<string, number>([
+  ['FW_MGMT_UPDATER_TASK_STATUS_PENDING', PROTOCOL_V2_TARGET_STATUS_PENDING],
+  ['FW_MGMT_UPDATER_TASK_STATUS_IN_PROGRESS', PROTOCOL_V2_TARGET_STATUS_IN_PROGRESS],
+  ['FW_MGMT_UPDATER_TASK_STATUS_FINISHED', PROTOCOL_V2_TARGET_STATUS_FINISHED],
+  ['FW_MGMT_UPDATER_TASK_STATUS_FAILED_FILE_NOT_FOUND', 3],
+  ['FW_MGMT_UPDATER_TASK_STATUS_FAILED_FILE_READ', 4],
+  ['FW_MGMT_UPDATER_TASK_STATUS_FAILED_FILE_WRITE', 5],
+  ['FW_MGMT_UPDATER_TASK_STATUS_FAILED_VERIFY', 6],
+  ['FW_MGMT_UPDATER_TASK_STATUS_FAILED_INSTALL', 7],
+  ['FW_MGMT_UPDATER_TASK_STATUS_FAILED_ABORT', 8],
+  ['FW_MGMT_UPDATER_TASK_STATUS_FAILED_BUSY', 9],
+  ['FW_MGMT_UPDATER_TASK_STATUS_FAILED_ENTRY_OUT_OF_BOUNDS', 10],
+]);
+
 const isProtocolV2ReconnectProbeError = (error: unknown) => {
   const message = getProtocolV2UnknownErrorText(error).toLowerCase();
   return (
@@ -138,10 +159,56 @@ const isProtocolV2PollingTransientError = (error: unknown) => {
   return (
     isProtocolV2DeviceDisconnectedError(error) ||
     isProtocolV2ReconnectProbeError(error) ||
+    message.includes('libusb_transfer_timed_out') ||
     (message.includes('response timeout') && message.includes('devicefirmwareupdatestatusget')) ||
     message.includes('device not found') ||
     message.includes('transportnotfound')
   );
+};
+
+const isProtocolV2StartUpdateTransientError = (error: unknown) => {
+  const message = getProtocolV2UnknownErrorText(error).toLowerCase();
+  return (
+    isProtocolV2DeviceDisconnectedError(error) ||
+    isProtocolV2ReconnectProbeError(error) ||
+    message.includes('libusb_transfer_timed_out') ||
+    (message.includes('response timeout') && message.includes('devicefirmwareupdaterequest'))
+  );
+};
+
+const isProtocolV2TargetStatusFinished = (status: ProtocolV2FirmwareUpdateStatusTarget['status']) =>
+  normalizeProtocolV2TargetStatus(status) === PROTOCOL_V2_TARGET_STATUS_FINISHED;
+
+const isProtocolV2TargetStatusInProgress = (
+  status: ProtocolV2FirmwareUpdateStatusTarget['status']
+) =>
+  normalizeProtocolV2TargetStatus(status) === PROTOCOL_V2_TARGET_STATUS_PENDING ||
+  normalizeProtocolV2TargetStatus(status) === PROTOCOL_V2_TARGET_STATUS_IN_PROGRESS;
+
+const isProtocolV2TargetStatusFailed = (status: ProtocolV2FirmwareUpdateStatusTarget['status']) => {
+  const normalizedStatus = normalizeProtocolV2TargetStatus(status);
+  return (
+    typeof normalizedStatus === 'number' && normalizedStatus >= PROTOCOL_V2_TARGET_STATUS_FAILED_MIN
+  );
+};
+
+const normalizeProtocolV2TargetId = (targetId: number | string) => {
+  if (typeof targetId === 'number') {
+    return targetId;
+  }
+  return PROTOCOL_V2_TARGET_ID_VALUES.get(targetId);
+};
+
+const normalizeProtocolV2TargetStatus = (
+  status: ProtocolV2FirmwareUpdateStatusTarget['status']
+) => {
+  if (typeof status === 'number') {
+    return status;
+  }
+  if (typeof status === 'string') {
+    return PROTOCOL_V2_TARGET_STATUS_VALUES.get(status);
+  }
+  return undefined;
 };
 
 /**
@@ -150,7 +217,7 @@ const isProtocolV2PollingTransientError = (error: unknown) => {
  * It intentionally does not fall back to FirmwareUpdateV3/V1 behavior:
  * - upload uses FilesystemFileWrite
  * - install uses DeviceFirmwareUpdateRequest
- * - completion reboots to normal, then polls Ping
+ * - completion waits for target status to finish, reboots to normal, then polls DeviceInfo
  */
 export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareUpdateV4Params> {
   init() {
@@ -160,6 +227,19 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
     this.skipForceUpdateCheck = true;
 
     const { payload } = this;
+
+    if (typeof payload.retryCount !== 'number') {
+      payload.retryCount = PROTOCOL_V2_CONNECT_RETRY_COUNT;
+    }
+    if (typeof payload.pollIntervalTime !== 'number') {
+      payload.pollIntervalTime = PROTOCOL_V2_CONNECT_POLL_INTERVAL;
+    }
+    if (typeof payload.timeout !== 'number') {
+      payload.timeout = PROTOCOL_V2_CONNECT_SINGLE_TIMEOUT;
+    }
+    if (typeof payload.protocolV2DeviceInfoTimeoutMs !== 'number') {
+      payload.protocolV2DeviceInfoTimeoutMs = PROTOCOL_V2_DEVICE_INFO_READY_TIMEOUT;
+    }
 
     validateParams(payload, [
       { name: 'chunkSize', type: 'number' },
@@ -258,6 +338,8 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
       );
     }
 
+    await this.enterProtocolV2BootloaderMode();
+
     await this.executeProtocolV2Update({
       resourceBinary,
       fwBinaryMap,
@@ -274,12 +356,12 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
   }
 
   private async getProtocolV2DeviceFeatures(): Promise<Features> {
+    if (this.device.features) {
+      return this.device.features;
+    }
     if (typeof this.device.getFeatures === 'function') {
       const features = await this.device.getFeatures();
       if (features) return features;
-    }
-    if (this.device.features) {
-      return this.device.features;
     }
     throw ERRORS.TypedError(HardwareErrorCode.RuntimeError, 'Device features not available');
   }
@@ -322,7 +404,7 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
     return orderedKeys
       .map(key => {
         const component = components[key];
-        return component ? [key, component] as const : undefined;
+        return component ? ([key, component] as const) : undefined;
       })
       .filter((entry): entry is readonly [string, IProtocolV2FirmwareComponent] => !!entry);
   }
@@ -399,11 +481,8 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
       this.postTipMessage(FirmwareUpdateTipMessage.AutoRebootToBootloader);
       await this.protocolV2Reboot(DeviceRebootType.Bootloader);
       this.postTipMessage(FirmwareUpdateTipMessage.GoToBootloaderSuccess);
-      this.checkDeviceToBootloader(this.payload.connectId);
-      await this.checkPromise?.promise;
-      this.checkPromise = null;
-      await wait(1500);
-      await this.device.acquire?.();
+      await wait(1000);
+      await this.waitForProtocolV2BootloaderMode();
       return true;
     } catch (error) {
       if (error instanceof HardwareError) {
@@ -412,6 +491,40 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
       Log.log('Protocol V2 auto go to bootloader mode failed: ', error);
       throw ERRORS.TypedError(HardwareErrorCode.FirmwareUpdateAutoEnterBootFailure);
     }
+  }
+
+  private async waitForProtocolV2BootloaderMode(
+    timeout = PROTOCOL_V2_BOOTLOADER_RECONNECT_TIMEOUT,
+    retryInterval = 1000
+  ) {
+    const startTime = Date.now();
+    let lastError: unknown;
+
+    while (Date.now() - startTime < timeout) {
+      try {
+        await this.reconnectProtocolV2Device();
+        const deviceInfo = await requestProtocolV2DeviceInfo({
+          commands: this.device.getCommands(),
+          timeoutMs: PROTOCOL_V2_SHORT_RESPONSE_TIMEOUT,
+        });
+        const features = this.device.updateProtocolV2Features(deviceInfo);
+        if (features?.bootloaderMode) {
+          return features;
+        }
+        lastError = new Error('Protocol V2 device is reachable but is not in bootloader mode');
+      } catch (error) {
+        lastError = error;
+        Log.log('Protocol V2 bootloader mode not ready, polling reconnect: ', error);
+      }
+      await wait(retryInterval);
+    }
+
+    throw ERRORS.TypedError(
+      HardwareErrorCode.FirmwareUpdateAutoEnterBootFailure,
+      `Protocol V2 bootloader not ready within ${timeout / 1000}s: ${this.normalizeErrorMessage(
+        lastError
+      )}`
+    );
   }
 
   /**
@@ -553,9 +666,8 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
   ) {
     const failedTarget = statusTargets.find(
       target =>
-        expectedTargetIds.has(target.target_id) &&
-        typeof target.status === 'number' &&
-        target.status >= PROTOCOL_V2_TARGET_STATUS_FAILED_MIN
+        expectedTargetIds.has(normalizeProtocolV2TargetId(target.target_id) ?? -1) &&
+        isProtocolV2TargetStatusFailed(target.status)
     );
     if (failedTarget) {
       throw ERRORS.TypedError(
@@ -566,8 +678,8 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
 
     const completedTargets = statusTargets.filter(
       target =>
-        expectedTargetIds.has(target.target_id) &&
-        target.status === PROTOCOL_V2_TARGET_STATUS_FINISHED
+        expectedTargetIds.has(normalizeProtocolV2TargetId(target.target_id) ?? -1) &&
+        isProtocolV2TargetStatusFinished(target.status)
     );
     if (completedTargets.length === expectedTargetIds.size && expectedTargetIds.size > 0) {
       return true;
@@ -575,9 +687,8 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
 
     const inProgressTarget = statusTargets.find(
       target =>
-        expectedTargetIds.has(target.target_id) &&
-        (target.status === PROTOCOL_V2_TARGET_STATUS_PENDING ||
-          target.status === PROTOCOL_V2_TARGET_STATUS_IN_PROGRESS)
+        expectedTargetIds.has(normalizeProtocolV2TargetId(target.target_id) ?? -1) &&
+        isProtocolV2TargetStatusInProgress(target.status)
     );
     if (inProgressTarget) {
       this.postProgressMessage(99, 'installingFirmware');
@@ -591,9 +702,6 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
     startResponse?: ProtocolV2FirmwareUpdateStartResponse
   ) {
     const expectedTargetIds = new Set(targets.map(target => target.target_id));
-    if (startResponse?.type === 'Success') {
-      return;
-    }
     if (startResponse?.type === 'DeviceFirmwareUpdateStatus') {
       const statusTargets = (startResponse.message.records ??
         []) as ProtocolV2FirmwareUpdateStatusTarget[];
@@ -687,7 +795,14 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
           // 更新完成判定只需要各 target 版本号；scope 与请求内容保持一致
           request: PROTOCOL_V2_VERSIONS_DEVICE_INFO_REQUEST,
         });
-        return this.device.updateProtocolV2Features(deviceInfo);
+        const features = this.device.updateProtocolV2Features(deviceInfo);
+        if (features.bootloaderMode || features.mode === 'bootloader') {
+          throw ERRORS.TypedError(
+            HardwareErrorCode.DeviceNotFound,
+            'Protocol V2 device is still in bootloader mode'
+          );
+        }
+        return features;
       } catch (error) {
         lastError = error;
         Log.log('Protocol V2 normal mode not ready, polling Ping: ', error);
@@ -712,15 +827,34 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
     const deviceDiff = await this.device.deviceConnector?.enumerate();
     const devicesDescriptor = deviceDiff?.descriptors ?? [];
 
+    if (
+      DataManager.isBrowserWebUsb(DataManager.getSettings('env')) &&
+      devicesDescriptor.length === 1
+    ) {
+      this.device.updateDescriptor(
+        {
+          ...devicesDescriptor[0],
+          protocolType: PROTOCOL_V2_CONNECT_PROTOCOL,
+        },
+        true
+      );
+      await this.device.acquire(PROTOCOL_V2_CONNECT_PROTOCOL, { throwOnRunPromiseError: true });
+      this.device.commands.disposed = false;
+      this.device.getCommands().mainId = this.device.mainId ?? '';
+      await this.device.initialize();
+      return;
+    }
+
     const { deviceList } = await DevicePool.getDevices(devicesDescriptor, this.connectId);
     if (deviceList.length !== 1) {
       throw ERRORS.TypedError(HardwareErrorCode.DeviceNotFound);
     }
 
     this.device.updateFromCache(deviceList[0]);
-    await this.device.acquire();
+    await this.device.acquire(PROTOCOL_V2_CONNECT_PROTOCOL, { throwOnRunPromiseError: true });
     this.device.commands.disposed = false;
     this.device.getCommands().mainId = this.device.mainId ?? '';
+    await this.device.initialize();
   }
 
   private async protocolV2CommonUpdateProcess({
@@ -870,8 +1004,11 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
         }
       );
     } catch (error) {
-      if (isProtocolV2DeviceDisconnectedError(error)) {
-        Log.log('Rebooting device');
+      if (isProtocolV2StartUpdateTransientError(error)) {
+        Log.log(
+          'Protocol V2 firmware update request did not return; continue status polling',
+          error
+        );
       } else {
         throw error;
       }

--- a/packages/core/src/api/firmware/FirmwareUpdateBaseMethod.ts
+++ b/packages/core/src/api/firmware/FirmwareUpdateBaseMethod.ts
@@ -138,6 +138,8 @@ export class FirmwareUpdateBaseMethod<Params> extends BaseMethod<Params> {
     // check device goto bootloader mode
     let isFirstCheck = true;
     let checkCount = 0;
+    let hasPromptedWebDevice = false;
+    let isPromptingWebDevice = false;
     // eslint-disable-next-line prefer-const
     let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -158,23 +160,28 @@ export class FirmwareUpdateBaseMethod<Params> extends BaseMethod<Params> {
         if (
           checkCount > 4 &&
           DataManager.isBrowserWebUsb(DataManager.getSettings('env')) &&
-          !this.payload.skipWebDevicePrompt
+          !this.payload.skipWebDevicePrompt &&
+          !hasPromptedWebDevice &&
+          !isPromptingWebDevice
         ) {
-          clearInterval(intervalTimer);
-          clearTimeout(timeoutTimer);
-
+          isPromptingWebDevice = true;
           try {
             this.postTipMessage(FirmwareUpdateTipMessage.SelectDeviceInBootloaderForWebDevice);
             const confirmed = await this._promptDeviceInBootloaderForWebDevice();
+            hasPromptedWebDevice = true;
             if (confirmed) {
               await this._checkDeviceInBootloaderMode(connectId, intervalTimer, timeoutTimer);
             }
           } catch (e) {
+            clearInterval(intervalTimer);
+            clearTimeout(timeoutTimer);
             Log.log(
               'FirmwareUpdateBaseMethod [checkDeviceToBootloader] _promptDeviceInBootloaderForWebDevice failed: ',
               e
             );
             this.checkPromise?.reject(e);
+          } finally {
+            isPromptingWebDevice = false;
           }
           return;
         }

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -95,6 +95,7 @@ const parseInitOptions = (method?: BaseMethod): InitOptions => ({
   deviceId: method?.payload.deviceId,
   deriveCardano: method && hasDeriveCardano(method),
   connectProtocol: method?.payload.connectProtocol,
+  protocolV2DeviceInfoTimeoutMs: method?.payload.protocolV2DeviceInfoTimeoutMs,
 });
 
 let _core: Core;

--- a/packages/core/src/device/Device.ts
+++ b/packages/core/src/device/Device.ts
@@ -76,6 +76,7 @@ export type InitOptions = {
   passphraseState?: string;
   deriveCardano?: boolean;
   connectProtocol?: HardwareConnectProtocol;
+  protocolV2DeviceInfoTimeoutMs?: number;
 };
 
 export type RunOptions = {
@@ -326,7 +327,10 @@ export class Device extends EventEmitter {
     });
   }
 
-  async acquire(connectProtocol?: HardwareConnectProtocol) {
+  async acquire(
+    connectProtocol?: HardwareConnectProtocol,
+    options?: { throwOnRunPromiseError?: boolean }
+  ) {
     const env = DataManager.getSettings('env');
     const mainIdKey = DataManager.isBleConnect(env) ? 'id' : 'session';
     const expectedProtocol = connectProtocol ?? this.originalDescriptor.protocolType;
@@ -375,6 +379,9 @@ export class Device extends EventEmitter {
 
       this.commands = new DeviceCommands(this, this.mainId ?? '');
     } catch (error) {
+      if (options?.throwOnRunPromiseError) {
+        throw error;
+      }
       if (this.runPromise) {
         this.runPromise.reject(error);
       } else {
@@ -740,13 +747,16 @@ export class Device extends EventEmitter {
     if (this.isProtocolV2()) {
       this.passphraseState = options?.passphraseState;
       if (this.features && !this.featuresNeedsReload && !options?.initSession) {
+        if (this.features.bootloaderMode) {
+          return;
+        }
         // 不能直接信任缓存 features：设备端 wipe / 完成初始化 / 改 label 后
         // features 会永久陈旧。每次 run 做一次轻量 status 刷新（不含 fw/SE），
         // 用字段级合并保留已有版本和 SE 信息。
-        await this._refreshProtocolV2Status();
+        await this._refreshProtocolV2Status(options);
         return;
       }
-      await this._initializeProtocolV2();
+      await this._initializeProtocolV2(options);
       return;
     }
 
@@ -799,7 +809,7 @@ export class Device extends EventEmitter {
    * Protocol V2 不走传统 Initialize/GetFeatures；直接用 DeviceInfoGet
    * 生成唯一的 features 状态。
    */
-  private async _initializeProtocolV2() {
+  private async _initializeProtocolV2(options?: InitOptions) {
     Log.debug('Initialize device via Protocol V2 features adapter');
 
     try {
@@ -808,6 +818,7 @@ export class Device extends EventEmitter {
       // 且 reject 后底层调用仍会残留。
       const deviceInfo = await requestProtocolV2DeviceInfo({
         commands: this.commands,
+        timeoutMs: options?.protocolV2DeviceInfoTimeoutMs,
       });
       // 默认请求不含 SE/hash 数据，scope 如实标注为 basic；
       // 完整数据由 getDeviceInfo(scope:'verify'|'full') 获取。
@@ -827,11 +838,12 @@ export class Device extends EventEmitter {
    * passphrase_enabled 等会在设备端变化的字段；hw/coprocessor 提供 serialNo / bleName。
    * versions 为空时按字段级合并保留旧值，verify 数据不会被降级。
    */
-  private async _refreshProtocolV2Status() {
+  private async _refreshProtocolV2Status(options?: InitOptions) {
     try {
       const deviceInfo = await requestProtocolV2DeviceInfo({
         commands: this.commands,
         request: PROTOCOL_V2_STATUS_DEVICE_INFO_REQUEST,
+        timeoutMs: options?.protocolV2DeviceInfoTimeoutMs,
       });
       const features = this.updateProtocolV2Features(deviceInfo);
       Log.debug('Protocol V2 features (status refresh):', features);

--- a/packages/core/src/deviceProfile/buildDeviceFeatures.ts
+++ b/packages/core/src/deviceProfile/buildDeviceFeatures.ts
@@ -3,6 +3,7 @@ import { EDeviceType, EFirmwareType } from '@onekeyfe/hd-shared';
 import type { Features } from '../types';
 import type { PROTO } from '../constants';
 import type { DeviceFirmwareImageInfo, ProtocolV2DeviceInfo } from '@onekeyfe/hd-transport';
+import { isProtocolV2BootloaderDeviceInfo } from '../protocols/protocol-v2/features';
 
 type ProtocolV1FeaturesCompat = PROTO.Features &
   Partial<PROTO.OnekeyFeatures> & {
@@ -248,6 +249,14 @@ export const buildProtocolV2FeaturesPayload = (
   const unlocked = firstValue(status?.unlocked, previous?.unlocked) ?? null;
   const attachToPinEnabled = status?.attach_to_pin_enabled ?? null;
   const unlockedAttachPin = status?.unlocked_by_attach_to_pin ?? undefined;
+  const bootloaderMode = isProtocolV2BootloaderDeviceInfo(info);
+  const mode = bootloaderMode
+    ? 'bootloader'
+    : initialized === false
+    ? 'notInitialized'
+    : initialized === true
+    ? 'normal'
+    : 'unknown';
 
   return {
     protocol: 'V2',
@@ -261,9 +270,9 @@ export const buildProtocolV2FeaturesPayload = (
     label,
     bleName: bleName ?? null,
     capabilities: [],
-    mode: initialized === false ? 'notInitialized' : initialized === true ? 'normal' : 'unknown',
+    mode,
     initialized,
-    bootloaderMode: false,
+    bootloaderMode,
     unlocked,
     firmwarePresent: previous?.firmwarePresent ?? null,
     passphraseProtection,
@@ -337,17 +346,13 @@ export const buildProtocolV2FeaturesPayload = (
       se03Hash: getImageHash(info?.se3?.application) ?? previous?.verify?.se03Hash,
       se04BuildId: getImageBuildId(info?.se4?.application) ?? previous?.verify?.se04BuildId,
       se04Hash: getImageHash(info?.se4?.application) ?? previous?.verify?.se04Hash,
-      se01BootBuildId:
-        getImageBuildId(info?.se1?.bootloader) ?? previous?.verify?.se01BootBuildId,
+      se01BootBuildId: getImageBuildId(info?.se1?.bootloader) ?? previous?.verify?.se01BootBuildId,
       se01BootHash: getImageHash(info?.se1?.bootloader) ?? previous?.verify?.se01BootHash,
-      se02BootBuildId:
-        getImageBuildId(info?.se2?.bootloader) ?? previous?.verify?.se02BootBuildId,
+      se02BootBuildId: getImageBuildId(info?.se2?.bootloader) ?? previous?.verify?.se02BootBuildId,
       se02BootHash: getImageHash(info?.se2?.bootloader) ?? previous?.verify?.se02BootHash,
-      se03BootBuildId:
-        getImageBuildId(info?.se3?.bootloader) ?? previous?.verify?.se03BootBuildId,
+      se03BootBuildId: getImageBuildId(info?.se3?.bootloader) ?? previous?.verify?.se03BootBuildId,
       se03BootHash: getImageHash(info?.se3?.bootloader) ?? previous?.verify?.se03BootHash,
-      se04BootBuildId:
-        getImageBuildId(info?.se4?.bootloader) ?? previous?.verify?.se04BootBuildId,
+      se04BootBuildId: getImageBuildId(info?.se4?.bootloader) ?? previous?.verify?.se04BootBuildId,
       se04BootHash: getImageHash(info?.se4?.bootloader) ?? previous?.verify?.se04BootHash,
     },
     sessionId: previous?.sessionId ?? null,

--- a/packages/core/src/deviceProfile/buildDeviceProfile.ts
+++ b/packages/core/src/deviceProfile/buildDeviceProfile.ts
@@ -26,6 +26,7 @@ import type {
 } from '../types/api/getDeviceInfo';
 import type { Features, OnekeyFeatures } from '../types';
 import type { DeviceFirmwareImageInfo, ProtocolV2DeviceInfo } from '@onekeyfe/hd-transport';
+import { isProtocolV2BootloaderDeviceInfo } from '../protocols/protocol-v2/features';
 
 type BuildProtocolV1ProfileParams = {
   protocol?: DeviceInfoProtocol;
@@ -86,6 +87,7 @@ const getDeviceMode = (features?: Features): DeviceInfoStatus['mode'] => {
 };
 
 const getProtocolV2Mode = (deviceInfo?: ProtocolV2DeviceInfo): DeviceInfoStatus['mode'] => {
+  if (isProtocolV2BootloaderDeviceInfo(deviceInfo)) return 'bootloader';
   const initialized = deviceInfo?.status?.init_states;
   if (initialized === false) return 'notInitialized';
   if (initialized === true) return 'normal';
@@ -184,10 +186,11 @@ const normalizeV1Status = (features?: Features): DeviceInfoStatus => ({
 
 const normalizeV2Status = (deviceInfo?: ProtocolV2DeviceInfo): DeviceInfoStatus => {
   const status = deviceInfo?.status;
+  const bootloaderMode = isProtocolV2BootloaderDeviceInfo(deviceInfo);
   return {
     mode: getProtocolV2Mode(deviceInfo),
     initialized: status?.init_states ?? null,
-    bootloaderMode: false,
+    bootloaderMode,
     unlocked: status?.unlocked ?? null,
     passphraseProtection: status?.passphrase_enabled ?? null,
     attachToPinEnabled: status?.attach_to_pin_enabled ?? null,

--- a/packages/core/src/protocols/protocol-v2/features.ts
+++ b/packages/core/src/protocols/protocol-v2/features.ts
@@ -50,6 +50,9 @@ export const getProtocolV2SeState = (se?: DeviceSEInfo): ProtocolV2SeStateLabel 
 export const getProtocolV2SeType = (se?: DeviceSEInfo): string | null =>
   normalizeEnumValue(DeviceSeType, se?.type);
 
+export const isProtocolV2BootloaderDeviceInfo = (deviceInfo?: ProtocolV2DeviceInfo | null) =>
+  !!deviceInfo && deviceInfo.status == null;
+
 export const PROTOCOL_V2_FEATURES_DEVICE_INFO_REQUEST = {
   targets: {
     hw: true,

--- a/packages/core/src/types/params.ts
+++ b/packages/core/src/types/params.ts
@@ -15,6 +15,10 @@ export interface CommonParams {
    */
   timeout?: number;
   /**
+   * Protocol V2 初始化阶段 DeviceInfoGet 超时时间
+   */
+  protocolV2DeviceInfoTimeoutMs?: number;
+  /**
    * passphrase state
    */
   passphraseState?: string;

--- a/packages/hd-cli/src/cli.ts
+++ b/packages/hd-cli/src/cli.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 import { Command } from 'commander';
 
 import { createSDK, disposeSDK } from './sdk';
@@ -80,6 +82,7 @@ program.option(
 );
 program.option('--passphrase-state <state>', 'Passphrase state for hidden wallet access');
 program.option('--use-empty-passphrase', 'Use standard wallet (skip passphrase prompt)');
+program.option('--debug', 'Enable SDK debug logs');
 
 // ============================================================
 // Device Commands
@@ -549,6 +552,29 @@ program
           'BLE firmware update via CLI is not supported. Please use the OneKey App or https://firmware.onekey.so/ to update firmware.',
         code: 'FIRMWARE_UPDATE_NOT_SUPPORTED',
       },
+    })
+  );
+
+program
+  .command('firmware-update-v4-debug')
+  .description('Debug Protocol V2 firmware update through sdk.firmwareUpdateV4')
+  .option('--chunk-size <bytes>', 'Transfer chunk size in bytes')
+  .option('--resource <path>', 'FW_MGMT_TARGET_RESOURCE binary path')
+  .option('--romloader <path>', 'FW_MGMT_TARGET_ROMLOADER binary path')
+  .option('--bootloader <path>', 'FW_MGMT_TARGET_BOOTLOADER binary path')
+  .option('--application-p1 <path>', 'FW_MGMT_TARGET_APPLICATION_P1 binary path')
+  .option('--application-p2 <path>', 'FW_MGMT_TARGET_APPLICATION_P2 binary path')
+  .option('--coprocessor <path>', 'FW_MGMT_TARGET_COPROCESSOR binary path')
+  .option('--se01 <path>', 'FW_MGMT_TARGET_SE01 binary path')
+  .option('--se02 <path>', 'FW_MGMT_TARGET_SE02 binary path')
+  .option('--se03 <path>', 'FW_MGMT_TARGET_SE03 binary path')
+  .option('--se04 <path>', 'FW_MGMT_TARGET_SE04 binary path')
+  .option('--forced-update-res', 'Force resource update')
+  .action(opts =>
+    runCommand({}, async ({ sdk, globalOpts }) => {
+      const params = buildFirmwareUpdateV4DebugParams(opts);
+      const result = await sdk.firmwareUpdateV4(globalOpts.connectId, params);
+      outputResult(globalOpts, result);
     })
   );
 
@@ -1117,6 +1143,64 @@ function safeJsonParse(input: string, label: string): unknown {
     (err as Error & { code?: string }).code = 'INVALID_JSON';
     throw err;
   }
+}
+
+function readBinaryParam(path: string): ArrayBuffer {
+  const buffer = readFileSync(path);
+  return new Uint8Array(buffer).buffer;
+}
+
+function buildFirmwareUpdateV4DebugParams(opts: {
+  chunkSize?: string;
+  resource?: string;
+  romloader?: string;
+  bootloader?: string;
+  applicationP1?: string;
+  applicationP2?: string;
+  coprocessor?: string;
+  se01?: string;
+  se02?: string;
+  se03?: string;
+  se04?: string;
+  forcedUpdateRes?: boolean;
+}) {
+  const params = {
+    platform: 'desktop' as const,
+    connectProtocol: 'V2' as const,
+    chunkSize: opts.chunkSize ? safeParseInt(opts.chunkSize, '--chunk-size') : undefined,
+    forcedUpdateRes: opts.forcedUpdateRes,
+    resourceBinary: opts.resource ? readBinaryParam(opts.resource) : undefined,
+    romloaderBinary: opts.romloader ? readBinaryParam(opts.romloader) : undefined,
+    bootloaderBinary: opts.bootloader ? readBinaryParam(opts.bootloader) : undefined,
+    applicationP1Binary: opts.applicationP1 ? readBinaryParam(opts.applicationP1) : undefined,
+    applicationP2Binary: opts.applicationP2 ? readBinaryParam(opts.applicationP2) : undefined,
+    coprocessorBinary: opts.coprocessor ? readBinaryParam(opts.coprocessor) : undefined,
+    se01Binary: opts.se01 ? readBinaryParam(opts.se01) : undefined,
+    se02Binary: opts.se02 ? readBinaryParam(opts.se02) : undefined,
+    se03Binary: opts.se03 ? readBinaryParam(opts.se03) : undefined,
+    se04Binary: opts.se04 ? readBinaryParam(opts.se04) : undefined,
+  };
+
+  const hasPayload = [
+    params.resourceBinary,
+    params.romloaderBinary,
+    params.bootloaderBinary,
+    params.applicationP1Binary,
+    params.applicationP2Binary,
+    params.coprocessorBinary,
+    params.se01Binary,
+    params.se02Binary,
+    params.se03Binary,
+    params.se04Binary,
+  ].some(Boolean);
+
+  if (!hasPayload) {
+    const err = new Error('firmware-update-v4-debug requires at least one binary path');
+    (err as Error & { code?: string }).code = 'MISSING_FIRMWARE_BINARY';
+    throw err;
+  }
+
+  return params;
 }
 
 /**

--- a/packages/hd-cli/src/sdk.ts
+++ b/packages/hd-cli/src/sdk.ts
@@ -22,6 +22,7 @@ export interface SDKOptions {
   connectId?: string;
   passphraseState?: string;
   useEmptyPassphrase?: boolean;
+  debug?: boolean;
 }
 
 /**
@@ -183,7 +184,7 @@ function registerEventHandlers(sdk: typeof HardwareSDK): void {
 
 async function initSDK(): Promise<typeof HardwareSDK> {
   const settings: Partial<ConnectSettings> = {
-    debug: false,
+    debug: currentOpts.debug ?? false,
     fetchConfig: true,
     env: 'node-usb',
   };

--- a/packages/hd-transport-usb/src/index.ts
+++ b/packages/hd-transport-usb/src/index.ts
@@ -44,7 +44,7 @@ const SERIAL_READ_TIMEOUT_MS = 5000;
 /** Packet I/O retry configuration (matches WebUsbTransport) */
 const PACKET_IO_MAX_RETRIES = 3;
 const PACKET_IO_RETRY_DELAY = 300;
-const PROTOCOL_PROBE_TIMEOUT = 1000;
+const PROTOCOL_PROBE_TIMEOUT = 5000;
 
 /**
  * Opened device state — holds the USB device, claimed interface, and endpoints.
@@ -151,32 +151,6 @@ function transferOutOnce(ep: usb.OutEndpoint, data: Buffer): Promise<void> {
       if (err) return reject(err);
       resolve();
     });
-  });
-}
-
-function resetUsbDevice(dev: usb.Device): Promise<void> {
-  return new Promise(resolve => {
-    const reset = (dev as usb.Device & { reset?: (callback: (err?: Error) => void) => void }).reset;
-    if (typeof reset !== 'function') {
-      resolve();
-      return;
-    }
-    reset.call(dev, () => resolve());
-  });
-}
-
-function clearEndpointHalt(ep: usb.InEndpoint | usb.OutEndpoint): Promise<void> {
-  return new Promise(resolve => {
-    const clearHalt = (
-      ep as (usb.InEndpoint | usb.OutEndpoint) & {
-        clearHalt?: (callback: (err?: Error) => void) => void;
-      }
-    ).clearHalt;
-    if (typeof clearHalt !== 'function') {
-      resolve();
-      return;
-    }
-    clearHalt.call(ep, () => resolve());
   });
 }
 
@@ -515,6 +489,11 @@ export default class NodeUsbTransport {
     );
   }
 
+  private isUsbTransferTimeout(error: unknown): boolean {
+    const message = this.getErrorMessage(error).toLowerCase();
+    return message.includes('timeout') || message.includes('timed_out');
+  }
+
   private getDeviceInterface(dev: usb.Device): usb.Interface {
     const { interfaces } = dev;
     if (!interfaces?.length) {
@@ -629,7 +608,8 @@ export default class NodeUsbTransport {
   private async transferInWithRetry(
     path: string,
     openDev: OpenDevice,
-    length: number
+    length: number,
+    options?: { waitIndefinitelyOnTimeout?: boolean }
   ): Promise<Buffer> {
     let lastError: unknown;
     let currentDev = openDev;
@@ -641,6 +621,10 @@ export default class NodeUsbTransport {
         return await transferInOnce(currentDev.epIn, length);
       } catch (error) {
         lastError = error;
+        if (options?.waitIndefinitelyOnTimeout && this.isUsbTransferTimeout(error)) {
+          attempt -= 1;
+          continue;
+        }
         const shouldRetry = attempt < PACKET_IO_MAX_RETRIES && this.isRetryableError(error);
         if (!shouldRetry) {
           throw error;
@@ -680,15 +664,6 @@ export default class NodeUsbTransport {
       dev.open();
       dev.timeout = TRANSFER_TIMEOUT_MS;
 
-      await resetUsbDevice(dev);
-
-      try {
-        dev.open();
-      } catch {
-        // libusb keeps some devices open across reset; continue with the current handle.
-      }
-      dev.timeout = TRANSFER_TIMEOUT_MS;
-
       const iface = this.getDeviceInterface(dev);
 
       // On Linux, detach kernel driver if active
@@ -723,8 +698,6 @@ export default class NodeUsbTransport {
       epIn.timeout = TRANSFER_TIMEOUT_MS;
       epOut.timeout = TRANSFER_TIMEOUT_MS;
 
-      await clearEndpointHalt(epIn);
-      await clearEndpointHalt(epOut);
       await this.drainStaleInput(epIn);
 
       this.openDevices.set(path, { device: dev, iface, epIn, epOut });
@@ -943,7 +916,8 @@ export default class NodeUsbTransport {
       const transferIn = this.transferInWithRetry(
         path,
         this.getOpenDevice(path),
-        PROTOCOL_V2_FRAME_MAX_BYTES
+        PROTOCOL_V2_FRAME_MAX_BYTES,
+        { waitIndefinitelyOnTimeout: !deadline }
       );
       const packet = deadline
         ? await this.withProtocolReadTimeout(

--- a/packages/hd-transport/src/constants.ts
+++ b/packages/hd-transport/src/constants.ts
@@ -20,11 +20,11 @@ export const PROTOCOL_V1_ENVELOPE_HEADER_SIZE = 1 + 1 + PROTOCOL_V1_MESSAGE_HEAD
 
 // ---- Protocol V2 (Pro2 USB / BLE transports) ----
 
-/** Protocol V2 单帧最大长度，包含 header、payload 和 CRC；需容纳 4096 数据块及 protobuf 开销。 */
+/** Protocol V2 单帧最大长度，包含 header、payload 和 CRC；需容纳 4000 数据块及 protobuf 开销。 */
 export const PROTOCOL_V2_FRAME_MAX_BYTES = 4608;
 
 /** WebUSB 下 FilesystemFileWrite 的文件数据分块大小。 */
-export const PROTOCOL_V2_WEBUSB_FILE_CHUNK_SIZE = 4096;
+export const PROTOCOL_V2_WEBUSB_FILE_CHUNK_SIZE = 4000;
 
 /** BLE 下 FilesystemFileWrite 的文件数据分块大小。 */
 export const PROTOCOL_V2_BLE_FILE_CHUNK_SIZE = 1800;

--- a/packages/hd-transport/src/protocols/v2/session.ts
+++ b/packages/hd-transport/src/protocols/v2/session.ts
@@ -229,11 +229,10 @@ export async function withProtocolTimeout<T>(
   }
 }
 
-// Watchdog for the write phase only. Writing a single frame (max 4608 bytes)
-// is a bounded transport operation, unlike the read phase where long-running
-// device operations (firmware install, user confirmation) can legitimately
-// take minutes — so no default timeout is applied to reads.
-export const PROTOCOL_V2_WRITE_WATCHDOG_TIMEOUT_MS = 30000;
+// Write completion is owned by the concrete transport. A Promise.race watchdog
+// here can return while libusb/WebUSB is still flushing a large Protocol V2
+// frame, which desynchronizes later request/response pairs.
+export const PROTOCOL_V2_WRITE_WATCHDOG_TIMEOUT_MS = 0;
 
 export class ProtocolV2Session {
   private readonly options: ProtocolV2SessionOptions;


### PR DESCRIPTION
## What changed
- Stabilize firmwareUpdateV4 for Protocol V2 bootloader reconnect, install status polling, final normal-mode polling, and WebUSB transfer behavior.
- Keep Protocol V2 firmware target/status handling canonical as numeric enums internally while accepting protobuf decoded enum names from the current SDK decode layer.
- Add hd-cli firmware-update-v4-debug payload options for local Pro2 update testing.
- Add focused Protocol V2 tests for bootloader mode detection, reconnect polling, status enum normalization, chunk size 4000, and file write behavior.

## Why
The protobuf wire enum is numeric, but the current SDK protobuf decoder converts single enum fields to enum-name strings. firmwareUpdateV4 now normalizes those decoded names back to numeric protocol values before comparing status/target IDs, so the update logic stays aligned with the firmware protocol without requiring a firmware-side enum change.

## Validation
- yarn --cwd packages/core test protocol-v2.test.ts --runInBand
- yarn --cwd packages/core build
- yarn --cwd packages/hd-cli build

## Notes
- packages/core build still prints the existing CheckAllFirmwareRelease TS2352 warning, but dts generation completed successfully.
- firmware-pro2 local changes are not included in this SDK PR; they need a separate firmware repo PR if we want firmware-side review.