### PR TITLE
[codex] add optional Pro2 boot resources update

### DIFF
--- a/packages/connect-examples/electron-example/package.json
+++ b/packages/connect-examples/electron-example/package.json
@@ -2,7 +2,7 @@
   "name": "hardware-example",
   "productName": "HardwareExample",
   "executableName": "onekey-hardware-example",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "author": "OneKey",
   "description": "End-to-end encrypted workspaces for teams",
   "main": "dist/index.js",

--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "scripts": {
     "start": "cross-env CONNECT_SRC=https://localhost:8087/ yarn expo start --dev-client",
     "android": "yarn expo run:android",

--- a/packages/connect-examples/expo-playground/package.json
+++ b/packages/connect-examples/expo-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onekey-hardware-playground",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "private": true,
   "sideEffects": [
     "app/utils/shim.js",
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.8.0",
-    "@onekeyfe/hd-common-connect-sdk": "1.2.0-alpha.44",
-    "@onekeyfe/hd-core": "1.2.0-alpha.44",
-    "@onekeyfe/hd-shared": "1.2.0-alpha.44",
+    "@onekeyfe/hd-common-connect-sdk": "1.2.0-alpha.45",
+    "@onekeyfe/hd-core": "1.2.0-alpha.45",
+    "@onekeyfe/hd-shared": "1.2.0-alpha.45",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/packages/connect-examples/hwk-demo/package.json
+++ b/packages/connect-examples/hwk-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hwk-demo",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/packages/core/__tests__/protocol-v2-resources.test.ts
+++ b/packages/core/__tests__/protocol-v2-resources.test.ts
@@ -12,7 +12,12 @@ import {
   requestProtocolV2ResourceInventory,
 } from '../src/protocols/protocol-v2/resources';
 
-import type { ConnectSettings, IProtocolV2Resource, RemoteConfigResponse } from '../src/types';
+import type {
+  ConnectSettings,
+  IProtocolV2BootResources,
+  IProtocolV2Resource,
+  RemoteConfigResponse,
+} from '../src/types';
 
 jest.mock('axios');
 jest.mock('../src/data/config', () => ({
@@ -31,6 +36,16 @@ const resources: IProtocolV2Resource[] = PROTOCOL_V2_RESOURCE_TYPES.map((type, i
   headerHash: index.toString(16).padStart(128, '0'),
 }));
 
+const bootResources: IProtocolV2BootResources = {
+  required: false,
+  target: 'CRATE',
+  url: 'https://example.com/boot-resources.crate.okpkg',
+  size: 1234,
+  fileHash: 'ab'.repeat(32),
+  payloadHash: 'cd'.repeat(64),
+  headerHash: 'ef'.repeat(64),
+};
+
 const createSettings = (configFetcher: ConnectSettings['configFetcher']): ConnectSettings =>
   ({
     env: 'node',
@@ -47,7 +62,7 @@ const createRemoteConfig = (): RemoteConfigResponse =>
     mini: { firmware: [], ble: [] },
     touch: { firmware: [], ble: [] },
     pro: { firmware: [], ble: [] },
-    pro2: { firmware: [], ble: [], resources: { stable: resources } },
+    pro2: { firmware: [], ble: [], resources: { stable: resources, boot: bootResources } },
     bridge: {},
   } as unknown as RemoteConfigResponse);
 
@@ -58,9 +73,13 @@ describe('Pro2 resource configuration', () => {
   });
 
   test('accepts exactly six resources and normalizes their deterministic order', () => {
-    const parsed = parseProtocolV2Resources({ stable: [...resources].reverse() });
+    const parsed = parseProtocolV2Resources({
+      stable: [...resources].reverse(),
+      boot: bootResources,
+    });
 
     expect(parsed?.stable.map(item => item.type)).toEqual(PROTOCOL_V2_RESOURCE_TYPES);
+    expect(parsed?.boot).toEqual(bootResources);
     expect(PROTOCOL_V2_RESOURCE_DEVICE_PATHS.translations).toBe(
       'vol0:/bundles/translations/translations.okpkg'
     );
@@ -80,6 +99,21 @@ describe('Pro2 resource configuration', () => {
         ),
       })
     ).toThrow('headerHash');
+  });
+
+  test('requires boot resources to remain optional and use a CRATE package', () => {
+    expect(() =>
+      parseProtocolV2Resources({
+        stable: resources,
+        boot: { ...bootResources, required: true },
+      })
+    ).toThrow('required flag');
+    expect(() =>
+      parseProtocolV2Resources({
+        stable: resources,
+        boot: { ...bootResources, target: 'RESC' },
+      })
+    ).toThrow('expected CRATE');
   });
 
   test('downloads nothing when all resource identities match', () => {
@@ -186,6 +220,7 @@ describe('Pro2 resource configuration', () => {
       expect.stringMatching(/^https:\/\/data\.onekey\.so\/pre-config\.json\?noCache=/)
     );
     expect(DataManager.getProtocolV2Resources()).toEqual(resources);
+    expect(DataManager.getProtocolV2BootResources()).toEqual(bootResources);
   });
 
   test('does not advance the cache timestamp when refresh fails', async () => {

--- a/packages/core/__tests__/protocol-v2.test.ts
+++ b/packages/core/__tests__/protocol-v2.test.ts
@@ -5,6 +5,7 @@ import {
   DeviceSettingsPage,
   DeviceType,
 } from '@onekeyfe/hd-transport';
+import { sha256 } from '@noble/hashes/sha256';
 
 import * as firmwareBinaryApi from '../src/api/firmware/getBinary';
 import DnxGetAddress from '../src/api/dynex/DnxGetAddress';
@@ -5982,6 +5983,100 @@ describe('Protocol V2 firmware reconnect identity', () => {
     expect(typedCall).not.toHaveBeenCalled();
     expect((method as any).downloadProtocolV2Resource).toHaveBeenCalledTimes(6);
     resourcesSpy.mockRestore();
+  });
+
+  const buildBootResourcesHeader = ({
+    type = 'CRAT',
+    payloadHash = 'ab'.repeat(64),
+    headerHash = 'cd'.repeat(64),
+  }: {
+    type?: string;
+    payloadHash?: string;
+    headerHash?: string;
+  } = {}) => {
+    const header = new Uint8Array(0x52a0);
+    const view = new DataView(header.buffer);
+    'OKPP'.split('').forEach((char, index) => {
+      header[index] = char.charCodeAt(0);
+    });
+    type.split('').forEach((char, index) => {
+      header[0x08 + index] = char.charCodeAt(0);
+    });
+    view.setUint32(0x0c, header.byteLength, true);
+    const writeHex = (offset: number, hex: string) => {
+      for (let index = 0; index < hex.length / 2; index++) {
+        header[offset + index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16);
+      }
+    };
+    writeHex(0x200, payloadHash);
+    writeHex(0x240, headerHash);
+    return header;
+  };
+
+  test('does not resolve boot resources unless the optional target is selected', async () => {
+    const method = new FirmwareUpdateV4({
+      id: 1,
+      payload: { method: 'firmwareUpdateV4', platform: 'web' },
+    });
+    method.init();
+    const configSpy = jest.spyOn(DataManager, 'getProtocolV2BootResources');
+    const downloadSpy = jest.spyOn(firmwareBinaryApi, 'getSysResourceBinary');
+
+    await expect((method as any).prepareProtocolV2BootResources()).resolves.toBeUndefined();
+
+    expect(configSpy).not.toHaveBeenCalled();
+    expect(downloadSpy).not.toHaveBeenCalled();
+  });
+
+  test('downloads and maps the selected boot resources CRATE target', async () => {
+    const payloadHash = 'ab'.repeat(64);
+    const headerHash = 'cd'.repeat(64);
+    const bytes = buildBootResourcesHeader({ payloadHash, headerHash });
+    const binary = bytes.buffer as ArrayBuffer;
+    const fileHash = Array.from(sha256(bytes), byte => byte.toString(16).padStart(2, '0')).join('');
+    const resource = {
+      required: false as const,
+      target: 'CRATE' as const,
+      url: 'https://example.com/boot-resources.crate.okpkg',
+      size: bytes.byteLength,
+      fileHash,
+      payloadHash,
+      headerHash,
+    };
+    const method = new FirmwareUpdateV4({
+      id: 1,
+      payload: {
+        method: 'firmwareUpdateV4',
+        platform: 'web',
+        targetsToUpdate: ['boot_resources'],
+      },
+    });
+    method.init();
+    jest.spyOn(DataManager, 'getProtocolV2BootResources').mockReturnValue(resource);
+    jest.spyOn(firmwareBinaryApi, 'getSysResourceBinary').mockResolvedValue({ binary });
+
+    await expect((method as any).prepareProtocolV2BootResources()).resolves.toEqual({
+      fileName: 'boot_resources.crate.okpkg',
+      binary,
+      targetId: 1,
+      kind: 'boot_resources',
+    });
+  });
+
+  test('rejects a non-CRATE manual boot resources package', async () => {
+    const method = new FirmwareUpdateV4({
+      id: 1,
+      payload: {
+        method: 'firmwareUpdateV4',
+        platform: 'web',
+        bootResourcesBinary: buildBootResourcesHeader({ type: 'RESC' }).buffer,
+      },
+    });
+    method.init();
+
+    await expect((method as any).prepareProtocolV2BootResources()).rejects.toThrow(
+      'Invalid Pro2 boot resources CRATE header'
+    );
   });
 });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "description": "Core processes and APIs for communicating with OneKey hardware devices.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.0-alpha.44",
-    "@onekeyfe/hd-transport": "1.2.0-alpha.44",
+    "@onekeyfe/hd-shared": "1.2.0-alpha.45",
+    "@onekeyfe/hd-transport": "1.2.0-alpha.45",
     "axios": "1.15.2",
     "bignumber.js": "^9.0.2",
     "bytebuffer": "^5.0.1",

--- a/packages/core/src/api/FirmwareUpdateV4.ts
+++ b/packages/core/src/api/FirmwareUpdateV4.ts
@@ -45,6 +45,7 @@ import type { TypedResponseMessage } from '../device/DeviceCommands';
 import type {
   Features,
   IFirmwareReleaseInfo,
+  IProtocolV2BootResources,
   IProtocolV2FirmwareComponent,
   IProtocolV2Resource,
   IVersionArray,
@@ -74,6 +75,7 @@ const PROTOCOL_V2_OKPP_HEADER_SIZE = 0x52a0;
 const PROTOCOL_V2_OKPP_PAYLOAD_HASH_OFFSET = 0x200;
 const PROTOCOL_V2_OKPP_HEADER_HASH_OFFSET = 0x240;
 const PROTOCOL_V2_OKPP_HASH_SIZE = 64;
+const PROTOCOL_V2_BOOT_RESOURCES_FILE_NAME = 'boot_resources.crate.okpkg';
 
 const getProtocolV2DeviceTransferProgress = (
   bytesBeforeChunk: number,
@@ -108,7 +110,7 @@ type ProtocolV2FirmwareUpdateStartResponse = TypedResponseMessage<'Success'>;
 
 type ProtocolV2TargetBinary = { fileName: string; binary: ArrayBuffer; targetId: number };
 type ProtocolV2InstallItem = ProtocolV2TargetBinary & {
-  kind: ProtocolV2RemoteComponentTarget['kind'];
+  kind: ProtocolV2RemoteComponentTarget['kind'] | 'boot_resources';
 };
 type ProtocolV2InstallTarget = ProtocolV2InstallItem & {
   path: string;
@@ -424,6 +426,7 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
       { name: 'chunkSize', type: 'number' },
       { name: 'forcedUpdateRes', type: 'boolean' },
       { name: 'bootloaderBinary', type: 'buffer' },
+      { name: 'bootResourcesBinary', type: 'buffer' },
       { name: 'romloaderBinary', type: 'buffer' },
       { name: 'applicationP1Binary', type: 'buffer' },
       { name: 'applicationP2Binary', type: 'buffer' },
@@ -442,6 +445,7 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
       chunkSize: payload.chunkSize,
       forcedUpdateRes: payload.forcedUpdateRes,
       bootloaderBinary: payload.bootloaderBinary,
+      bootResourcesBinary: payload.bootResourcesBinary,
       romloaderBinary: payload.romloaderBinary,
       applicationP1Binary: payload.applicationP1Binary,
       applicationP2Binary: payload.applicationP2Binary,
@@ -490,6 +494,7 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
 
     let fwBinaryMap: ProtocolV2TargetBinary[] = [];
     let bootloaderBinary: ArrayBuffer | null = null;
+    let bootResourcesInstallItem: ProtocolV2InstallItem | undefined;
     let installItems: ProtocolV2InstallItem[] | undefined;
     let resourceBundles: ProtocolV2ResourceBundleBinary[] | undefined;
     try {
@@ -500,7 +505,10 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
       const needsRemoteResources =
         !this.params.resourceBundleFiles?.length &&
         !!this.params.targetsToUpdate?.includes('resource');
-      if (needsRemoteFirmware || needsRemoteResources) {
+      const needsRemoteBootResources =
+        !this.params.bootResourcesBinary &&
+        !!this.params.targetsToUpdate?.includes('boot_resources');
+      if (needsRemoteFirmware || needsRemoteResources || needsRemoteBootResources) {
         // Remote updates must use a freshly fetched config before any reboot or file write.
         await DataManager.forceReloadData();
       }
@@ -513,13 +521,25 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
         fwBinaryMap = remoteBinaries.fwBinaryMap;
         installItems = remoteBinaries.installItems;
       }
+      bootResourcesInstallItem = await this.prepareProtocolV2BootResources();
+      if (bootResourcesInstallItem) {
+        installItems = [
+          bootResourcesInstallItem,
+          ...(installItems ?? this.buildProtocolV2InstallItems({ bootloaderBinary, fwBinaryMap })),
+        ];
+      }
       resourceBundles = await this.prepareProtocolV2ResourceBundles(resourceRecoveryMode);
       this.postTipMessage(FirmwareUpdateTipMessage.FinishDownloadFirmware);
     } catch (err) {
       throw ERRORS.TypedError(HardwareErrorCode.FirmwareUpdateDownloadFailed, err.message ?? err);
     }
 
-    if (!bootloaderBinary && fwBinaryMap.length === 0 && !resourceBundles?.length) {
+    if (
+      !bootloaderBinary &&
+      fwBinaryMap.length === 0 &&
+      !installItems?.length &&
+      !resourceBundles?.length
+    ) {
       if (resourceBundles !== undefined) {
         this.postTipMessage(FirmwareUpdateTipMessage.FirmwareUpdateCompleted);
         return this.getProtocolV2VersionResult(deviceFeatures);
@@ -599,6 +619,7 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
     return (
       !!this.params.resourceBundleFiles?.length ||
       !!this.params.bootloaderBinary ||
+      !!this.params.bootResourcesBinary ||
       fwBinaryMap.length > 0
     );
   }
@@ -745,6 +766,54 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
       bootloaderBinary,
       fwBinaryMap,
       installItems,
+    };
+  }
+
+  private validateProtocolV2BootResourcesBinary(
+    binary: ArrayBuffer,
+    resource?: IProtocolV2BootResources
+  ) {
+    if (resource && !isProtocolV2ResourceFileValid(binary, resource)) {
+      throw new Error('Pro2 boot resources file verification failed');
+    }
+    const header = parseProtocolV2OkppHeader(toProtocolV2Bytes(binary));
+    if (!header || header.type !== 'CRAT') {
+      throw new Error('Invalid Pro2 boot resources CRATE header');
+    }
+    if (resource) {
+      const expectedPayloadHash = normalizeProtocolV2Hex(resource.payloadHash);
+      const expectedHeaderHash = normalizeProtocolV2Hex(resource.headerHash);
+      if (header.payloadHash !== expectedPayloadHash) {
+        throw new Error('Pro2 boot resources payload hash mismatch');
+      }
+      if (header.headerHash !== expectedHeaderHash) {
+        throw new Error('Pro2 boot resources header hash mismatch');
+      }
+    }
+  }
+
+  private async prepareProtocolV2BootResources(): Promise<ProtocolV2InstallItem | undefined> {
+    let binary = this.params.bootResourcesBinary;
+    let resource: IProtocolV2BootResources | undefined;
+
+    if (!binary) {
+      if (!this.params.targetsToUpdate?.includes('boot_resources')) {
+        return undefined;
+      }
+      resource = DataManager.getProtocolV2BootResources();
+      if (!resource) {
+        throw new Error('Missing Pro2 boot resources configuration');
+      }
+      Log.log('[FirmwareUpdateV4] downloading Pro2 boot resources CRATE');
+      ({ binary } = await getSysResourceBinary(resource.url));
+    }
+
+    this.validateProtocolV2BootResourcesBinary(binary, resource);
+    return {
+      fileName: PROTOCOL_V2_BOOT_RESOURCES_FILE_NAME,
+      binary,
+      targetId: ProtocolV2FirmwareTargetType.FW_MGMT_TARGET_CRATE,
+      kind: 'boot_resources',
     };
   }
 

--- a/packages/core/src/data-manager/DataManager.ts
+++ b/packages/core/src/data-manager/DataManager.ts
@@ -509,6 +509,10 @@ export default class DataManager {
     return this.deviceMap[EDeviceType.Pro2]?.resources?.stable;
   }
 
+  static getProtocolV2BootResources() {
+    return this.deviceMap[EDeviceType.Pro2]?.resources?.boot;
+  }
+
   static getProtobufMessages(schema: ProtobufMessageSchema = 'v1CurrentSchema'): JSON {
     return this.messages[schema];
   }

--- a/packages/core/src/protocols/protocol-v2/resources.ts
+++ b/packages/core/src/protocols/protocol-v2/resources.ts
@@ -1,6 +1,7 @@
 import { sha256 } from '@noble/hashes/sha256';
 
 import type {
+  IProtocolV2BootResources,
   IProtocolV2Resource,
   IProtocolV2ResourceType,
   IProtocolV2Resources,
@@ -149,6 +150,34 @@ function validateResource(value: unknown, index: number): IProtocolV2Resource {
   };
 }
 
+function validateBootResources(value: unknown): IProtocolV2BootResources {
+  if (!value || typeof value !== 'object') {
+    throw new Error('Invalid Pro2 boot resources config');
+  }
+  const resource = value as Partial<IProtocolV2BootResources>;
+  if (resource.required !== false) {
+    throw new Error('Invalid Pro2 boot resources required flag: expected false');
+  }
+  if (resource.target !== 'CRATE') {
+    throw new Error('Invalid Pro2 boot resources target: expected CRATE');
+  }
+  if (typeof resource.url !== 'string' || !resource.url.startsWith('https://')) {
+    throw new Error('Invalid Pro2 boot resources url');
+  }
+  if (!Number.isSafeInteger(resource.size) || Number(resource.size) <= 0) {
+    throw new Error('Invalid Pro2 boot resources size');
+  }
+  return {
+    required: false,
+    target: 'CRATE',
+    url: resource.url,
+    size: Number(resource.size),
+    fileHash: normalizeHex(resource.fileHash, SHA256_HEX_LENGTH, 'boot fileHash'),
+    payloadHash: normalizeHex(resource.payloadHash, SHA3_512_HEX_LENGTH, 'boot payloadHash'),
+    headerHash: normalizeHex(resource.headerHash, SHA3_512_HEX_LENGTH, 'boot headerHash'),
+  };
+}
+
 /** Validate a complete Pro2 stable resource set from remote configuration. */
 export function parseProtocolV2Resources(value: unknown): IProtocolV2Resources | undefined {
   if (value === undefined) return undefined;
@@ -160,7 +189,8 @@ export function parseProtocolV2Resources(value: unknown): IProtocolV2Resources |
     throw new Error('Invalid Pro2 resources config: stable must be an array');
   }
 
-  const stable = (value as { stable: unknown[] }).stable.map(validateResource);
+  const config = value as { stable: unknown[]; boot?: unknown };
+  const stable = config.stable.map(validateResource);
   const types = new Set(stable.map(resource => resource.type));
   if (stable.length !== PROTOCOL_V2_RESOURCE_TYPES.length || types.size !== stable.length) {
     throw new Error('Invalid Pro2 resources config: stable must contain six unique resource types');
@@ -170,6 +200,7 @@ export function parseProtocolV2Resources(value: unknown): IProtocolV2Resources |
       throw new Error(`Invalid Pro2 resources config: stable is missing ${type}`);
     }
   }
+  const boot = config.boot === undefined ? undefined : validateBootResources(config.boot);
   return {
     stable: PROTOCOL_V2_RESOURCE_TYPES.map(type => {
       const resource = stable.find(item => item.type === type);
@@ -178,6 +209,7 @@ export function parseProtocolV2Resources(value: unknown): IProtocolV2Resources |
       }
       return resource;
     }),
+    ...(boot ? { boot } : undefined),
   };
 }
 

--- a/packages/core/src/types/api/firmwareUpdate.ts
+++ b/packages/core/src/types/api/firmwareUpdate.ts
@@ -63,6 +63,7 @@ export interface FirmwareUpdateV3Params {
  */
 export type FirmwareUpdateV4Target =
   | 'boot'
+  | 'boot_resources'
   | 'app_v1'
   | 'app_v2'
   | 'coprocessor'
@@ -82,6 +83,8 @@ export interface FirmwareUpdateV4Params {
   romloaderBinary?: ArrayBuffer;
   /** FW_MGMT_TARGET_BOOTLOADER = 3 */
   bootloaderBinary?: ArrayBuffer;
+  /** FW_MGMT_TARGET_CRATE = 1; optional Pro2 startup resources. */
+  bootResourcesBinary?: ArrayBuffer;
   /** FW_MGMT_TARGET_APPLICATION_P1 = 4 */
   applicationP1Binary?: ArrayBuffer;
   /** FW_MGMT_TARGET_APPLICATION_P2 = 5 */

--- a/packages/core/src/types/settings.ts
+++ b/packages/core/src/types/settings.ts
@@ -81,8 +81,24 @@ export type IProtocolV2Resource = {
   headerHash: string;
 };
 
+/** Optional Pro2 startup-resource CRATE installed by the bootloader updater. */
+export type IProtocolV2BootResources = {
+  required: false;
+  target: 'CRATE';
+  url: string;
+  /** Complete CRATE file size in bytes. */
+  size: number;
+  /** SHA-256 of the complete CRATE file. */
+  fileHash: string;
+  /** SHA3-512 payload_hash from the signed CRATE header. */
+  payloadHash: string;
+  /** SHA3-512 header_hash from the signed CRATE header. */
+  headerHash: string;
+};
+
 export type IProtocolV2Resources = {
   stable: IProtocolV2Resource[];
+  boot?: IProtocolV2BootResources;
 };
 
 /** Pro2 RESC bundle okpkg descriptor for incremental FileWrite synchronization. */

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.0-alpha.44",
-    "@onekeyfe/hd-shared": "1.2.0-alpha.44",
-    "@onekeyfe/hd-transport-react-native": "1.2.0-alpha.44"
+    "@onekeyfe/hd-core": "1.2.0-alpha.45",
+    "@onekeyfe/hd-shared": "1.2.0-alpha.45",
+    "@onekeyfe/hd-transport-react-native": "1.2.0-alpha.45"
   }
 }

--- a/packages/hd-cli/package.json
+++ b/packages/hd-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hardware-cli",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "description": "OneKey hardware wallet CLI for testing device communication",
   "author": "OneKey",
   "license": "Apache-2.0",
@@ -31,10 +31,10 @@
     "test": "jest"
   },
   "dependencies": {
-    "@onekeyfe/hd-common-connect-sdk": "1.2.0-alpha.44",
-    "@onekeyfe/hd-core": "1.2.0-alpha.44",
-    "@onekeyfe/hd-shared": "1.2.0-alpha.44",
-    "@onekeyfe/hd-transport-usb": "1.2.0-alpha.44",
+    "@onekeyfe/hd-common-connect-sdk": "1.2.0-alpha.45",
+    "@onekeyfe/hd-core": "1.2.0-alpha.45",
+    "@onekeyfe/hd-shared": "1.2.0-alpha.45",
+    "@onekeyfe/hd-transport-usb": "1.2.0-alpha.45",
     "@stoprocent/noble": "2.3.16",
     "commander": "^12.0.0"
   }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,12 +20,12 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.0-alpha.44",
-    "@onekeyfe/hd-shared": "1.2.0-alpha.44",
-    "@onekeyfe/hd-transport-emulator": "1.2.0-alpha.44",
-    "@onekeyfe/hd-transport-http": "1.2.0-alpha.44",
-    "@onekeyfe/hd-transport-lowlevel": "1.2.0-alpha.44",
-    "@onekeyfe/hd-transport-usb": "1.2.0-alpha.44",
-    "@onekeyfe/hd-transport-web-device": "1.2.0-alpha.44"
+    "@onekeyfe/hd-core": "1.2.0-alpha.45",
+    "@onekeyfe/hd-shared": "1.2.0-alpha.45",
+    "@onekeyfe/hd-transport-emulator": "1.2.0-alpha.45",
+    "@onekeyfe/hd-transport-http": "1.2.0-alpha.45",
+    "@onekeyfe/hd-transport-lowlevel": "1.2.0-alpha.45",
+    "@onekeyfe/hd-transport-usb": "1.2.0-alpha.45",
+    "@onekeyfe/hd-transport-web-device": "1.2.0-alpha.45"
   }
 }

