### PR TITLE
fix: prevent desktop BLE background reconnects

### DIFF
--- a/packages/connect-examples/electron-example/src/preload.ts
+++ b/packages/connect-examples/electron-example/src/preload.ts
@@ -8,6 +8,7 @@ import { ipcMessageKeys } from './config';
 import type {
   DesktopAPI as BaseDesktopAPI,
   NobleBleAPI,
+  NobleBleConnectOptions,
   NobleBleWriteOptions,
 } from '@onekeyfe/hd-transport-electron';
 
@@ -72,7 +73,12 @@ const desktopApi = {
     enumerate: () => ipcRenderer.invoke(EOneKeyBleMessageKeys.NOBLE_BLE_ENUMERATE),
     getDevice: (uuid: string) =>
       ipcRenderer.invoke(EOneKeyBleMessageKeys.NOBLE_BLE_GET_DEVICE, uuid),
-    connect: (uuid: string) => ipcRenderer.invoke(EOneKeyBleMessageKeys.NOBLE_BLE_CONNECT, uuid),
+    connect: (uuid: string, options?: NobleBleConnectOptions) =>
+      ipcRenderer.invoke(EOneKeyBleMessageKeys.NOBLE_BLE_CONNECT, uuid, options),
+    connectConnectedOnly: (uuid: string) =>
+      ipcRenderer.invoke(EOneKeyBleMessageKeys.NOBLE_BLE_CONNECT, uuid, {
+        reuseConnectedOnly: true,
+      }),
     disconnect: (uuid: string) =>
       ipcRenderer.invoke(EOneKeyBleMessageKeys.NOBLE_BLE_DISCONNECT, uuid),
     subscribe: (uuid: string) =>

--- a/packages/core/__tests__/ble-connection-errors.test.ts
+++ b/packages/core/__tests__/ble-connection-errors.test.ts
@@ -1,0 +1,103 @@
+import { ERRORS, HardwareErrorCode } from '@onekeyfe/hd-shared';
+
+import {
+  isRetryableBleProtocolV2ProbeError,
+  shouldRetryBleConnection,
+  shouldStopBleConnectionPolling,
+} from '../src/core/bleConnectionErrors';
+
+import type { BaseMethod } from '../src/api/BaseMethod';
+
+function buildMethod(connectProtocol: 'V1' | 'V2', options?: { reuseConnectedOnly?: boolean }) {
+  return {
+    payload: { connectProtocol, ...options },
+  } as BaseMethod;
+}
+
+describe('BLE connection polling errors', () => {
+  test('stops polling when BLE UUID is missing', () => {
+    const error = ERRORS.TypedError(HardwareErrorCode.BleRequiredUUID);
+
+    expect(shouldStopBleConnectionPolling(buildMethod('V2'), error)).toBe(true);
+  });
+
+  test('stops outer polling after a strict Protocol V2 probe mismatch', () => {
+    const error = Object.assign(
+      new Error(
+        'Device protocol mismatch: expected V2, but device did not respond to expected protocol'
+      ),
+      { errorCode: HardwareErrorCode.RuntimeError }
+    );
+
+    expect(isRetryableBleProtocolV2ProbeError(buildMethod('V2'), error)).toBe(true);
+    expect(shouldStopBleConnectionPolling(buildMethod('V2'), error)).toBe(true);
+  });
+
+  test('stops polling when connected-only reuse finds a disconnected device', () => {
+    const error = ERRORS.TypedError(HardwareErrorCode.DeviceNotFound);
+
+    expect(
+      shouldStopBleConnectionPolling(buildMethod('V2', { reuseConnectedOnly: true }), error)
+    ).toBe(true);
+    expect(shouldStopBleConnectionPolling(buildMethod('V2'), error)).toBe(false);
+  });
+
+  test.each([
+    ERRORS.TypedError(HardwareErrorCode.DeviceBusy),
+    Object.assign(new Error('IPC transport error'), {
+      errorCode: HardwareErrorCode.RuntimeError,
+    }),
+    new Error('IPC error without structured fields'),
+  ])('stops connected-only polling after any single connection failure', error => {
+    expect(
+      shouldStopBleConnectionPolling(buildMethod('V2', { reuseConnectedOnly: true }), error)
+    ).toBe(true);
+  });
+
+  test('does not classify a generic runtime error as terminal', () => {
+    const error = Object.assign(new Error('temporary BLE failure'), {
+      errorCode: HardwareErrorCode.RuntimeError,
+    });
+
+    expect(shouldStopBleConnectionPolling(buildMethod('V2'), error)).toBe(false);
+  });
+
+  test('does not apply the Protocol V2 mismatch rule to Protocol V1', () => {
+    const error = Object.assign(
+      new Error(
+        'Device protocol mismatch: expected V2, but device did not respond to expected protocol'
+      ),
+      { errorCode: HardwareErrorCode.RuntimeError }
+    );
+
+    expect(shouldStopBleConnectionPolling(buildMethod('V1'), error)).toBe(false);
+  });
+
+  test.each([
+    ERRORS.TypedError(HardwareErrorCode.BleTimeoutError),
+    ERRORS.TypedError(HardwareErrorCode.BleConnectedError),
+    Object.assign(
+      new Error(
+        'Device protocol mismatch: expected V2, but device did not respond to expected protocol'
+      ),
+      { errorCode: HardwareErrorCode.RuntimeError }
+    ),
+  ])('does not retry any reusable-link failure in connected-only mode', error => {
+    expect(shouldRetryBleConnection(buildMethod('V2', { reuseConnectedOnly: true }), error)).toBe(
+      false
+    );
+  });
+
+  test.each([
+    ERRORS.TypedError(HardwareErrorCode.BleTimeoutError),
+    ERRORS.TypedError(HardwareErrorCode.BleConnectedError),
+    Object.assign(
+      new Error(
+        'Device protocol mismatch: expected V2, but device did not respond to expected protocol'
+      ),
+      { errorCode: HardwareErrorCode.RuntimeError }
+    ),
+  ])('keeps the existing retry policy outside connected-only mode', error => {
+    expect(shouldRetryBleConnection(buildMethod('V2'), error)).toBe(true);
+  });
+});

--- a/packages/core/__tests__/device-connector-protocol.test.ts
+++ b/packages/core/__tests__/device-connector-protocol.test.ts
@@ -63,6 +63,29 @@ describe('DeviceConnector protocol validation', () => {
     );
   });
 
