### PR TITLE
[codex] hide Agent Wallet navigation

### DIFF
--- a/packages/connect-examples/developer-portal/content/en/_meta.js
+++ b/packages/connect-examples/developer-portal/content/en/_meta.js
@@ -13,39 +13,10 @@ export default {
       copyPage: false,
     },
   },
-  /*
   'agent-wallet': {
     title: 'Agent Wallet',
-    type: 'menu',
-    items: {
-      landing: { title: 'Landing', href: '/en/agent-wallet/' },
-      overview: { title: 'Overview', href: '/en/agent-wallet/overview' },
-      quickstart: { title: 'Quickstart', href: '/en/agent-wallet/quickstart' },
-      capabilities: {
-        title: 'Capabilities',
-        href: '/en/agent-wallet/capabilities',
-      },
-      'wallet-skills': {
-        title: 'Wallet Skills',
-        href: '/en/agent-wallet/wallet-skills',
-      },
-      recipes: { title: 'Recipes', href: '/en/agent-wallet/recipes' },
-      'wallet-session': {
-        title: 'Agent Wallet Session',
-        href: '/en/agent-wallet/wallet-session',
-      },
-      'keyless-binding': {
-        title: 'Keyless Binding',
-        href: '/en/agent-wallet/keyless-binding',
-      },
-      'hardware-control': {
-        title: 'Hardware Control',
-        href: '/en/agent-wallet/hardware-control',
-      },
-      safety: { title: 'Safety Rules', href: '/en/agent-wallet/safety' },
-    },
+    display: 'hidden',
   },
-  */
   // Navigation menus with dropdown items
   'hardware-sdk': {
     title: 'Hardware Integration',

--- a/packages/connect-examples/developer-portal/content/zh/_meta.js
+++ b/packages/connect-examples/developer-portal/content/zh/_meta.js
@@ -13,39 +13,10 @@ export default {
       copyPage: false,
     },
   },
-  /*
   'agent-wallet': {
     title: 'Agent Wallet',
-    type: 'menu',
-    items: {
-      landing: { title: '首页', href: '/zh/agent-wallet/' },
-      overview: { title: '概览', href: '/zh/agent-wallet/overview' },
-      quickstart: { title: '快速开始', href: '/zh/agent-wallet/quickstart' },
-      capabilities: {
-        title: '能力地图',
-        href: '/zh/agent-wallet/capabilities',
-      },
-      'wallet-skills': {
-        title: 'Wallet Skills',
-        href: '/zh/agent-wallet/wallet-skills',
-      },
-      recipes: { title: '场景示例', href: '/zh/agent-wallet/recipes' },
-      'wallet-session': {
-        title: 'Agent Wallet 会话',
-        href: '/zh/agent-wallet/wallet-session',
-      },
-      'keyless-binding': {
-        title: 'Keyless 绑定',
-        href: '/zh/agent-wallet/keyless-binding',
-      },
-      'hardware-control': {
-        title: '硬件控制',
-        href: '/zh/agent-wallet/hardware-control',
-      },
-      safety: { title: '安全规则', href: '/zh/agent-wallet/safety' },
-    },
+    display: 'hidden',
   },
-  */
   // 导航菜单及下拉项
   'hardware-sdk': {
     title: '硬件接入',


### PR DESCRIPTION
## What changed

- Explicitly hide the Agent Wallet section from the English developer documentation navigation.
- Explicitly hide the Agent Wallet section from the Chinese developer documentation navigation.
- Keep the existing documentation pages and direct URLs available.

## Why

Commenting out the menu configuration does not reliably hide the directory because Nextra can still discover pages from the filesystem. Setting display: hidden at the top-level metadata prevents the Agent Wallet section from appearing in navigation without deleting its content or routes.

## Validation

- git diff --check
- node --check packages/connect-examples/developer-portal/content/en/_meta.js
- node --check packages/connect-examples/developer-portal/content/zh/_meta.js

Dependencies were not installed and a full documentation build was not run, as this is a metadata-only change.