--- a/packages/hd-transport-electron/package.json
+++ b/packages/hd-transport-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-electron",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -25,9 +25,9 @@
     "electron-log": ">=4.0.0"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.0-alpha.44",
-    "@onekeyfe/hd-shared": "1.2.0-alpha.44",
-    "@onekeyfe/hd-transport": "1.2.0-alpha.44",
+    "@onekeyfe/hd-core": "1.2.0-alpha.45",
+    "@onekeyfe/hd-shared": "1.2.0-alpha.45",
+    "@onekeyfe/hd-transport": "1.2.0-alpha.45",
     "@stoprocent/noble": "2.3.16",
     "p-retry": "^4.6.2"
   },

--- a/packages/hd-transport-emulator/package.json
+++ b/packages/hd-transport-emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-emulator",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "description": "hardware emulator transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.0-alpha.44",
-    "@onekeyfe/hd-transport": "1.2.0-alpha.44",
+    "@onekeyfe/hd-shared": "1.2.0-alpha.45",
+    "@onekeyfe/hd-transport": "1.2.0-alpha.45",
     "axios": "1.15.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.0-alpha.44",
-    "@onekeyfe/hd-transport": "1.2.0-alpha.44",
+    "@onekeyfe/hd-shared": "1.2.0-alpha.45",
+    "@onekeyfe/hd-transport": "1.2.0-alpha.45",
     "axios": "1.15.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.0-alpha.44",