+  it('forwards connected-only BLE reuse to the active transport', async () => {
+    const acquire = jest.fn().mockResolvedValue({
+      id: 'pro2-id',
+      path: 'pro2-id',
+      protocolType: 'V2',
+    });
+    transportManagerMock.default.getTransport.mockReturnValue({
+      acquire,
+      getProtocolType: jest.fn(() => 'V2'),
+    });
+    const connector = new DeviceConnector();
+
+    await connector.acquire('pro2-id', undefined, true, 'V2', undefined, true);
+
+    expect(acquire).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedProtocol: 'V2',
+        reuseConnectedOnly: true,
+        uuid: 'pro2-id',
+      })
+    );
+  });
+
   it('still rejects a real mismatch reported by the active protocol probe', async () => {
     transportManagerMock.default.getTransport.mockReturnValue({
       acquire: jest.fn().mockResolvedValue({

--- a/packages/core/__tests__/device-lifecycle-events.test.ts
+++ b/packages/core/__tests__/device-lifecycle-events.test.ts
@@ -111,7 +111,7 @@ describe('public device lifecycle events', () => {
 
     await device.acquire();
 
-    expect(acquire).toHaveBeenCalledWith('ble-id', undefined, true, 'V1', undefined);
+    expect(acquire).toHaveBeenCalledWith('ble-id', undefined, true, 'V1', undefined, undefined);
     expect(device.getProtocol()).toBe('V1');
     expect(device.originalDescriptor.protocolType).toBe('V1');
   });
@@ -129,9 +129,32 @@ describe('public device lifecycle events', () => {
 
     await device.acquire(undefined, { forceProtocolDetection: true });
 
-    expect(acquire).toHaveBeenCalledWith('ble-id', undefined, true, undefined, undefined);
+    expect(acquire).toHaveBeenCalledWith(
+      'ble-id',
+      undefined,
+      true,
+      undefined,
+      undefined,
+      undefined
+    );
     expect(device.getProtocol()).toBe('V2');
     expect(device.originalDescriptor.protocolType).toBe('V2');
+  });
+
+  test('forwards connected-only reuse through the BLE device lifecycle', async () => {
+    jest.spyOn(DataManager, 'getSettings').mockReturnValue('desktop-web-ble' as never);
+    const device = Device.fromDescriptor({
+      id: 'ble-id',
+      path: 'ble-id',
+      commType: 'electron-ble',
+      protocolType: 'V2',
+    } as never);
+    const acquire = jest.fn().mockResolvedValue({ uuid: 'ble-id', protocolType: 'V2' });
+    device.deviceConnector = { acquire } as never;
+
+    await device.acquire('V2', { reuseConnectedOnly: true });
+
+    expect(acquire).toHaveBeenCalledWith('ble-id', undefined, true, 'V2', undefined, true);
   });
 
   test('does not reuse a stale protocol when active detection returns no protocol', async () => {
@@ -230,7 +253,7 @@ describe('public device lifecycle events', () => {
 
     await device.acquire('V2');
 
-    expect(acquire).toHaveBeenCalledWith('ble-id', undefined, true, 'V2', undefined);
+    expect(acquire).toHaveBeenCalledWith('ble-id', undefined, true, 'V2', undefined, undefined);
     expect(device.getProtocol()).toBe('V2');
   });
 

--- a/packages/core/src/api/UploadPortfolio.ts
+++ b/packages/core/src/api/UploadPortfolio.ts
@@ -6,6 +6,7 @@ import FileWrite from './FileWrite';
 
 export type UploadPortfolioParams = {
   packageBase64: string;
+  reuseConnectedOnly?: boolean;
   timeoutMs?: number | string;
 };
 

--- a/packages/core/src/core/bleConnectionErrors.ts
+++ b/packages/core/src/core/bleConnectionErrors.ts
@@ -1,0 +1,34 @@
+import { HardwareErrorCode } from '@onekeyfe/hd-shared';
+
+import type { BaseMethod } from '../api/BaseMethod';
+
+export function isRetryableBleProtocolV2ProbeError(method: BaseMethod, error: unknown) {
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  return (
+    method.payload.connectProtocol === 'V2' &&
+    message.includes('Device protocol mismatch') &&
+    message.includes('expected V2') &&
+    message.includes('did not respond to expected protocol')
+  );
+}
+
+export function shouldStopBleConnectionPolling(method: BaseMethod, error: unknown) {
+  const errorCode = (error as { errorCode?: unknown } | null)?.errorCode;
+  return (
+    method.payload.reuseConnectedOnly === true ||
+    errorCode === HardwareErrorCode.BleRequiredUUID ||
+    isRetryableBleProtocolV2ProbeError(method, error)
+  );
+}
+
+export function shouldRetryBleConnection(method: BaseMethod, error: unknown) {
+  if (method.payload.reuseConnectedOnly) {
+    return false;
+  }
+  const errorCode = (error as { errorCode?: unknown } | null)?.errorCode;
+  return (
+    errorCode === HardwareErrorCode.BleTimeoutError ||
+    errorCode === HardwareErrorCode.BleConnectedError ||
+    isRetryableBleProtocolV2ProbeError(method, error)
+  );
+}

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -64,6 +64,7 @@ import {
   isProtocolV2UiEnabled,
 } from '../protocols/protocol-v2/uiInteraction';
 import { createUiProgressMessageFilter } from '../utils/uiProgressThrottle';
+import { shouldRetryBleConnection, shouldStopBleConnectionPolling } from './bleConnectionErrors';
 
 import type { ConnectSettings, Features, KnownDevice } from '../types';
 import type { CoreMessage, IFrameCallMessage, UiPromise, UiPromiseResponse } from '../events';
@@ -892,16 +893,6 @@ function canSkipInitialize(method: BaseMethod, device: Device): boolean {
   return true;
 }
 
-function isRetryableBleProtocolV2ProbeError(method: BaseMethod, error: unknown) {
-  const message = error instanceof Error ? error.message : String(error ?? '');
-  return (
-    method.payload.connectProtocol === 'V2' &&
-    message.includes('Device protocol mismatch') &&
-    message.includes('expected V2') &&
-    message.includes('did not respond to expected protocol')
-  );
-}
-
 /**
  * If the Bluetooth connection times out, retry up to 6 times
  * @param retryCount - Current retry count (default 0)
@@ -919,6 +910,7 @@ async function connectDeviceForBle(method: BaseMethod, device: Device, retryCoun
     if (shouldAcquire) {
       await device.acquire(method.payload.connectProtocol, {
         forceProtocolDetection: method.payload.forceProtocolDetection,
+        reuseConnectedOnly: method.payload.reuseConnectedOnly,
       });
     }
     if (method.payload?.onlyConnectBleDevice) {
@@ -954,12 +946,7 @@ async function connectDeviceForBle(method: BaseMethod, device: Device, retryCoun
       // next attempt skip acquire and initialize onto the link we just cut.
       device.markTransportDisconnected();
     }
-    if (
-      (err.errorCode === HardwareErrorCode.BleTimeoutError ||
-        err.errorCode === HardwareErrorCode.BleConnectedError ||
-        isRetryableBleProtocolV2ProbeError(method, err)) &&
-      retryCount < 6
-    ) {
+    if (shouldRetryBleConnection(method, err) && retryCount < 6) {
       const nextRetry = retryCount + 1;
       Log.debug(`Bluetooth connect timeout and will retry, retry count: ${nextRetry}`);
       await wait(3000);
@@ -1097,7 +1084,8 @@ const ensureConnected = async (
             HardwareErrorCode.DeviceDetectInBootloaderMode,
             HardwareErrorCode.BleCharacteristicNotifyChangeFailure,
             HardwareErrorCode.BridgeNeedsPermission,
-          ].includes(error.errorCode)
+          ].includes(error.errorCode) ||
+          shouldStopBleConnectionPolling(method, error)
         ) {
           reject(error);
           return;

--- a/packages/core/src/device/Device.ts
+++ b/packages/core/src/device/Device.ts
@@ -424,7 +424,11 @@ export class Device extends EventEmitter {
 
   async acquire(
     expectedProtocol?: HardwareConnectProtocol,
-    options?: { throwOnRunPromiseError?: boolean; forceProtocolDetection?: boolean }
+    options?: {
+      throwOnRunPromiseError?: boolean;
+      forceProtocolDetection?: boolean;
+      reuseConnectedOnly?: boolean;
+    }
   ) {
     const env = DataManager.getSettings('env');
     const mainIdKey = DataManager.isBleConnect(env) ? 'id' : 'session';
@@ -446,7 +450,8 @@ export class Device extends EventEmitter {
           undefined,
           true,
           strictProtocol,
-          undefined
+          undefined,
+          options?.reuseConnectedOnly
         );
         this.mainId = (acquireResult as any)?.uuid ?? '';
         Log.debug('Expected uuid:', this.mainId);

--- a/packages/core/src/device/DeviceConnector.ts
+++ b/packages/core/src/device/DeviceConnector.ts
@@ -94,7 +94,8 @@ export default class DeviceConnector {
     session?: string | null,
     forceCleanRunPromise?: boolean,
     expectedProtocol?: HardwareConnectProtocol,
-    protocolHint?: HardwareConnectProtocol
+    protocolHint?: HardwareConnectProtocol,
+    reuseConnectedOnly?: boolean
   ) {
     Log.debug('acquire', path, session, expectedProtocol, protocolHint);
     const env = DataManager.getSettings('env');
@@ -102,12 +103,14 @@ export default class DeviceConnector {
       const transport = this.getActiveTransport();
       let res;
       if (DataManager.isBleConnect(env)) {
-        res = await transport.acquire({
+        const acquireInput = {
           uuid: path,
           forceCleanRunPromise,
           expectedProtocol,
           protocolHint,
-        });
+          reuseConnectedOnly,
+        };
+        res = await transport.acquire(acquireInput);
       } else {
         res = await transport.acquire({
           path,

--- a/packages/core/src/types/api/protocolV2.ts
+++ b/packages/core/src/types/api/protocolV2.ts
@@ -67,7 +67,7 @@ export declare function deviceUploadNft(
 
 export declare function uploadPortfolio(
   connectId: string,
-  params: {
+  params: CommonParams & {
     packageBase64: string;
     timeoutMs?: number | string;
   }

--- a/packages/core/src/types/params.ts
+++ b/packages/core/src/types/params.ts
@@ -70,6 +70,12 @@ export interface CommonParams {
    * protocol again. Intended for the first verified connection or explicit recovery.
    */
   forceProtocolDetection?: boolean;
+
+  /**
+   * Reuse an already-connected BLE link. If the physical link is gone, fail
+   * immediately without direct-connect recovery or scanning.
+   */
+  reuseConnectedOnly?: boolean;
 }
 
 export type Params<T> = CommonParams & T & { bundle?: undefined };

--- a/packages/hd-transport-electron/src/__tests__/noble-ble-handler.test.ts
+++ b/packages/hd-transport-electron/src/__tests__/noble-ble-handler.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import { EOneKeyBleMessageKeys } from '@onekeyfe/hd-shared';
+import { EOneKeyBleMessageKeys, HardwareErrorCode } from '@onekeyfe/hd-shared';
 
 import {
   NOBLE_BLE_CONNECTION_TIMEOUT_MS,
@@ -177,6 +177,49 @@ describe('Electron Noble BLE device discovery', () => {
     stopScanningCallback?.();
     await expect(connectPromise).rejects.toThrow('expected test connection failure');
     expect(peripheral.connect).toHaveBeenCalledTimes(1);
+  });
+
+  test('connected-only reuse fails before Noble can scan or reconnect', async () => {
+    const handlers = new Map<string, IpcHandler>();
+    const ipcMain = {
+      handle: jest.fn((channel: string, handler: IpcHandler) => {
+        handlers.set(channel, handler);
+      }),
+      removeHandler: jest.fn((channel: string) => {
+        handlers.delete(channel);
+      }),
+    };
+    const noble = Object.assign(new EventEmitter(), {
+      state: 'poweredOn',
+      startScanning: jest.fn(),
+      stopScanning: jest.fn(),
+      connectAsync: jest.fn(),
+    });
+
+    jest.doMock('@stoprocent/noble', () => noble);
+    jest.doMock('electron', () => ({ ipcMain }));
+    jest.doMock('electron-log', () => ({
+      info: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+    }));
+
+    const { setupNobleBleHandlers } = await import('../noble-ble-handler');
+    setupNobleBleHandlers({
+      on: jest.fn(),
+      send: jest.fn(),
+    } as unknown as WebContents);
+
+    const connect = handlers.get(EOneKeyBleMessageKeys.NOBLE_BLE_CONNECT);
+    if (!connect) {
+      throw new Error('Electron Noble BLE connect handler was not registered');
+    }
+
+    await expect(
+      connect(undefined, 'stale-device', { reuseConnectedOnly: true })
+    ).rejects.toMatchObject({ errorCode: HardwareErrorCode.DeviceNotFound });
+    expect(noble.connectAsync).not.toHaveBeenCalled();
+    expect(noble.startScanning).not.toHaveBeenCalled();
   });
 
   test('disconnects a connection callback that arrives after timeout', async () => {

--- a/packages/hd-transport-electron/src/index.ts
+++ b/packages/hd-transport-electron/src/index.ts
@@ -3,7 +3,12 @@ import type { WebContents } from 'electron';
 export * from './types';
 
 // Export Desktop API types for other packages to reuse
-export type { DesktopAPI, NobleBleAPI, NobleBleWriteOptions } from './types/desktop-api';
+export type {
+  DesktopAPI,
+  NobleBleAPI,
+  NobleBleConnectOptions,
+  NobleBleWriteOptions,
+} from './types/desktop-api';
 
 export async function initNobleBleSupport(webContents: WebContents) {
   const { setupNobleBleHandlers } = await import('./noble-ble-handler');

--- a/packages/hd-transport-electron/src/noble-ble-handler.ts
+++ b/packages/hd-transport-electron/src/noble-ble-handler.ts
@@ -31,7 +31,7 @@ import {
 
 import type { IpcMain, IpcMainInvokeEvent, WebContents } from 'electron';
 import type { Characteristic, Peripheral, Service } from '@stoprocent/noble';
-import type { NobleBleWriteOptions } from './types/desktop-api';
+import type { NobleBleConnectOptions, NobleBleWriteOptions } from './types/desktop-api';
 import type { CharacteristicPair, DeviceInfo, Logger, NobleModule } from './types/noble-extended';
 
 // Noble will be dynamically imported to avoid bundling issues
@@ -1387,7 +1387,11 @@ async function tryDirectConnectById(deviceId: string): Promise<Peripheral | unde
 }
 
 // Connect to device - supports both discovered and direct connection modes
-async function connectDevice(deviceId: string, webContents: WebContents): Promise<void> {
+async function connectDevice(
+  deviceId: string,
+  webContents: WebContents,
+  options?: NobleBleConnectOptions
+): Promise<void> {
   logger?.info('[NobleBLE] Connect device request:', {
     deviceId,
     hasDiscovered: discoveredDevices.has(deviceId),
@@ -1396,6 +1400,18 @@ async function connectDevice(deviceId: string, webContents: WebContents): Promis
     totalDiscovered: discoveredDevices.size,
     totalConnected: connectedDevices.size,
   });
+
+  if (options?.reuseConnectedOnly) {
+    const connectedPeripheral = connectedDevices.get(deviceId);
+    if (connectedPeripheral?.state !== 'connected' || !deviceCharacteristics.has(deviceId)) {
+      throw ERRORS.TypedError(
+        HardwareErrorCode.DeviceNotFound,
+        `Device ${deviceId} has no reusable BLE connection`
+      );
+    }
+    setupDisconnectListener(connectedPeripheral, deviceId, webContents);
+    return;
+  }
 
   // enumerate clears the discovery map; a kept-alive link outlives it.
   let peripheral = discoveredDevices.get(deviceId) ?? connectedDevices.get(deviceId);
@@ -1786,7 +1802,7 @@ export function setupNobleBleHandlers(webContents: WebContents): void {
     // Handle connect request
     handle(
       EOneKeyBleMessageKeys.NOBLE_BLE_CONNECT,
-      async (_event: IpcMainInvokeEvent, deviceId: string) => {
+      async (_event: IpcMainInvokeEvent, deviceId: string, options?: NobleBleConnectOptions) => {
         logger?.info('[NobleBLE] IPC CONNECT request received:', {
           deviceId,
           hasPeripheral: connectedDevices.has(deviceId),
@@ -1798,7 +1814,7 @@ export function setupNobleBleHandlers(webContents: WebContents): void {
         // A fired timer must settle first, or the fast path returns a dying link.
         await awaitIdleDisconnect(deviceId);
         try {
-          await connectDevice(deviceId, webContents);
+          await connectDevice(deviceId, webContents, options);
         } finally {
           // This timer is the only thing that frees a kept-alive link.
           if (connectedDevices.has(deviceId)) {

--- a/packages/hd-transport-electron/src/types/desktop-api.ts
+++ b/packages/hd-transport-electron/src/types/desktop-api.ts
@@ -8,10 +8,19 @@ export interface NobleBleWriteOptions {
   pacingDelayMs?: number;
 }
 
+export interface NobleBleConnectOptions {
+  /** Reuse only a fully initialized physical link; never scan, reconnect, or rediscover services. */
+  reuseConnectedOnly?: boolean;
+}
+
 export interface NobleBleAPI {
   enumerate: () => Promise<{ id: string; name: string }[]>;
-  getDevice: (uuid: string) => Promise<{ id: string; name: string; mtu?: number } | null>;
-  connect: (uuid: string) => Promise<void>;
+  getDevice: (
+    uuid: string
+  ) => Promise<{ id: string; name: string; mtu?: number; state?: string } | null>;
+  connect: (uuid: string, options?: NobleBleConnectOptions) => Promise<void>;
+  /** Optional host capability: reuse a fully initialized link without scanning or reconnecting. */
+  connectConnectedOnly?: (uuid: string) => Promise<void>;
   // Logical end-of-operation: link stays up, idle countdown starts. Optional —
   // older hosts do not bridge it, so the transport feature-detects.
   release?: (uuid: string, keepSession?: boolean) => Promise<void>;

--- a/packages/hd-transport-web-device/__tests__/electron-ble-transport.test.ts
+++ b/packages/hd-transport-web-device/__tests__/electron-ble-transport.test.ts
@@ -100,6 +100,7 @@ const createNobleBle = (device = { id: 'flaky-pro2-id', name: 'Unknown BLE Devic
   enumerate: jest.fn(() => Promise.resolve([device])),
   getDevice: jest.fn(() => Promise.resolve(device)),
   connect: jest.fn(() => Promise.resolve()),
+  connectConnectedOnly: jest.fn(() => Promise.resolve()),
   disconnect: jest.fn(() => Promise.resolve()),
   subscribe: jest.fn(() => Promise.resolve()),
   unsubscribe: jest.fn(() => Promise.resolve()),
@@ -141,7 +142,11 @@ describe('ElectronBleTransport protocol detection', () => {
   });
 
   test('keeps raw BLE lifecycle payloads off the public device event channel', async () => {
-    const device = { id: 'lifecycle-pro2-id', name: 'OneKey Pro 2' };
+    const device = {
+      id: 'lifecycle-pro2-id',
+      name: 'OneKey Pro 2',
+      state: 'connected',
+    };
     const nobleBle = createNobleBle(device);
     const emitter = new EventEmitter();
     let notificationHandler: ((deviceId: string, data: string) => void) | undefined;
@@ -176,7 +181,13 @@ describe('ElectronBleTransport protocol detection', () => {
     emitter.on('transport-device-disconnect', transportDisconnect);
     const bleTransport = configureTransport(nobleBle, emitter);
 
-    await bleTransport.acquire({ uuid: device.id, expectedProtocol: 'V2' });
+    await bleTransport.acquire({
+      uuid: device.id,
+      expectedProtocol: 'V2',
+      reuseConnectedOnly: true,
+    });
+    expect(nobleBle.connectConnectedOnly).toHaveBeenCalledWith(device.id);
+    expect(nobleBle.connect).not.toHaveBeenCalled();
     expect(nobleBle.subscribe.mock.invocationCallOrder[0]).toBeLessThan(
       nobleBle.getDevice.mock.invocationCallOrder[1]
     );
@@ -189,6 +200,92 @@ describe('ElectronBleTransport protocol detection', () => {
       connectId: device.id,
       name: device.name,
     });
+  });
+
+  test('does not reconnect or scan when connected-only reuse finds a stale link', async () => {
+    const device = {
+      id: 'stale-pro2-id',
+      name: 'OneKey Pro 2',
+      state: 'disconnected',
+    };
+    const nobleBle = createNobleBle(device);
+    const bleTransport = configureTransport(nobleBle);
+
+    await expect(
+      bleTransport.acquire({
+        uuid: device.id,
+        expectedProtocol: 'V2',
+        reuseConnectedOnly: true,
+      })
+    ).rejects.toMatchObject({ errorCode: HardwareErrorCode.DeviceNotFound });
+
+    expect(nobleBle.connect).not.toHaveBeenCalled();
+    expect(nobleBle.subscribe).not.toHaveBeenCalled();
+  });
+
+  test('fails closed when the desktop host lacks connected-only capability', async () => {
+    const device = {
+      id: 'legacy-host-pro2-id',
+      name: 'OneKey Pro 2',
+      state: 'connected',
+    };
+    const nobleBle = createNobleBle(device);
+    delete (nobleBle as Partial<typeof nobleBle>).connectConnectedOnly;
+    const bleTransport = configureTransport(nobleBle);
+
+    await expect(
+      bleTransport.acquire({
+        uuid: device.id,
+        expectedProtocol: 'V2',
+        reuseConnectedOnly: true,
+      })
+    ).rejects.toMatchObject({ errorCode: HardwareErrorCode.DeviceNotFound });
+
+    expect(nobleBle.connect).not.toHaveBeenCalled();
+    expect(nobleBle.subscribe).not.toHaveBeenCalled();
+  });
+
+  test('rebuilds an IPC connection rejection as a terminal DeviceNotFound error', async () => {
+    const device = {
+      id: 'ipc-disconnected-pro2-id',
+      name: 'OneKey Pro 2',
+      state: 'connected',
+    };
+    const nobleBle = createNobleBle(device);
+    nobleBle.connectConnectedOnly.mockRejectedValue(new Error('Error invoking remote method'));
+    const bleTransport = configureTransport(nobleBle);
+
+    await expect(
+      bleTransport.acquire({
+        uuid: device.id,
+        expectedProtocol: 'V2',
+        reuseConnectedOnly: true,
+      })
+    ).rejects.toMatchObject({ errorCode: HardwareErrorCode.DeviceNotFound });
+
+    expect(nobleBle.disconnect).not.toHaveBeenCalled();
+  });
+
+  test('does not tear down the kept-alive link when connected-only setup fails', async () => {
+    const device = {
+      id: 'subscribe-failed-pro2-id',
+      name: 'OneKey Pro 2',
+      state: 'connected',
+    };
+    const nobleBle = createNobleBle(device);
+    nobleBle.subscribe.mockRejectedValue(new Error('subscribe failed'));
+    const bleTransport = configureTransport(nobleBle);
+
+    await expect(
+      bleTransport.acquire({
+        uuid: device.id,
+        expectedProtocol: 'V2',
+        reuseConnectedOnly: true,
+      })
+    ).rejects.toThrow('subscribe failed');
+
+    expect(nobleBle.unsubscribe).not.toHaveBeenCalled();
+    expect(nobleBle.disconnect).not.toHaveBeenCalled();
   });
 
   test('uses the Protocol V2 BLE writer with the Electron packet size', async () => {

--- a/packages/hd-transport-web-device/src/electron-ble-transport.ts
+++ b/packages/hd-transport-web-device/src/electron-ble-transport.ts
@@ -41,6 +41,7 @@ declare global {
 export type BleAcquireInput = {
   uuid: string;
   forceCleanRunPromise?: boolean;
+  reuseConnectedOnly?: boolean;
   expectedProtocol?: ProtocolType;
   protocolHint?: ProtocolType;
 };
@@ -282,7 +283,7 @@ export default class ElectronBleTransport {
   }
 
   async acquire(input: BleAcquireInput) {
-    const { uuid, forceCleanRunPromise, expectedProtocol } = input;
+    const { uuid, forceCleanRunPromise, expectedProtocol, reuseConnectedOnly } = input;
 
     if (!uuid) {
       throw ERRORS.TypedError(HardwareErrorCode.BleRequiredUUID);
@@ -308,6 +309,13 @@ export default class ElectronBleTransport {
       if (!device) {
         throw ERRORS.TypedError(HardwareErrorCode.DeviceNotFound, `Device ${uuid} not found`);
       }
+      const deviceState = (device as typeof device & { state?: string }).state;
+      if (reuseConnectedOnly && deviceState !== 'connected') {
+        throw ERRORS.TypedError(
+          HardwareErrorCode.DeviceNotFound,
+          `Device ${uuid} is no longer connected`
+        );
+      }
       const protocolHint = expectedProtocol
         ? undefined
         : input.protocolHint ??
@@ -318,9 +326,27 @@ export default class ElectronBleTransport {
       }
 
       try {
-        await window.desktopApi.nobleBle.connect(uuid);
+        if (reuseConnectedOnly) {
+          const { connectConnectedOnly } = window.desktopApi.nobleBle;
+          if (!connectConnectedOnly) {
+            throw ERRORS.TypedError(
+              HardwareErrorCode.DeviceNotFound,
+              'Desktop host does not support connected-only BLE reuse'
+            );
+          }
+          await connectConnectedOnly(uuid);
+        } else {
+          await window.desktopApi.nobleBle.connect(uuid);
+        }
         this.connectedDevices.add(uuid);
       } catch (error) {
+        if (reuseConnectedOnly) {
+          // Electron IPC does not reliably preserve custom Error fields such as errorCode.
+          throw ERRORS.TypedError(
+            HardwareErrorCode.DeviceNotFound,
+            error instanceof Error ? error.message : `Device ${uuid} is no longer connected`
+          );
+        }
         this.handleBluetoothError(error);
       }
 
@@ -372,7 +398,7 @@ export default class ElectronBleTransport {
     } catch (error) {
       this.Log?.error('[Electron BLE] acquire failed:', error);
       try {
-        if (window.desktopApi?.nobleBle && this.connectedDevices.has(uuid)) {
+        if (!reuseConnectedOnly && window.desktopApi?.nobleBle && this.connectedDevices.has(uuid)) {
           await window.desktopApi.nobleBle.unsubscribe(uuid);
           await window.desktopApi.nobleBle.disconnect(uuid);
         }

--- a/packages/hd-transport/src/types/transport.ts
+++ b/packages/hd-transport/src/types/transport.ts
@@ -52,6 +52,8 @@ export type AcquireInput = {
   previous?: string | null;
   uuid?: string;
   forceCleanRunPromise?: boolean;
+  /** Reuse an already-connected BLE link and fail without scanning when it is gone. */
+  reuseConnectedOnly?: boolean;
   expectedProtocol?: ProtocolType;
   protocolHint?: ProtocolType;
 };


### PR DESCRIPTION
## Summary

- propagate an optional `reuseConnectedOnly` flag from Core through `DeviceConnector` into Electron BLE transport
- require an already-connected, fully initialized Noble link in the Electron main process; never scan, reconnect, rediscover services, or retry in this mode
- fail closed when the desktop preload does not expose the connected-only capability, normalize IPC failures to terminal `DeviceNotFound`, and preserve the user's kept-alive BLE link when a background setup attempt fails
- stop both inner retry and outer polling after the single connected-only attempt

## Why

Desktop Portfolio Sync runs as a best-effort idle task. It must not turn a stale BLE lease into active scanning/reconnection, block foreground hardware work, or disconnect the user's active BLE session.

## Validation

- `yarn jest --runInBand` on 5 focused suites: 74 tests passed
- ESLint passed on all 18 changed TypeScript files
- `tsc` passed for `hd-transport` and `hd-transport-web-device` after building the Electron transport declarations
- Electron transport build passed; its standalone `tsc` still reports the pre-existing unused `webContents` parameter at `noble-ble-handler.ts:423`

## Integration note

The dependent App PR must remain Draft until these SDK packages are published together and the App upgrades `hd-core`, `hd-transport-electron`, and `hd-transport-web-device` from `1.2.0-alpha.108`.
