### PR TITLE
fix: preserve binary payloads across SDK runtime bridges

### DIFF
--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -51,6 +51,25 @@ Pro2，也不能用 Pro/Pro2 型号反推协议。这样 Pro 后续迁移到 Pro
 - `packages/hd-transport/src/protocols/v2/frame-assembler.ts`
 - `packages/hd-transport/src/protocols/v2/link-manager.ts`
 
+## TopLevel / LowLevel 跨运行时二进制边界
+
+TopLevel 与 LowLevel SDK 可能运行在不同上下文，并通过 iframe、Extension offscreen 等只支持 JSON
+语义的宿主桥接。`ArrayBuffer`、TypedArray 和 `Blob` 不能直接依赖宿主的隐式序列化：
+
+- TopLevel 在调用 LowLevel 前递归编码二进制参数，Core 方法分发器在构造方法实例前统一还原。
+- 线格式使用带命名标记的 Base64 对象，并保留 `ArrayBuffer` 与 `Uint8Array` 的类型区别；TypedArray
+  视图只编码 `byteOffset + byteLength` 指定的有效字节，不能泄漏底层 buffer 的其他区域。
+- 编解码器必须支持嵌套对象和数组，并对已编码对象保持幂等，使 SDK 可以安全穿过 App 自己的桥接层。
+- 非法标记、非法 Base64 和循环引用在设备 I/O 前返回 `CallMethodInvalidParameter`，不得落入固件调用。
+- 该编码只属于 TopLevel / LowLevel 传输边界；同运行时直接调用 LowLevel 的路径继续使用原始二进制，
+  Protobuf、文件系统和设备协议格式均不受影响。
+
+主要实现：
+
+- `packages/core/src/topLevelInject.ts`
+- `packages/core/src/utils/bridgeBinaryPayload.ts`
+- `packages/core/src/api/utils.ts`
+
 ## 钱包 Session 所有权与缓存键
 
 Transport 连接、帧序号、设备端 `session_id` 和钱包标识是四类不同状态，不能共用缓存：