-    "@onekeyfe/hd-transport": "1.2.0-alpha.44"
+    "@onekeyfe/hd-shared": "1.2.0-alpha.45",
+    "@onekeyfe/hd-transport": "1.2.0-alpha.45"
   }
 }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -20,9 +20,9 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.0-alpha.44",
-    "@onekeyfe/hd-shared": "1.2.0-alpha.44",
-    "@onekeyfe/hd-transport": "1.2.0-alpha.44",
+    "@onekeyfe/hd-core": "1.2.0-alpha.45",
+    "@onekeyfe/hd-shared": "1.2.0-alpha.45",
+    "@onekeyfe/hd-transport": "1.2.0-alpha.45",
     "@onekeyfe/react-native-ble-utils": "^0.1.6",
     "react-native-ble-plx": "3.5.1"
   }

--- a/packages/hd-transport-usb/package.json
+++ b/packages/hd-transport-usb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-usb",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "description": "OneKey hardware wallet direct USB transport plugin (libusb)",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -21,8 +21,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.0-alpha.44",
-    "@onekeyfe/hd-transport": "1.2.0-alpha.44",
+    "@onekeyfe/hd-shared": "1.2.0-alpha.45",
+    "@onekeyfe/hd-transport": "1.2.0-alpha.45",
     "bytebuffer": "^5.0.1",
     "usb": "^2.14.0"
   }

