### PR TITLE
fix: correct Agent Wallet mobile layout

### DIFF
--- a/packages/connect-examples/developer-portal/components/AgentWalletLanding.jsx
+++ b/packages/connect-examples/developer-portal/components/AgentWalletLanding.jsx
@@ -217,7 +217,7 @@ export function AgentWalletLanding({ locale = 'en' }) {
   const basePath = `/${locale}`
 
   return (
-    <div className="landing-page flex min-h-screen max-w-full flex-col overflow-x-hidden bg-[#101111] text-white">
+    <div className="landing-page flex min-h-screen flex-col overflow-x-hidden bg-[#101111] text-white">
       <main className="flex flex-col">
         {/* HERO — copy + product shot */}
         <section className="relative overflow-hidden">

--- a/packages/connect-examples/developer-portal/styles/globals.css
+++ b/packages/connect-examples/developer-portal/styles/globals.css
@@ -938,7 +938,7 @@ input[type="search"]::placeholder,
 }
 
 .agent-wallet-disclaimer {
-  margin: 0 0 var(--space-6);
+  margin: var(--space-10) 0 var(--space-6);
   padding: var(--space-4) var(--space-5);
   border: 1px solid rgba(251, 191, 36, 0.35);
   border-left: 4px solid #f59e0b;
@@ -960,6 +960,10 @@ input[type="search"]::placeholder,
   color: inherit;
   font-size: 14px;
   line-height: 1.65;
+}
+
+body:has(.landing-page) .agent-wallet-disclaimer {
+  margin-top: 0;
 }
 
 /* Ensure main footer stays visible */
@@ -1613,6 +1617,7 @@ hr {
 /* Landing page container - break out of article constraints */
 .landing-page {
   width: 100vw;
+  max-width: none;
   margin-left: calc(-50vw + 50%);
   flex: 1;
   display: flex;


### PR DESCRIPTION
## Summary

- let the Agent Wallet landing page break out to the full viewport width on mobile
- add stable spacing between the breadcrumb/copy controls and the private beta disclaimer
- preserve the compact disclaimer spacing on the landing page

## Root cause

The landing page combined `width: 100vw` with Tailwind's `max-w-full`, so the Nextra article container capped it at 358px inside a 390px viewport and left a visible strip on the right. On documentation pages, the disclaimer was inserted as the first content element with no top margin, placing it at the same vertical position as Nextra's floating Copy Page control and directly against the breadcrumb.

## Impact

Agent Wallet pages now render without horizontal clipping on narrow screens, and the disclaimer no longer overlaps page controls. Desktop layout and both English and Chinese routes retain their existing behavior.

## Validation

- `yarn build` in `packages/connect-examples/developer-portal` (586 static pages generated)
- `git diff --check`
- Playwright viewport checks at 390×844 for English landing, English Recipes, and Chinese Recipes
- Playwright viewport check at 1440×900 for the desktop landing page
- confirmed document `scrollWidth` equals viewport width at both 390px and 1440px

`yarn agent:check --profile commit` is not available on the current `onekey` base because the root package does not define the `agent:check` script.