### PR TITLE
fix(automation): harden main-wallet passphrase guard and slow SDK case pacing

### DIFF
--- a/packages/connect-examples/expo-example/src/testTools/automationTest/useAutomationTest.ts
+++ b/packages/connect-examples/expo-example/src/testTools/automationTest/useAutomationTest.ts
@@ -118,7 +118,7 @@ const CONFIRM_ACTION_STEP_DELAY_MS = 1000;
 const POST_SEQUENCE_SETTLE_MS = 3000;
 /** Extra settle time between device preparation (import/create) and the first SDK call. */
 const PRE_SDK_SETTLE_MS = 3000;
-const SDK_CASE_DELAY_MS = 80;
+const SDK_CASE_DELAY_MS = 300;
 const DEVICE_FLOW_ONLY_SUITES: TestSuiteType[] = ['deviceFlow'];
 type DeviceUiAction = 'confirm' | 'slide';
 
@@ -1463,10 +1463,16 @@ export function useAutomationTest() {
         featuresAfter = await fetchDeviceFeatures(sdk, connectId);
       }
 
-      const forceUseEmptyPassphrase = featuresAfter?.passphrase_protection === true;
+      // Treat an unknown state (features fetch failed) as still-enabled: forcing
+      // useEmptyPassphrase on a passphrase-off device is a harmless no-op, while
+      // skipping it on a passphrase-on device fails every main-wallet call with
+      // DeviceOpenedPassphrase (a prior deviceFlow suite leaves passphrase on).
+      const forceUseEmptyPassphrase = featuresAfter?.passphrase_protection !== false;
       if (forceUseEmptyPassphrase) {
         addLog(
-          `[${suiteLabel}] passphrase_protection is still enabled; forcing useEmptyPassphrase for main-wallet SDK calls`
+          `[${suiteLabel}] passphrase_protection is ${
+            featuresAfter ? 'still enabled' : 'unknown'
+          }; forcing useEmptyPassphrase for main-wallet SDK calls`
         );
       }
 


### PR DESCRIPTION
## Summary

Two robustness fixes for the hardware automation test suite (runs against PhonePilot):

- **`prepareStandaloneMainWallet`: treat an unknown `passphrase_protection` state as still-enabled.** The guard used `featuresAfter?.passphrase_protection === true`, so a transient `getFeatures` failure (`undefined`) skipped `useEmptyPassphrase` on all main-wallet calls. When a preceding deviceFlow suite left the device with passphrase enabled, every securityCheck/chainMethodBatch case then failed with `failure(Device opened passphrase)` (observed on the "BIP39 导入 / API 专用助记词" scenario). Forcing `useEmptyPassphrase` on a passphrase-off device is a harmless no-op, so unknown now defaults to forcing it; the log line distinguishes `still enabled` from `unknown`.
- **`SDK_CASE_DELAY_MS` 80ms → 300ms** to reduce flakiness between consecutive SDK cases.

Counterpart PhonePilot changes (OCR calibration + sequence timing): OneKeyHQ/qa-auto-hardware#32. All PhonePilot sequence IDs referenced here (`/health` drift check) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)