--- a/packages/hd-transport-web-device/package.json
+++ b/packages/hd-transport-web-device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-web-device",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -21,11 +21,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.0-alpha.44",
-    "@onekeyfe/hd-transport": "1.2.0-alpha.44"
+    "@onekeyfe/hd-shared": "1.2.0-alpha.45",
+    "@onekeyfe/hd-transport": "1.2.0-alpha.45"
   },
   "devDependencies": {
-    "@onekeyfe/hd-transport-electron": "1.2.0-alpha.44",
+    "@onekeyfe/hd-transport-electron": "1.2.0-alpha.45",
     "@types/w3c-web-usb": "^1.0.6",
     "@types/web-bluetooth": "^0.0.17"
   }

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "description": "Transport layer abstractions and utilities for OneKey hardware SDK.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -23,10 +23,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "2.2.67",
-    "@onekeyfe/hd-core": "1.2.0-alpha.44",
-    "@onekeyfe/hd-shared": "1.2.0-alpha.44",
-    "@onekeyfe/hd-transport-http": "1.2.0-alpha.44",
-    "@onekeyfe/hd-transport-web-device": "1.2.0-alpha.44"
+    "@onekeyfe/hd-core": "1.2.0-alpha.45",
+    "@onekeyfe/hd-shared": "1.2.0-alpha.45",
+    "@onekeyfe/hd-transport-http": "1.2.0-alpha.45",
+    "@onekeyfe/hd-transport-web-device": "1.2.0-alpha.45"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/hwk-adapter-core/package.json
+++ b/packages/hwk-adapter-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-adapter-core",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "description": "Shared types and utilities for OneKey hardware wallet kit",
   "author": "OneKey",
   "license": "MIT",