--- a/packages/core/__tests__/bridgeBinaryPayload.test.ts
+++ b/packages/core/__tests__/bridgeBinaryPayload.test.ts
@@ -1,0 +1,173 @@
+import { HardwareTopLevelSdk } from '../src';
+import { findMethod } from '../src/api/utils';
+import {
+  decodeBridgeBinaryPayload,
+  encodeBridgeBinaryPayload,
+} from '../src/utils/bridgeBinaryPayload';
+
+import type { LowLevelCoreApi } from '../src';
+
+jest.mock('../src/data/config', () => ({
+  DEFAULT_DOMAIN: 'https://example.com/',
+  getSDKVersion: () => '0.0.0-test',
+}));
+
+const crossJsonOnlyBridge = (value: unknown): unknown => JSON.parse(JSON.stringify(value));
+
+describe('bridge binary payload', () => {
+  test('preserves nested ArrayBuffer and sliced Uint8Array values', async () => {
+    const arrayBuffer = new Uint8Array([1, 2, 3]).buffer;
+    const backing = new Uint8Array([90, 4, 5, 6, 91]);
+    const encoded = await encodeBridgeBinaryPayload({
+      arrayBuffer,
+      bytes: backing.subarray(1, 4),
+    });
+    const decoded = decodeBridgeBinaryPayload(crossJsonOnlyBridge(encoded)) as {
+      arrayBuffer: ArrayBuffer;
+      bytes: Uint8Array;
+    };
+
+    expect(decoded.arrayBuffer).toBeInstanceOf(ArrayBuffer);
+    expect(Array.from(new Uint8Array(decoded.arrayBuffer))).toEqual([1, 2, 3]);
+    expect(decoded.bytes).toBeInstanceOf(Uint8Array);
+    expect(Array.from(decoded.bytes)).toEqual([4, 5, 6]);
+  });
+
+  test('encodes Blob input as byte data', async () => {
+    const encoded = await encodeBridgeBinaryPayload(new Blob([new Uint8Array([7, 8])]));
+    const decoded = decodeBridgeBinaryPayload(crossJsonOnlyBridge(encoded));
+
+    expect(decoded).toBeInstanceOf(Uint8Array);
+    expect(Array.from(decoded as Uint8Array)).toEqual([7, 8]);
+  });
+
+  test('routes portfolio, wallpaper and NFT bytes through the top-level boundary', async () => {
+    const restoredPayloads: Array<Record<string, any>> = [];
+    const lowLevelApi = {
+      call: jest.fn(params => {
+        const wirePayload = crossJsonOnlyBridge(params);
+        const method = findMethod({ id: 1, payload: wirePayload } as any);
+        restoredPayloads.push(method.payload);
+        return Promise.resolve({ success: true, payload: {} });
+      }),
+      init: jest.fn(() => Promise.resolve(true)),
+    } as unknown as LowLevelCoreApi;
+    const sdk = HardwareTopLevelSdk();
+    await sdk.init({}, lowLevelApi);
+
+    const portfolioBytes = new Uint8Array([1, 2, 3]).buffer;
+    const wallpaperBacking = new Uint8Array([90, 4, 5, 6, 91]);
+    const nftBacking = new Uint8Array([80, 7, 8, 9, 10, 81]);
+    await sdk.uploadPortfolio('connect-id', { packageBytes: portfolioBytes });
+    await sdk.deviceUploadWallpaper('connect-id', {
+      width: 604,
+      height: 1024,
+      rgba: wallpaperBacking.subarray(1, 4),
+    });
+    await sdk.deviceUploadNft('connect-id', {
+      image: { width: 540, height: 540, rgba: nftBacking.subarray(1, 3) },
+      thumbnail: { width: 263, height: 263, rgba: nftBacking.subarray(3, 5) },
+      title: 'NFT',
+      subtitle: '',
+    });
+
+    expect(Array.from(new Uint8Array(restoredPayloads[0].packageBytes))).toEqual([1, 2, 3]);
+    expect(Array.from(restoredPayloads[1].rgba)).toEqual([4, 5, 6]);
+    expect(Array.from(restoredPayloads[2].image.rgba)).toEqual([7, 8]);
+    expect(Array.from(restoredPayloads[2].thumbnail.rgba)).toEqual([9, 10]);
+  });
+
+  test('routes firmware update binaries through the top-level boundary', async () => {
+    const restoredPayloads: Array<Record<string, any>> = [];
+    const lowLevelApi = {
+      call: jest.fn(params => {
+        const wirePayload = crossJsonOnlyBridge(params);
+        const method = findMethod({ id: 1, payload: wirePayload } as any);
+        restoredPayloads.push(method.payload);
+        return Promise.resolve({ success: true, payload: {} });
+      }),
+      init: jest.fn(() => Promise.resolve(true)),
+    } as unknown as LowLevelCoreApi;
+    const sdk = HardwareTopLevelSdk();
+    await sdk.init({}, lowLevelApi);
+    const binary = (...bytes: number[]) => Uint8Array.from(bytes).buffer;
+
+    await sdk.firmwareUpdate('connect-id', {
+      binary: binary(1),
+      updateType: 'firmware',
+    });
+    await sdk.firmwareUpdateV2('connect-id', {
+      binary: binary(2),
+      updateType: 'firmware',
+      platform: 'ext',
+    });
+    await sdk.firmwareUpdateV3('connect-id', {
+      platform: 'ext',
+      bleBinary: binary(3),
+      firmwareBinary: binary(4),
+      bootloaderBinary: binary(5),
+      resourceBinary: binary(6),
+    });
+    await sdk.firmwareUpdateV4('connect-id', {
+      platform: 'ext',
+      targetsToUpdate: [
+        'boot',
+        'app_v1',
+        'app_v2',
+        'coprocessor',
+        'se01',
+        'se02',
+        'se03',
+        'se04',
+        'resource',
+      ],
+      romloaderBinary: binary(7),
+      bootloaderBinary: binary(8),
+      applicationP1Binary: binary(9),
+      applicationP2Binary: binary(10),
+      coprocessorBinary: binary(11),
+      se01Binary: binary(12),
+      se02Binary: binary(13),
+      se03Binary: binary(14),
+      se04Binary: binary(15),
+      resourceArchiveBinary: binary(16),
+    });
+    await sdk.deviceUpdateBootloader('connect-id', { binary: binary(17) });
+    await sdk.deviceFullyUploadResource('connect-id', { binary: binary(18) });
+
+    expect(restoredPayloads).toHaveLength(6);
+    const restoredBinaries = [
+      restoredPayloads[0].binary,
+      restoredPayloads[1].binary,
+      restoredPayloads[2].bleBinary,
+      restoredPayloads[2].firmwareBinary,
+      restoredPayloads[2].bootloaderBinary,
+      restoredPayloads[2].resourceBinary,
+      restoredPayloads[3].romloaderBinary,
+      restoredPayloads[3].bootloaderBinary,
+      restoredPayloads[3].applicationP1Binary,
+      restoredPayloads[3].applicationP2Binary,
+      restoredPayloads[3].coprocessorBinary,
+      restoredPayloads[3].se01Binary,
+      restoredPayloads[3].se02Binary,
+      restoredPayloads[3].se03Binary,
+      restoredPayloads[3].se04Binary,
+      restoredPayloads[3].resourceArchiveBinary,
+      restoredPayloads[4].binary,
+      restoredPayloads[5].binary,
+    ];
+    expect(restoredBinaries.map(value => Array.from(new Uint8Array(value)))).toEqual(
+      Array.from({ length: 18 }, (_, index) => [index + 1])
+    );
+  });
+
+  test('rejects malformed tagged binary data', () => {
+    expect(() =>
+      decodeBridgeBinaryPayload({
+        __onekey_hd_bridge_binary_payload__: 1,
+        data: 'not-base64',
+        type: 'uint8-array',
+      })
+    ).toThrow('Invalid bridge binary payload data');
+  });
+});

