### PR TITLE
fix: stop firmware v4 polling for uninitialized devices

### DIFF
--- a/packages/core/__tests__/protocol-v2.test.ts
+++ b/packages/core/__tests__/protocol-v2.test.ts
@@ -4145,7 +4145,7 @@ describe('Protocol V2 firmware update targets', () => {
     );
   });
 
-  test('uses Protocol V2 features after BLE final reconnect without V1 Initialize', async () => {
+  test('accepts uninitialized Protocol V2 features after BLE final reconnect', async () => {
     const method = new FirmwareUpdateV4({
       id: 1,
       payload: {
@@ -4173,7 +4173,7 @@ describe('Protocol V2 firmware update targets', () => {
       if (name === 'DeviceStatusGet') {
         return Promise.resolve({
           type: 'DeviceStatus',
-          message: { init_states: true, unlocked: true },
+          message: { init_states: false, unlocked: false },
         });
       }
       if (name === 'ProtocolInfoRequest') {
@@ -4194,7 +4194,7 @@ describe('Protocol V2 firmware update targets', () => {
       getCommands: () => commands,
       updateProtocolV2Features: jest.fn(() => ({
         bootloaderMode: false,
-        mode: 'normal',
+        mode: 'notInitialized',
         firmwareVersion: '0.0.0',
         bootloaderVersion: '0.0.0',
         bleVersion: '0.0.0',
@@ -5609,6 +5609,7 @@ describe('Protocol V2 firmware update targets', () => {
 
   test.each([
     [{ mode: 'normal', bootloaderMode: false }, true],
+    [{ mode: 'notInitialized', bootloaderMode: false }, true],
     [{ mode: 'bootloader', bootloaderMode: true }, false],
   ])('derives firmware completion from the runtime-state probe: %o', async (features, expected) => {
     const method = new FirmwareUpdateV4({

--- a/packages/core/src/api/FirmwareUpdateV4.ts
+++ b/packages/core/src/api/FirmwareUpdateV4.ts
@@ -2896,7 +2896,13 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
       PROTOCOL_V2_SHORT_RESPONSE_TIMEOUT
     );
     this.protocolV2LastRuntimeProbeFeatures = features;
-    return features.mode === 'normal' && !features.bootloaderMode;
+    return this.isProtocolV2ApplicationMode(features);
+  }
+
+  private isProtocolV2ApplicationMode(features: Features) {
+    return (
+      (features.mode === 'normal' || features.mode === 'notInitialized') && !features.bootloaderMode
+    );
   }
 
   private async waitForProtocolV2FinalFeatures() {
@@ -2958,7 +2964,7 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
           deviceInfo,
           PROTOCOL_V2_SHORT_RESPONSE_TIMEOUT
         );
-        if (features.mode === 'normal' && !features.bootloaderMode) {
+        if (this.isProtocolV2ApplicationMode(features)) {
           return features;
         }
         lastError = ERRORS.TypedError(


### PR DESCRIPTION
## What changed

- Treat both `normal` and `notInitialized` device states as Protocol V2 application mode during FirmwareUpdateV4 completion checks.
- Reuse the same application-mode predicate for install-status polling and final reconnect/version verification.
- Add regression coverage for uninitialized devices in both completion paths.

## Root cause

After firmware installation and reboot, an application-mode device with `DeviceStatus.init_states=false` is projected as `mode: 'notInitialized'`. FirmwareUpdateV4 only accepted `mode: 'normal'`, so it kept polling even though the device had already left the loader and restarted successfully.

## Impact

Uninitialized Pro2/Neo Protocol V2 devices can now finish FirmwareUpdateV4 without waiting for the install or final reconnect timeout. Initialized devices, loader detection, Protocol V1 behavior, public APIs, and transport cleanup remain unchanged.

## Validation

- `yarn --cwd packages/core test protocol-v2.test.ts firmware-update-v4-install-poll.test.ts --runInBand`
- `yarn --cwd packages/core build`
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