--- a/packages/hwk-ledger-adapter/package.json
+++ b/packages/hwk-ledger-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-adapter",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "description": "Ledger hardware wallet adapter for OneKey",
   "author": "OneKey",
   "license": "MIT",
@@ -50,7 +50,7 @@
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/hw-app-trx": "^6.34.1",
     "@ledgerhq/hw-transport": "^6.34.1",
-    "@onekeyfe/hwk-adapter-core": "1.2.0-alpha.44",
+    "@onekeyfe/hwk-adapter-core": "1.2.0-alpha.45",
     "bitcoinjs-lib": "npm:@onekeyfe/bitcoinjs-lib@7.0.1"
   },
   "devDependencies": {

--- a/packages/hwk-ledger-connector-ble/package.json
+++ b/packages/hwk-ledger-connector-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-connector-ble",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "description": "IConnector implementation for Ledger hardware wallets via React Native BLE",
   "author": "OneKey",
   "license": "MIT",
@@ -51,8 +51,8 @@
     "@ledgerhq/device-signer-kit-ethereum": "^1.9.0",
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/device-transport-kit-react-native-ble": "^1.0.0",
-    "@onekeyfe/hwk-adapter-core": "1.2.0-alpha.44",
-    "@onekeyfe/hwk-ledger-adapter": "1.2.0-alpha.44"
+    "@onekeyfe/hwk-adapter-core": "1.2.0-alpha.45",
+    "@onekeyfe/hwk-ledger-adapter": "1.2.0-alpha.45"
   },
   "peerDependencies": {
     "react-native": "*"

--- a/packages/hwk-ledger-connector-webhid/package.json
+++ b/packages/hwk-ledger-connector-webhid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-connector-webhid",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "description": "IConnector implementation for Ledger hardware wallets via WebHID (DMK)",
   "author": "OneKey",
   "license": "MIT",
@@ -49,8 +49,8 @@
     "@ledgerhq/device-signer-kit-ethereum": "^1.9.0",
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/device-transport-kit-web-hid": "^1.0.0",
-    "@onekeyfe/hwk-adapter-core": "1.2.0-alpha.44",
-    "@onekeyfe/hwk-ledger-adapter": "1.2.0-alpha.44"
+    "@onekeyfe/hwk-adapter-core": "1.2.0-alpha.45",
+    "@onekeyfe/hwk-ledger-adapter": "1.2.0-alpha.45"
   },
   "devDependencies": {
     "rimraf": "^5.0.0",

--- a/packages/hwk-trezor-adapter/package.json
+++ b/packages/hwk-trezor-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-adapter",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "description": "Trezor hardware wallet adapter primitives for OneKey",
   "author": "OneKey",
   "license": "MIT",
@@ -43,8 +43,8 @@
     "crypto"
   ],
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.0-alpha.44",
-    "@onekeyfe/hwk-trezor-core": "1.2.0-alpha.44",
+    "@onekeyfe/hwk-adapter-core": "1.2.0-alpha.45",
+    "@onekeyfe/hwk-trezor-core": "1.2.0-alpha.45",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/packages/hwk-trezor-connector-electron-ble/package.json
+++ b/packages/hwk-trezor-connector-electron-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector-electron-ble",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "description": "IConnector implementation for Trezor hardware wallets via Electron BLE (noble in main process)",
   "author": "OneKey",
   "license": "MIT",