--- a/packages/core/src/api/utils.ts
+++ b/packages/core/src/api/utils.ts
@@ -1,6 +1,7 @@
 import { ERRORS, HardwareErrorCode } from '@onekeyfe/hd-shared';
 
 import * as ApiMethods from './index';
+import { decodeBridgeBinaryPayload } from '../utils/bridgeBinaryPayload';
 
 import type { BaseMethod } from './BaseMethod';
 import type { IFrameCallMessage } from '../events';
@@ -11,14 +12,16 @@ type MethodConstructor = new (message: IFrameCallMessage & { id?: number }) => B
 const publicMethodRegistry = ApiMethods as unknown as Record<string, MethodConstructor>;
 
 export function findMethod(message: IFrameCallMessage & { id?: number }): BaseMethod<any> {
-  const { method } = message.payload;
+  const payload = decodeBridgeBinaryPayload(message.payload) as IFrameCallMessage['payload'];
+  const normalizedMessage = payload === message.payload ? message : { ...message, payload };
+  const { method } = payload;
   if (typeof method !== 'string') {
     throw ERRORS.TypedError(HardwareErrorCode.CallMethodInvalidParameter, 'Method is not set');
   }
 
   const MethodConstructor = publicMethodRegistry[method];
   if (MethodConstructor) {
-    return new MethodConstructor(message);
+    return new MethodConstructor(normalizedMessage);
   }
 
   throw ERRORS.TypedError(

--- a/packages/core/src/topLevelInject.ts
+++ b/packages/core/src/topLevelInject.ts
@@ -2,6 +2,7 @@ import EventEmitter from 'events';
 
 import { createCoreApi, createProtocolAwareCall } from './inject';
 import { unregisterFirmwareUpdateHostBinding } from './api/firmware/FirmwareHostBinding';
+import { encodeBridgeBinaryPayload } from './utils/bridgeBinaryPayload';
 
 import type { ConnectSettings } from './types/settings';
 import type { CoreApi } from './types/api';
@@ -16,9 +17,10 @@ const eventEmitter = new EventEmitter();
 
 export const topLevelInject = () => {
   let lowLevelApi: LowLevelCoreApi | undefined;
-  const call = (params: any) => {
+  const call = async (params: any) => {
     if (!lowLevelApi) return Promise.resolve(undefined);
-    return lowLevelApi.call(params);
+    const encodedParams = await encodeBridgeBinaryPayload(params);
+    return lowLevelApi.call(encodedParams as any);
   };
   const protocolAwareCall = createProtocolAwareCall(call);
   const api: CoreApi = {

--- a/packages/core/src/utils/bridgeBinaryPayload.ts
+++ b/packages/core/src/utils/bridgeBinaryPayload.ts
@@ -1,0 +1,137 @@
+import { Buffer } from 'buffer';
+import { ERRORS, HardwareErrorCode } from '@onekeyfe/hd-shared';
+
+// Top-level and low-level SDK instances can be separated by JSON-only hosts,
+// including browser extension background/offscreen message bridges.
+const BRIDGE_BINARY_PAYLOAD_MARKER = '__onekey_hd_bridge_binary_payload__';
+
+type BridgeBinaryPayload = {
+  [BRIDGE_BINARY_PAYLOAD_MARKER]: 1;
+  data: string;
+  type: 'array-buffer' | 'uint8-array';
+};
+
+const BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+const invalidBinaryPayload = (message: string) =>
+  ERRORS.TypedError(HardwareErrorCode.CallMethodInvalidParameter, message);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isArrayBufferValue(value: unknown): value is ArrayBuffer {
+  return Boolean(
+    typeof ArrayBuffer !== 'undefined' &&
+      (value instanceof ArrayBuffer ||
+        Object.prototype.toString.call(value) === '[object ArrayBuffer]')
+  );
+}
+
+function isBlobValue(value: unknown): value is Blob {
+  return Boolean(
+    typeof Blob !== 'undefined' &&
+      (value instanceof Blob || Object.prototype.toString.call(value) === '[object Blob]') &&
+      typeof (value as Blob).arrayBuffer === 'function'
+  );
+}
+
+function readBinaryPayload(value: unknown): BridgeBinaryPayload | undefined {
+  if (!isPlainObject(value) || !(BRIDGE_BINARY_PAYLOAD_MARKER in value)) return undefined;
+  const payload = value as Partial<BridgeBinaryPayload>;
+  if (
+    payload[BRIDGE_BINARY_PAYLOAD_MARKER] !== 1 ||
+    (payload.type !== 'array-buffer' && payload.type !== 'uint8-array') ||
+    typeof payload.data !== 'string'
+  ) {
+    throw invalidBinaryPayload('Invalid bridge binary payload');
+  }
+  return payload as BridgeBinaryPayload;
+}
+
+function bytesToPayload(bytes: Uint8Array, type: BridgeBinaryPayload['type']): BridgeBinaryPayload {
+  return {
+    [BRIDGE_BINARY_PAYLOAD_MARKER]: 1,
+    data: Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString('base64'),
+    type,
+  };
+}
+
+function payloadToBytes(payload: BridgeBinaryPayload): Uint8Array {
+  if (payload.data.length % 4 !== 0 || !BASE64_PATTERN.test(payload.data)) {
+    throw invalidBinaryPayload('Invalid bridge binary payload data');
+  }
+  const decoded = Buffer.from(payload.data, 'base64');
+  if (decoded.toString('base64') !== payload.data) {
+    throw invalidBinaryPayload('Invalid bridge binary payload data');
+  }
+  return Uint8Array.from(decoded);
+}
+
+async function encodeValue(value: unknown, seen: WeakSet<object>): Promise<unknown> {
+  if (isArrayBufferValue(value)) {
+    return bytesToPayload(new Uint8Array(value), 'array-buffer');
+  }
+  if (typeof ArrayBuffer !== 'undefined' && ArrayBuffer.isView(value)) {
+    return bytesToPayload(
+      new Uint8Array(value.buffer, value.byteOffset, value.byteLength),
+      'uint8-array'
+    );
+  }
+  if (isBlobValue(value)) {
+    return bytesToPayload(new Uint8Array(await value.arrayBuffer()), 'uint8-array');
+  }
+
+  const encodedPayload = readBinaryPayload(value);
+  if (encodedPayload) return encodedPayload;
+  if (Array.isArray(value)) {
+    if (seen.has(value)) throw invalidBinaryPayload('Circular bridge payload');
+    seen.add(value);
+    try {
+      const encoded: unknown[] = [];
+      for (const item of value) {
+        encoded.push(await encodeValue(item, seen));
+      }
+      return encoded.some((item, index) => item !== value[index]) ? encoded : value;
+    } finally {
+      seen.delete(value);
+    }
+  }
+  if (!isPlainObject(value)) return value;
+  if (seen.has(value)) throw invalidBinaryPayload('Circular bridge payload');
+  seen.add(value);
+  try {
+    const entries: [string, unknown][] = [];
+    for (const [key, item] of Object.entries(value)) {
+      entries.push([key, await encodeValue(item, seen)]);
+    }
+    return entries.some(([key, item]) => item !== value[key]) ? Object.fromEntries(entries) : value;
+  } finally {
+    seen.delete(value);
+  }
+}
+
+function decodeValue(value: unknown): unknown {
+  const payload = readBinaryPayload(value);
+  if (payload) {
+    const bytes = payloadToBytes(payload);
+    return payload.type === 'array-buffer' ? bytes.buffer : bytes;
+  }
+  if (Array.isArray(value)) {
+    const decoded = value.map(decodeValue);
+    return decoded.some((item, index) => item !== value[index]) ? decoded : value;
+  }
+  if (!isPlainObject(value)) return value;
+  const entries = Object.entries(value).map(([key, item]) => [key, decodeValue(item)] as const);
+  return entries.some(([key, item]) => item !== value[key]) ? Object.fromEntries(entries) : value;
+}
+
+export async function encodeBridgeBinaryPayload(value: unknown): Promise<unknown> {
+  return encodeValue(value, new WeakSet());
+}
+
+export function decodeBridgeBinaryPayload(value: unknown): unknown {
+  return decodeValue(value);
+}


### PR DESCRIPTION
## What changed

- recursively encode `ArrayBuffer`, typed-array views, and `Blob` inputs at the TopLevel/LowLevel boundary
- restore tagged Base64 payloads before SDK method construction and validation
- preserve `ArrayBuffer` versus `Uint8Array` semantics and exact typed-array slice boundaries
- reject malformed Base64, malformed tagged objects, and circular payloads before hardware I/O
- document the cross-runtime binary boundary
- add public API regression coverage for Portfolio, wallpaper, NFT, firmware V1–V4, bootloader, and full resource uploads

## Why

TopLevel and LowLevel SDK instances can be separated by JSON-only hosts such as extension background/offscreen bridges. Native binary values lose their runtime type during serialization, which caused `FilesystemFileWrite` validation to reject Portfolio data before reaching the device.

## Impact

SDK consumers receive a generic, host-independent binary transport boundary. Existing same-runtime LowLevel callers, protobuf payloads, filesystem formats, and device firmware protocols are unchanged.

Companion App PR: https://github.com/OneKeyHQ/app-monorepo/pull/12814

## Validation

- `bridgeBinaryPayload.test.ts`: 5 tests passed
- targeted ESLint passed
- `git diff --check` passed
- no hardware or firmware command was executed