@@ -56,9 +56,9 @@
     "connector"
   ],
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.0-alpha.44",
-    "@onekeyfe/hwk-trezor-adapter": "1.2.0-alpha.44",
-    "@onekeyfe/hwk-trezor-connector": "1.2.0-alpha.44",
+    "@onekeyfe/hwk-adapter-core": "1.2.0-alpha.45",
+    "@onekeyfe/hwk-trezor-adapter": "1.2.0-alpha.45",
+    "@onekeyfe/hwk-trezor-connector": "1.2.0-alpha.45",
     "buffer": "^6.0.3"
   },
   "peerDependencies": {

--- a/packages/hwk-trezor-connector-rn-ble/package.json
+++ b/packages/hwk-trezor-connector-rn-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector-rn-ble",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "description": "IConnector implementation for Trezor hardware wallets via React Native BLE",
   "author": "OneKey",
   "license": "MIT",
@@ -46,9 +46,9 @@
     "connector"
   ],
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.0-alpha.44",
-    "@onekeyfe/hwk-trezor-adapter": "1.2.0-alpha.44",
-    "@onekeyfe/hwk-trezor-connector": "1.2.0-alpha.44",
+    "@onekeyfe/hwk-adapter-core": "1.2.0-alpha.45",
+    "@onekeyfe/hwk-trezor-adapter": "1.2.0-alpha.45",
+    "@onekeyfe/hwk-trezor-connector": "1.2.0-alpha.45",
     "buffer": "^6.0.3",
     "react-native-ble-plx": "^3.5.1"
   },

--- a/packages/hwk-trezor-connector-webusb/package.json
+++ b/packages/hwk-trezor-connector-webusb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector-webusb",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "description": "IConnector implementation for Trezor hardware wallets via WebUSB",
   "author": "OneKey",
   "license": "MIT",
@@ -55,8 +55,8 @@
     "connector"
   ],
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.0-alpha.44",
-    "@onekeyfe/hwk-trezor-connector": "1.2.0-alpha.44",
+    "@onekeyfe/hwk-adapter-core": "1.2.0-alpha.45",
+    "@onekeyfe/hwk-trezor-connector": "1.2.0-alpha.45",
     "buffer": "^6.0.3"
   },
   "devDependencies": {

--- a/packages/hwk-trezor-connector/package.json
+++ b/packages/hwk-trezor-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "description": "Shared Trezor connector base for Hardware Wallet Kit",
   "author": "OneKey",
   "license": "MIT",
@@ -38,13 +38,13 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.0-alpha.44",
-    "@onekeyfe/hwk-trezor-core": "1.2.0-alpha.44"
+    "@onekeyfe/hwk-adapter-core": "1.2.0-alpha.45",
+    "@onekeyfe/hwk-trezor-core": "1.2.0-alpha.45"
   },
   "devDependencies": {
-    "@onekeyfe/hwk-trezor-protobuf": "1.2.0-alpha.44",
-    "@onekeyfe/hwk-trezor-protocol": "1.2.0-alpha.44",
-    "@onekeyfe/hwk-trezor-transport": "1.2.0-alpha.44",
+    "@onekeyfe/hwk-trezor-protobuf": "1.2.0-alpha.45",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.0-alpha.45",
+    "@onekeyfe/hwk-trezor-transport": "1.2.0-alpha.45",
     "rimraf": "^5.0.0",
     "tsup": "^8.0.0",
     "typescript": "5.1.6"

--- a/packages/hwk-trezor-core/package.json
+++ b/packages/hwk-trezor-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-core",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "description": "Minimal Trezor core call layer for Hardware Wallet Kit",
   "author": "OneKey",
   "license": "MIT",
@@ -41,9 +41,9 @@
   "devDependencies": {
     "@noble/ciphers": "^1.3.0",
     "@noble/hashes": "^1.8.0",
-    "@onekeyfe/hwk-trezor-protobuf": "1.2.0-alpha.44",
-    "@onekeyfe/hwk-trezor-protocol": "1.2.0-alpha.44",
-    "@onekeyfe/hwk-trezor-transport": "1.2.0-alpha.44",
+    "@onekeyfe/hwk-trezor-protobuf": "1.2.0-alpha.45",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.0-alpha.45",
+    "@onekeyfe/hwk-trezor-transport": "1.2.0-alpha.45",
     "buffer": "^6.0.3",
     "rimraf": "^5.0.0",
     "tsup": "^8.0.0",

--- a/packages/hwk-trezor-protobuf/package.json
+++ b/packages/hwk-trezor-protobuf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-protobuf",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "private": true,
   "description": "Trezor protobuf helpers vendored from Trezor Suite MIT sources",
   "author": "OneKey",
@@ -50,7 +50,7 @@
   "sideEffects": false,
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
-    "@onekeyfe/hwk-trezor-schema-utils": "1.2.0-alpha.44"
+    "@onekeyfe/hwk-trezor-schema-utils": "1.2.0-alpha.45"
   },
   "devDependencies": {
     "rimraf": "^5.0.0",

--- a/packages/hwk-trezor-protocol/package.json
+++ b/packages/hwk-trezor-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-protocol",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "private": true,
   "description": "Trezor transport protocol helpers vendored from Trezor Suite MIT sources",
   "author": "OneKey",

--- a/packages/hwk-trezor-schema-utils/package.json
+++ b/packages/hwk-trezor-schema-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-schema-utils",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "private": true,
   "description": "Schema helpers vendored from Trezor Suite MIT sources for HWK Trezor support",
   "author": "OneKey",
@@ -44,7 +44,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.0-alpha.44",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.0-alpha.45",
     "@sinclair/typebox": "^0.34.49",
     "ts-mixer": "^6.0.4"
   },

--- a/packages/hwk-trezor-transport/package.json
+++ b/packages/hwk-trezor-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-transport",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "private": true,
   "description": "Low-level Trezor transport helpers vendored from Trezor Suite MIT sources",
   "author": "OneKey",
@@ -49,10 +49,10 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-protobuf": "1.2.0-alpha.44",
-    "@onekeyfe/hwk-trezor-protocol": "1.2.0-alpha.44",
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.0-alpha.44",
-    "@onekeyfe/hwk-trezor-utils": "1.2.0-alpha.44",
+    "@onekeyfe/hwk-trezor-protobuf": "1.2.0-alpha.45",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.0-alpha.45",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.0-alpha.45",
+    "@onekeyfe/hwk-trezor-utils": "1.2.0-alpha.45",
     "cross-fetch": "^4.1.0",
     "usb": "^2.17.0"
   },

--- a/packages/hwk-trezor-type-utils/package.json
+++ b/packages/hwk-trezor-type-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-type-utils",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "private": true,
   "description": "Type helpers vendored from Trezor Suite MIT sources for HWK Trezor support",
   "author": "OneKey",

--- a/packages/hwk-trezor-utils/package.json
+++ b/packages/hwk-trezor-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-utils",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "private": true,
   "description": "Utility helpers vendored from Trezor Suite MIT sources for HWK Trezor support",
   "author": "OneKey",
@@ -39,7 +39,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.0-alpha.44",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.0-alpha.45",
     "bignumber.js": "^9.3.1",
     "events": "^3.3.0"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",


### PR DESCRIPTION
## Summary

- add the opt-in boot_resources target and manual bootResourcesBinary input
- parse and validate the optional Pro2 resources.boot CRATE descriptor
- verify full-file, payload, header hashes, and CRAT package type before device mutation
- bump publishable SDK packages to 1.2.0-alpha.45

## Behavior

The CRATE is never included in automatic firmware recommendations. It is downloaded and installed only when callers explicitly request boot_resources or provide a manual binary.

## Validation

- Protocol V2 focused suites: 222 tests passed
- full package build passed
- agent:check commit passed
- npm prerelease workflow: https://github.com/OneKeyHQ/hardware-js-sdk/actions/runs/30805486118