### PR TITLE
fix: harden Protocol V2 firmware updates and release resources

### DIFF
--- a/docs/business/pro2-device-management.md
+++ b/docs/business/pro2-device-management.md
@@ -136,7 +136,9 @@ Protocol V1 继续使用 `firmwareUpdate` 至 `firmwareUpdateV3`；Pro2 与 Neo 
 5. 必要时重启进入 bootloader，并轮询确认模式。
 6. 将目标文件分片写入 `vol0:/`，再使用 PathInfo 校验大小。
 7. 先通过 `DeviceFirmwareUpdateStage.targets[]` 提交全部待安装文件，再发送空的
-   `DeviceFirmwareUpdateRequest` 触发安装。
+   `DeviceFirmwareUpdateRequest` 触发安装。发送安装请求前，SDK 发出非阻塞
+   `REQUEST_BUTTON`（`reason='firmware-update'`），提示 App 展示“请在设备上确认”；App 不调用
+   `uiResponse()`。
 8. 轮询 target 安装状态，允许安装阶段断连、超时和重连探测；同一连接可用时复用当前
    command channel，只在链路失败后重新枚举和校验物理身份。
 9. 确认设备已自动回到 normal mode 时不再重复发送 Normal reboot；随后显式刷新

--- a/docs/protocol/protocol-v1-v2.md
+++ b/docs/protocol/protocol-v1-v2.md
@@ -190,6 +190,8 @@ BLE 平台实现包括 Electron、React Native 和 lowlevel 插件。公共约�
   burst 或 flush pause；只对明确的 `GATT_CONGESTED` 做有界退避重试，断连或 generation
   变化立即中止，不能跨连接继续写。
 - notification 数据统一进入 `ProtocolV2FrameAssembler`，不能假设一次通知就是一帧。
+- Electron BLE 在 V1/V2 probe 回退时只轮换 renderer notification token 和协议缓冲，不断开或
+  重新订阅 GATT；未配对设备因此只触发一次系统配对流程。
 - 重连或重新订阅后，旧回调必须通过 generation/token 失效。
 - lowlevel 插件只提供连接、读写和订阅能力，不复制协议状态机。
 

--- a/docs/sdk/events.md
+++ b/docs/sdk/events.md
@@ -278,6 +278,11 @@ V2 中，地址/公钥、签名和设备管理方法在进入设备交互前直�
 `ButtonAck`。应用在两个协议版本下都只需展示“请在设备上确认”，不要调用 `uiResponse()`。
 
 Pro2 设置页 Event 还会携带 `source='method-lifecycle'`、`reason`、`completion` 和 `page`。
+
+`firmwareUpdateV4` 在 `DeviceFirmwareUpdateStage` 成功后、发送
+`DeviceFirmwareUpdateRequest` 前发出同类非阻塞 `REQUEST_BUTTON`，其中
+`reason='firmware-update'`、`completion='operation-completed'`。App 只展示设备确认提示，不调用
+`uiResponse()`；安装进度继续通过 `FIRMWARE_TIP` 与 `FIRMWARE_PROGRESS` 通知。
 `completion='page-accepted'` 表示 API 成功只证明设备页面已打开，不代表用户已经完成或确认设置。
 
 `uploadPortfolio` 不属于设备确认流程：SDK 不为它生成 `REQUEST_BUTTON/REQUEST_PIN`，文件写入也关闭
@@ -298,6 +303,8 @@ V1 用户选择设备端输入后，设备可能返回 `ButtonRequest_Passphrase
 
 关闭事件是状态通知，不代表一个新的业务失败，也不需要回传。App 收到关闭通知时只幂等收起 UI，
 不能反向触发第二次 Cancel；只有用户主动关闭/取消交互时才取消当前 SDK 调用。
+用户取消 `firmwareUpdateV4` 的设备确认提示时，Core 先在当前 Protocol V2 link 上发送仅写 `Cancel`
+流控帧，再中断并释放原调用；该帧不排在等待设备确认的业务响应之后。
 
 ## 进度和中间结果
 

--- a/packages/core/__tests__/firmware-update/firmware-prepared-resource-archive.test.ts
+++ b/packages/core/__tests__/firmware-update/firmware-prepared-resource-archive.test.ts
@@ -105,6 +105,27 @@ const createPreparedResourcePlan = ({
 };
 
 describe.each(['v2', 'v3'] as const)('%s prepared resource archive binding', executor => {
+  test('rejects a missing artifact reader', async () => {
+    const entryBinary = Uint8Array.from([1, 2, 3, 4]).buffer;
+    const zip = new JSZip();
+    zip.file('images/logo.bin', entryBinary);
+    const archiveBinary = await zip.generateAsync({ type: 'arraybuffer' });
+    const { preparedPlan } = createPreparedResourcePlan({
+      executor,
+      archiveBinary,
+      entryBinary,
+    });
+
+    await expect(
+      readVerifiedPreparedResourceArchive({
+        preparedPlan,
+        reader: undefined,
+      })
+    ).rejects.toMatchObject({
+      params: { firmwareUpdateCode: 'FirmwareArtifactReaderInvalid' },
+    });
+  });
+
   test('uses canonical bytes extracted from the approved ZIP', async () => {
     const entryBinary = Uint8Array.from([1, 2, 3, 4]).buffer;
     const zip = new JSZip();

--- a/packages/core/__tests__/firmware-update/firmware-update-v4-install-poll.test.ts
+++ b/packages/core/__tests__/firmware-update/firmware-update-v4-install-poll.test.ts
@@ -42,7 +42,12 @@ describe('FirmwareUpdateV4 install polling', () => {
 
     method.device = {
       getCommands: () => ({ typedCall, call }),
+      createProtocolV2UiPhaseMetadata: jest.fn().mockReturnValue(undefined),
+      toMessageObject: jest.fn().mockReturnValue({ connectId: 'pro2-ble' }),
+      setCancelableAction: jest.fn(),
+      clearCancelableAction: jest.fn(),
     } as unknown as Device;
+    method.postMessage = jest.fn();
     method.postTipMessage = jest.fn();
     method.postProgressMessage = jest.fn();
 

--- a/packages/core/__tests__/protocol-v2-resources.test.ts
+++ b/packages/core/__tests__/protocol-v2-resources.test.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { sha256 } from '@noble/hashes/sha256';
-import { EDeviceType, HardwareErrorCode } from '@onekeyfe/hd-shared';
+import { EDeviceType, EFirmwareType, HardwareErrorCode } from '@onekeyfe/hd-shared';
 
 import { DataManager } from '../src/data-manager';
 import {
@@ -8,7 +8,7 @@ import {
   parseProtocolV2Resources,
 } from '../src/protocols/protocol-v2/resources';
 
-import type { ConnectSettings, RemoteConfigResponse } from '../src/types';
+import type { ConnectSettings, Features, RemoteConfigResponse } from '../src/types';
 
 jest.mock('axios');
 jest.mock('../src/data/config', () => ({
@@ -108,10 +108,37 @@ const createRemoteConfig = (): RemoteConfigResponse =>
     mini: { firmware: [], ble: [] },
     touch: { firmware: [], ble: [] },
     pro: { firmware: [], ble: [] },
-    pro2: { firmware: [], ble: [], resources: { source: resourceSource } },
-    neo: { firmware: [], ble: [], resources: { source: neoResourceSource } },
+    pro2: {
+      'firmware-v1': [
+        {
+          required: false,
+          version: [1, 0, 0],
+          url: 'https://example.com/pro2.okpkg',
+          fingerprint: 'a'.repeat(64),
+          changelog: { 'zh-CN': 'Pro2', 'en-US': 'Pro2' },
+          resources: { source: resourceSource },
+        },
+      ],
+      ble: [],
+    },
+    neo: {
+      'firmware-v1': [
+        {
+          required: false,
+          version: [1, 0, 0],
+          url: 'https://example.com/neo.okpkg',
+          fingerprint: 'b'.repeat(64),
+          changelog: { 'zh-CN': 'Neo', 'en-US': 'Neo' },
+          resources: { source: neoResourceSource },
+        },
+      ],
+      ble: [],
+    },
     bridge: {},
   } as unknown as RemoteConfigResponse);
+
+const getProtocolV2Release = (deviceType: EDeviceType.Pro2 | EDeviceType.Neo) =>
+  DataManager.deviceMap[deviceType]?.['firmware-v1']?.[0];
 
 describe('Pro2 resource configuration', () => {
   beforeEach(() => {
@@ -184,8 +211,68 @@ describe('Pro2 resource configuration', () => {
     expect(configFetcher).toHaveBeenCalledWith(
       expect.stringMatching(/^https:\/\/data\.onekey\.so\/pre-config\.json\?noCache=/)
     );
-    expect(DataManager.getProtocolV2ResourceSource()).toEqual(resourceSource);
+    expect(DataManager.getProtocolV2ResourceSource(getProtocolV2Release(EDeviceType.Pro2))).toEqual(
+      resourceSource
+    );
     expect(DataManager.lastCheckTimestamp).toBeGreaterThan(0);
+  });
+
+  test('uses the resource archive bound to the selected firmware release', async () => {
+    const newerResourceSource = {
+      archiveUrl: 'https://example.com/resource/pro2-resource-v2.zip',
+      archiveSha256: 'c'.repeat(64),
+      archiveSize: 20_000_000,
+    };
+    const remoteConfig = createRemoteConfig();
+    remoteConfig.pro2['firmware-v1']?.push({
+      ...remoteConfig.pro2['firmware-v1'][0],
+      version: [2, 0, 0],
+      resources: { source: newerResourceSource },
+    });
+
+    await expect(
+      DataManager.load(createSettings(jest.fn().mockResolvedValue(remoteConfig)))
+    ).resolves.toBe(true);
+
+    const selectedRelease = DataManager.getFirmwareLatestRelease(
+      { deviceType: 'pro2', firmwareVersion: '1.0.0' } as Features,
+      EFirmwareType.Universal
+    );
+    expect(selectedRelease?.version).toEqual([2, 0, 0]);
+    expect(DataManager.getProtocolV2ResourceSource(selectedRelease)).toEqual(newerResourceSource);
+  });
+
+  test('does not use a device-level Protocol V2 resource archive', async () => {
+    const remoteConfig = createRemoteConfig();
+    delete remoteConfig.pro2['firmware-v1']?.[0].resources;
+    (remoteConfig.pro2 as unknown as { resources: unknown }).resources = {
+      source: resourceSource,
+    };
+
+    await expect(
+      DataManager.load(createSettings(jest.fn().mockResolvedValue(remoteConfig)))
+    ).resolves.toBe(true);
+
+    expect(
+      DataManager.getProtocolV2ResourceSource(getProtocolV2Release(EDeviceType.Pro2))
+    ).toBeUndefined();
+  });
+
+  test('does not block the latest release when an older release has invalid resources', async () => {
+    const remoteConfig = createRemoteConfig();
+    (remoteConfig.pro2['firmware-v1']?.[0] as { resources?: unknown }).resources = { source: {} };
+    remoteConfig.pro2['firmware-v1']?.push({
+      ...remoteConfig.pro2['firmware-v1'][0],
+      version: [2, 0, 0],
+      resources: { source: resourceSource },
+    });
+    const configFetcher = jest.fn().mockResolvedValue(remoteConfig);
+
+    await expect(DataManager.load(createSettings(configFetcher))).resolves.toBe(true);
+    await expect(DataManager.forceReloadData({ requireResources: true })).resolves.toBeUndefined();
+
+    const latestRelease = DataManager.deviceMap[EDeviceType.Pro2]?.['firmware-v1']?.[1];
+    expect(DataManager.getProtocolV2ResourceSource(latestRelease)).toEqual(resourceSource);
   });
 
   test('reuses the configuration fetched during SDK initialization for an immediate update', async () => {
@@ -200,25 +287,33 @@ describe('Pro2 resource configuration', () => {
 
   test('keeps base SDK initialization available when remote Pro2 resources are invalid', async () => {
     const remoteConfig = createRemoteConfig();
-    (remoteConfig.pro2 as { resources?: unknown }).resources = { source: {} };
+    (remoteConfig.pro2['firmware-v1']?.[0] as { resources?: unknown }).resources = { source: {} };
     const configFetcher = jest.fn().mockResolvedValue(remoteConfig);
 
     await expect(DataManager.load(createSettings(configFetcher))).resolves.toBe(true);
 
-    expect(DataManager.getProtocolV2ResourceSource()).toBeUndefined();
+    expect(
+      DataManager.getProtocolV2ResourceSource(getProtocolV2Release(EDeviceType.Pro2))
+    ).toBeUndefined();
     expect(DataManager.protocolV2ResourcesConfigError).toBeInstanceOf(Error);
-    expect(DataManager.getProtocolV2ResourceSource(EDeviceType.Neo)).toEqual(neoResourceSource);
+    expect(DataManager.getProtocolV2ResourceSource(getProtocolV2Release(EDeviceType.Neo))).toEqual(
+      neoResourceSource
+    );
   });
 
   test('keeps Pro2 resources available when remote Neo resources are invalid', async () => {
     const remoteConfig = createRemoteConfig();
-    (remoteConfig.neo as { resources?: unknown }).resources = { source: {} };
+    (remoteConfig.neo?.['firmware-v1']?.[0] as { resources?: unknown }).resources = { source: {} };
     const configFetcher = jest.fn().mockResolvedValue(remoteConfig);
 
     await expect(DataManager.load(createSettings(configFetcher))).resolves.toBe(true);
 
-    expect(DataManager.getProtocolV2ResourceSource(EDeviceType.Pro2)).toEqual(resourceSource);
-    expect(DataManager.getProtocolV2ResourceSource(EDeviceType.Neo)).toBeUndefined();
+    expect(DataManager.getProtocolV2ResourceSource(getProtocolV2Release(EDeviceType.Pro2))).toEqual(
+      resourceSource
+    );
+    expect(
+      DataManager.getProtocolV2ResourceSource(getProtocolV2Release(EDeviceType.Neo))
+    ).toBeUndefined();
     await expect(
       DataManager.forceReloadData({
         requireResources: true,
@@ -238,7 +333,7 @@ describe('Pro2 resource configuration', () => {
 
   test('only blocks resource mutation when the refreshed Pro2 resources are invalid', async () => {
     const remoteConfig = createRemoteConfig();
-    (remoteConfig.pro2 as { resources?: unknown }).resources = { source: {} };
+    (remoteConfig.pro2['firmware-v1']?.[0] as { resources?: unknown }).resources = { source: {} };
     const settings = createSettings(jest.fn().mockResolvedValue(remoteConfig));
     DataManager.settings = settings;
 
@@ -252,7 +347,7 @@ describe('Pro2 resource configuration', () => {
 
   test('checks resource configuration errors for the requested device only', async () => {
     const remoteConfig = createRemoteConfig();
-    (remoteConfig.pro2 as { resources?: unknown }).resources = { source: {} };
+    (remoteConfig.pro2['firmware-v1']?.[0] as { resources?: unknown }).resources = { source: {} };
     const settings = createSettings(jest.fn().mockResolvedValue(remoteConfig));
     DataManager.settings = settings;
 

--- a/packages/core/__tests__/protocol-v2.test.ts
+++ b/packages/core/__tests__/protocol-v2.test.ts
@@ -514,6 +514,10 @@ function stubDevice<T extends Record<string, any>>(device: T): T {
   const d = device as any;
   d.updateState ??= jest.fn();
   d.markProtocolV2Reboot ??= jest.fn();
+  d.setCancelableAction ??= jest.fn();
+  d.clearCancelableAction ??= jest.fn();
+  d.toMessageObject ??= jest.fn(() => ({ connectId: d.originalDescriptor?.id }));
+  d.createProtocolV2UiPhaseMetadata ??= jest.fn(() => undefined);
   d.isProtocolV2 ??= () => d.originalDescriptor?.protocolType === 'V2';
   d.isBootloader ??= () => d.features?.mode === 'bootloader';
   d.isRomloader ??= () => d.features?.mode === 'romloader';
@@ -4271,7 +4275,7 @@ describe('Protocol V2 firmware update targets', () => {
     });
     (method as any).protocolV2Reboot = jest.fn();
     (method as any).enterProtocolV2BootloaderMode = jest.fn().mockResolvedValue(true);
-    method.postTipMessage = jest.fn();
+    method.postMessage = jest.fn();
 
     await method.run();
 
@@ -5254,10 +5258,26 @@ describe('Protocol V2 firmware update targets', () => {
     const targets = [{ target_id: 4, path: 'vol1:firmware.bin' }];
     const typedCall = jest.fn().mockResolvedValue({ type: 'Success', message: {} });
     const call = jest.fn().mockResolvedValue({ type: 'WriteCompleted', message: {} });
+    const cancelDevice = jest.fn().mockResolvedValue(undefined);
+    let cancelableAction: (() => Promise<unknown>) | undefined;
+    const interaction = {
+      interactionId: 'firmware-update',
+      phaseId: 'firmware-update:phase-1',
+      sequence: 1,
+      phase: 'button',
+      transition: 'start',
+      protocol: 'V2',
+    };
 
     (method as any).device = stubDevice({
-      getCommands: () => ({ typedCall, call }),
+      getCommands: () => ({ typedCall, call, cancelDevice }),
+      createProtocolV2UiPhaseMetadata: jest.fn().mockReturnValue(interaction),
+      toMessageObject: jest.fn().mockReturnValue({ connectId: 'pro2' }),
+      setCancelableAction: jest.fn(action => {
+        cancelableAction = action;
+      }),
     });
+    method.postMessage = jest.fn();
     method.postTipMessage = jest.fn();
     method.postProgressMessage = jest.fn();
 
@@ -5266,14 +5286,32 @@ describe('Protocol V2 firmware update targets', () => {
     ).resolves.toBeUndefined();
 
     expect(typedCall).toHaveBeenCalledWith('DeviceFirmwareUpdateStage', 'Success', { targets });
+    expect(method.postMessage).toHaveBeenCalledWith({
+      event: 'UI_EVENT',
+      type: UI_REQUEST.REQUEST_BUTTON,
+      payload: {
+        device: { connectId: 'pro2' },
+        source: 'method-lifecycle',
+        reason: 'firmware-update',
+        completion: 'operation-completed',
+        deviceOnly: true,
+        operation: 'firmwareUpdateV4',
+        interaction,
+      },
+    });
     expect(call).toHaveBeenCalledWith(
       'DeviceFirmwareUpdateRequest',
       {},
       { returnAfterWrite: true }
     );
     expect(typedCall.mock.invocationCallOrder[0]).toBeLessThan(call.mock.invocationCallOrder[0]);
-    expect(method.postTipMessage).toHaveBeenCalledWith('FirmwareUpdating');
-    expect(method.postProgressMessage).toHaveBeenCalledWith(0, 'installingFirmware');
+    expect((method.postMessage as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      call.mock.invocationCallOrder[0]
+    );
+    expect(method.postTipMessage).not.toHaveBeenCalled();
+    expect(method.postProgressMessage).not.toHaveBeenCalled();
+    await cancelableAction?.();
+    expect(cancelDevice).toHaveBeenCalledTimes(1);
   });
 
   test('does not send the install request when Protocol V2 staging fails', async () => {
@@ -5289,6 +5327,7 @@ describe('Protocol V2 firmware update targets', () => {
     (method as any).device = stubDevice({
       getCommands: () => ({ typedCall, call }),
     });
+    method.postMessage = jest.fn();
     method.postTipMessage = jest.fn();
     method.postProgressMessage = jest.fn();
 
@@ -5299,6 +5338,7 @@ describe('Protocol V2 firmware update targets', () => {
     ).rejects.toThrow('stage failed');
 
     expect(call).not.toHaveBeenCalled();
+    expect(method.postMessage).not.toHaveBeenCalled();
     expect(method.postTipMessage).not.toHaveBeenCalled();
     expect(method.postProgressMessage).not.toHaveBeenCalled();
   });
@@ -5315,7 +5355,10 @@ describe('Protocol V2 firmware update targets', () => {
 
     (method as any).device = stubDevice({
       getCommands: () => ({ typedCall, call }),
+      createProtocolV2UiPhaseMetadata: jest.fn().mockReturnValue(undefined),
+      toMessageObject: jest.fn().mockReturnValue({ connectId: 'pro2' }),
     });
+    method.postMessage = jest.fn();
     method.postTipMessage = jest.fn();
     method.postProgressMessage = jest.fn();
 
@@ -5347,23 +5390,23 @@ describe('Protocol V2 firmware update targets', () => {
         type: 'DeviceFirmwareUpdateStatus',
         message: { records: [{ target_id: 4, status: 2 }] },
       });
-    const reconnectProtocolV2Device = jest
-      .fn()
-      .mockRejectedValueOnce(new Error('Device rebooting'))
-      .mockResolvedValue(undefined);
+    const reconnectProtocolV2Device = jest.fn();
+    const verifyProtocolV2ReconnectIdentity = jest.fn();
 
     (method as any).device = stubDevice({
       getCommands: () => ({ typedCall }),
     });
     (method as any).reconnectProtocolV2Device = reconnectProtocolV2Device;
-    (method as any).verifyProtocolV2ReconnectIdentity = jest.fn().mockResolvedValue(undefined);
+    (method as any).verifyProtocolV2ReconnectIdentity = verifyProtocolV2ReconnectIdentity;
     method.postProgressMessage = jest.fn();
+    method.postTipMessage = jest.fn();
 
     await (method as any).waitForProtocolV2FirmwareUpdateComplete([
       { target_id: 4, path: 'vol0:/application_p1.bin' },
     ]);
 
-    expect(reconnectProtocolV2Device).toHaveBeenCalledTimes(2);
+    expect(reconnectProtocolV2Device).not.toHaveBeenCalled();
+    expect(verifyProtocolV2ReconnectIdentity).not.toHaveBeenCalled();
     expect(typedCall.mock.calls.map(call => call[0])).toEqual([
       'DeviceFirmwareUpdateStatusGet',
       'DeviceFirmwareUpdateStatusGet',
@@ -5418,7 +5461,7 @@ describe('Protocol V2 firmware update targets', () => {
       setTimeoutSpy.mockRestore();
     }
 
-    expect(reconnectProtocolV2Device).toHaveBeenCalledTimes(1);
+    expect(reconnectProtocolV2Device).not.toHaveBeenCalled();
     expect(typedCall.mock.calls.map(call => call[0])).toEqual([
       'DeviceFirmwareUpdateStatusGet',
       'DeviceFirmwareUpdateStatusGet',
@@ -5706,7 +5749,9 @@ describe('Protocol V2 firmware update targets', () => {
       'DeviceFirmwareUpdateStatusGet',
       'DeviceFirmwareUpdateStatusGet',
     ]);
-    expect((method as any).probeProtocolV2NormalMode).toHaveBeenCalledWith(deviceInfo);
+    expect((method as any).reconnectProtocolV2Device).toHaveBeenCalledTimes(1);
+    expect((method as any).verifyProtocolV2ReconnectIdentity).toHaveBeenCalledTimes(1);
+    expect((method as any).probeProtocolV2NormalMode).not.toHaveBeenCalled();
   });
 
   test('rejects a finished target whose payload version conflicts with the plan', () => {
@@ -5916,7 +5961,7 @@ describe('Protocol V2 firmware update targets', () => {
       ])
     ).resolves.toBeUndefined();
 
-    expect(reconnectProtocolV2Device).toHaveBeenCalledTimes(1);
+    expect(reconnectProtocolV2Device).not.toHaveBeenCalled();
     expect(typedCall).toHaveBeenCalledWith(
       'DeviceFirmwareUpdateStatusGet',
       ['DeviceFirmwareUpdateStatus', 'Success'],
@@ -6015,7 +6060,7 @@ describe('Protocol V2 firmware update targets', () => {
         { target_id: 4, path: 'vol0:/application_p1.bin' },
       ])
     ).resolves.toBeUndefined();
-    expect(reconnectProtocolV2Device).toHaveBeenCalledTimes(2);
+    expect(reconnectProtocolV2Device).toHaveBeenCalledTimes(1);
     expect(typedCall).toHaveBeenCalledTimes(4);
   });
 
@@ -8426,7 +8471,7 @@ describe('Protocol V2 firmware update targets', () => {
     expect(writePayloads.map(payload => payload.file.data.byteLength)).toEqual([1960, 1]);
   });
 
-  test('starts install progress only after Stage and the empty Request are written', async () => {
+  test('keeps the confirmation UI active after Stage and the empty Request are written', async () => {
     const method = new FirmwareUpdateV4({
       id: 1,
       payload: {
@@ -8444,7 +8489,10 @@ describe('Protocol V2 firmware update targets', () => {
 
     (method as any).device = stubDevice({
       getCommands: () => ({ typedCall, call }),
+      createProtocolV2UiPhaseMetadata: jest.fn().mockReturnValue(undefined),
+      toMessageObject: jest.fn().mockReturnValue({ connectId: 'pro2' }),
     });
+    method.postMessage = jest.fn();
     method.postProgressMessage = jest.fn();
     method.postTipMessage = jest.fn();
 
@@ -8470,9 +8518,8 @@ describe('Protocol V2 firmware update targets', () => {
 
     resolveWrite?.({ type: 'WriteCompleted', message: {} });
     await startPromise;
-    expect(method.postTipMessage).toHaveBeenCalledWith('FirmwareUpdating');
-    expect(method.postProgressMessage).toHaveBeenCalledWith(0, 'installingFirmware');
-    expect(method.postTipMessage).toHaveBeenCalledTimes(1);
+    expect(method.postTipMessage).not.toHaveBeenCalled();
+    expect(method.postProgressMessage).not.toHaveBeenCalled();
   });
 
   test('sends an empty Protocol V2 firmware install request without waiting for its response', async () => {
@@ -8490,7 +8537,10 @@ describe('Protocol V2 firmware update targets', () => {
 
     (method as any).device = stubDevice({
       getCommands: () => ({ typedCall, call }),
+      createProtocolV2UiPhaseMetadata: jest.fn().mockReturnValue(undefined),
+      toMessageObject: jest.fn().mockReturnValue({ connectId: 'pro2' }),
     });
+    method.postMessage = jest.fn();
     method.postProgressMessage = jest.fn();
     method.postTipMessage = jest.fn();
 
@@ -8504,7 +8554,7 @@ describe('Protocol V2 firmware update targets', () => {
       {},
       { returnAfterWrite: true }
     );
-    expect(method.postTipMessage).toHaveBeenCalledWith('FirmwareUpdating');
+    expect(method.postTipMessage).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/api/CheckAllFirmwareRelease.ts
+++ b/packages/core/src/api/CheckAllFirmwareRelease.ts
@@ -1,4 +1,4 @@
-import { EDeviceType, HardwareError } from '@onekeyfe/hd-shared';
+import { HardwareError } from '@onekeyfe/hd-shared';
 import semver from 'semver';
 
 import { BaseMethod } from './BaseMethod';
@@ -411,9 +411,7 @@ export default class CheckAllFirmwareRelease extends BaseMethod {
       release,
       deviceType: state.identity.deviceType,
     });
-    const resourceDeviceType =
-      state.identity.deviceType === 'neo' ? EDeviceType.Neo : EDeviceType.Pro2;
-    const resourceSource = DataManager.getProtocolV2ResourceSource(resourceDeviceType);
+    const resourceSource = DataManager.getProtocolV2ResourceSource(release);
     const resourceStatus = 'unknown' as const;
     const detectedComponentTargets = validatedForceUpdateTargets.includes('firmware')
       ? plan.components.flatMap(component =>

--- a/packages/core/src/api/FirmwareUpdateV4.ts
+++ b/packages/core/src/api/FirmwareUpdateV4.ts
@@ -915,7 +915,8 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
       }
       if (wantsResources) {
         this.params.resourceArchiveBinary = await this.downloadRemoteProtocolV2ResourceArchive(
-          deviceFeatures
+          deviceFeatures,
+          firmwareType
         );
         resourceMemoryHost = await this.prepareProtocolV2LocalMemoryHost({
           features: deviceFeatures,
@@ -1880,7 +1881,10 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
     };
   }
 
-  private async downloadRemoteProtocolV2ResourceArchive(features: Features): Promise<ArrayBuffer> {
+  private async downloadRemoteProtocolV2ResourceArchive(
+    features: Features,
+    firmwareType: EFirmwareType
+  ): Promise<ArrayBuffer> {
     const deviceType = getDeviceType(features);
     if (deviceType !== EDeviceType.Pro2 && deviceType !== EDeviceType.Neo) {
       throw ERRORS.TypedError(
@@ -1888,7 +1892,8 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
         'Protocol V2 resource archive requires a Pro2 or Neo device'
       );
     }
-    const source = DataManager.getProtocolV2ResourceSource(deviceType);
+    const release = DataManager.getFirmwareLatestRelease(features, firmwareType);
+    const source = DataManager.getProtocolV2ResourceSource(release);
     const expectedSha256 = normalizeProtocolV2Hex(source?.archiveSha256);
     if (
       !source?.archiveUrl ||

--- a/packages/core/src/api/FirmwareUpdateV4.ts
+++ b/packages/core/src/api/FirmwareUpdateV4.ts
@@ -9,7 +9,7 @@ import {
 } from '@onekeyfe/hd-transport';
 import { sha256 } from '@noble/hashes/sha256';
 
-import { FirmwareUpdateTipMessage, UI_REQUEST } from '../events/ui-request';
+import { FirmwareUpdateTipMessage, UI_REQUEST, createUiMessage } from '../events/ui-request';
 import { validateParams } from './helpers/paramsValidator';
 import {
   LoggerNames,
@@ -71,6 +71,7 @@ import type {
   IProtocolV2FirmwareComponent,
   IProtocolV2ResourceManifestFile,
   IVersionArray,
+  KnownDevice,
 } from '../types';
 import type { FirmwareByteSource } from './firmware/FirmwareArtifactSource';
 import type {
@@ -2375,9 +2376,13 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
       target_id: item.targetId,
       path: item.path,
     }));
-    await this.protocolV2StartFirmwareUpdate({ targets });
-    await wait(PROTOCOL_V2_INSTALL_STATUS_INITIAL_DELAY);
-    await this.waitForProtocolV2FirmwareUpdateComplete(targets, true);
+    try {
+      await this.protocolV2StartFirmwareUpdate({ targets });
+      await wait(PROTOCOL_V2_INSTALL_STATUS_INITIAL_DELAY);
+      await this.waitForProtocolV2FirmwareUpdateComplete(targets, true);
+    } finally {
+      this.device?.clearCancelableAction();
+    }
   }
 
   private async protocolV2SourceUpdateProcess({
@@ -2637,7 +2642,9 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
     const expectedPaths = new Map(targets.map(target => [target.target_id, target.path]));
     const startTime = Date.now();
     let lastError: unknown;
-    let shouldReconnect = true;
+    // DeviceFirmwareUpdateRequest leaves the current loader link usable for status polling.
+    // Reconnecting here probes DeviceInfo, which loaders reject while installation is active.
+    let shouldReconnect = false;
     let deviceInfo: ProtocolV2DeviceInfo | undefined;
     let missingTargetStatusSince: number | undefined;
     let missingTargetStatusKey: string | undefined;
@@ -2684,16 +2691,15 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
             statusResponse.type === 'DeviceFirmwareUpdateStatus'
               ? ((statusResponse.message.records ?? []) as ProtocolV2FirmwareUpdateStatusTarget[])
               : [];
-          if (
-            statusTargets.some(target => {
-              const targetId = normalizeProtocolV2TargetId(target.target_id);
-              return (
-                targetId !== undefined &&
-                expectedTargetIds.has(targetId) &&
-                isProtocolV2TargetStatusInProgress(target.status)
-              );
-            })
-          ) {
+          const hasInProgressTarget = statusTargets.some(target => {
+            const targetId = normalizeProtocolV2TargetId(target.target_id);
+            return (
+              targetId !== undefined &&
+              expectedTargetIds.has(targetId) &&
+              isProtocolV2TargetStatusInProgress(target.status)
+            );
+          });
+          if (hasInProgressTarget) {
             currentInstallStatusObserved = true;
           }
           const hasMatchingTargetStatus = statusTargets.some(target => {
@@ -3138,9 +3144,20 @@ export default class FirmwareUpdateV4 extends FirmwareUpdateBaseMethod<FirmwareU
     this.protocolV2LastRuntimeProbeFeatures = undefined;
     const commands = this.device.getCommands();
     await commands.typedCall('DeviceFirmwareUpdateStage', 'Success', { targets });
+    this.device.setCancelableAction(() => commands.cancelDevice());
+    const interaction = this.device.createProtocolV2UiPhaseMetadata('button', 'start');
+    this.postMessage(
+      createUiMessage(UI_REQUEST.REQUEST_BUTTON, {
+        device: this.device.toMessageObject() as KnownDevice,
+        source: 'method-lifecycle',
+        reason: 'firmware-update',
+        completion: 'operation-completed',
+        deviceOnly: true,
+        operation: this.name,
+        ...(interaction ? { interaction } : {}),
+      })
+    );
     await commands.call('DeviceFirmwareUpdateRequest', {}, { returnAfterWrite: true });
-    this.postTipMessage(FirmwareUpdateTipMessage.FirmwareUpdating);
-    this.postProgressMessage(0, 'installingFirmware');
   }
 
   private async protocolV2Reboot(rebootType: DeviceRebootType) {

--- a/packages/core/src/api/firmware/FirmwarePreparedResourceArchive.ts
+++ b/packages/core/src/api/firmware/FirmwarePreparedResourceArchive.ts
@@ -26,7 +26,10 @@ export type VerifiedPreparedResourceEntry = {
 
 const resourceArchiveError = (
   message: string,
-  firmwareUpdateCode: 'FirmwareArtifactsNotPrepared' | 'FirmwareArtifactReceiptMismatch'
+  firmwareUpdateCode:
+    | 'FirmwareArtifactsNotPrepared'
+    | 'FirmwareArtifactReceiptMismatch'
+    | 'FirmwareArtifactReaderInvalid'
 ): never => {
   throw ERRORS.TypedError(HardwareErrorCode.RuntimeError, message, { firmwareUpdateCode });
 };
@@ -72,6 +75,12 @@ export const readVerifiedPreparedResourceArchive = async ({
       );
     }
     return [];
+  }
+  if (!reader) {
+    return resourceArchiveError(
+      'Firmware artifact reader is required for prepared resource archives',
+      'FirmwareArtifactReaderInvalid'
+    );
   }
   if (resourceArtifacts.length !== 1) {
     return resourceArchiveError(

--- a/packages/core/src/data-manager/DataManager.ts
+++ b/packages/core/src/data-manager/DataManager.ts
@@ -26,7 +26,7 @@ import type {
   Features,
   IDeviceBLEFirmwareStatus,
   IDeviceFirmwareStatus,
-  IProtocolV2Resources,
+  IFirmwareReleaseInfo,
   ITransportStatus,
   IVersionArray,
   RemoteConfigResponse,
@@ -407,6 +407,37 @@ export default class DataManager {
     return enrichedData;
   }
 
+  private static enrichProtocolV2FirmwareReleaseInfo(
+    deviceData: DeviceTypeMap[keyof DeviceTypeMap] | undefined,
+    onResourcesError: (error: Error) => void
+  ): NonNullable<DeviceTypeMap[keyof DeviceTypeMap]> {
+    const enrichedData = this.enrichFirmwareReleaseInfo(deviceData);
+    const releases = enrichedData['firmware-v1'];
+    if (!Array.isArray(releases)) {
+      return enrichedData;
+    }
+    const latestRelease = findLatestRelease(releases);
+
+    return {
+      ...enrichedData,
+      'firmware-v1': releases.map(release => {
+        const { resources: rawResources, ...releaseWithoutResources } = release;
+        try {
+          const resources = parseProtocolV2Resources(rawResources);
+          return {
+            ...releaseWithoutResources,
+            ...(resources ? { resources } : undefined),
+          };
+        } catch (error) {
+          if (release === latestRelease) {
+            onResourcesError(error instanceof Error ? error : new Error(String(error)));
+          }
+          return releaseWithoutResources;
+        }
+      }),
+    };
+  }
+
   static async load(settings: ConnectSettings): Promise<boolean> {
     this.settings = settings;
     this.protocolV2ResourcesConfigError = undefined;
@@ -471,32 +502,16 @@ export default class DataManager {
   }
 
   private static applyRemoteConfig(data: RemoteConfigResponse) {
-    let pro2Resources: IProtocolV2Resources | undefined;
-    let neoResources: IProtocolV2Resources | undefined;
-    try {
-      pro2Resources = parseProtocolV2Resources(
-        (data.pro2 as { resources?: unknown } | undefined)?.resources
-      );
-    } catch (error) {
+    const pro2Config = this.enrichProtocolV2FirmwareReleaseInfo(data.pro2, error => {
       // Firmware resource metadata is not required for base communication. If the
-      // remote config is temporarily incomplete, disable this resource update only.
-      this.protocolV2ResourcesConfigError =
-        error instanceof Error ? error : new Error(String(error));
-      Log.warn('[DataConfig] Ignoring invalid Pro2 resources config:', error);
-    }
-    try {
-      neoResources = parseProtocolV2Resources(
-        (data.neo as { resources?: unknown } | undefined)?.resources
-      );
-    } catch (error) {
-      this.protocolV2NeoResourcesConfigError =
-        error instanceof Error ? error : new Error(String(error));
-      Log.warn('[DataConfig] Ignoring invalid Neo resources config:', error);
-    }
-    const enrichedPro2Config = this.enrichFirmwareReleaseInfo(data.pro2);
-    const enrichedNeoConfig = this.enrichFirmwareReleaseInfo(data.neo);
-    const { resources: _unvalidatedResources, ...pro2Config } = enrichedPro2Config;
-    const { resources: _unvalidatedNeoResources, ...neoConfig } = enrichedNeoConfig;
+      // The selected release is incomplete, so disable its resource update only.
+      this.protocolV2ResourcesConfigError = error;
+      Log.warn('[DataConfig] Ignoring invalid Pro2 release resources config:', error);
+    });
+    const neoConfig = this.enrichProtocolV2FirmwareReleaseInfo(data.neo, error => {
+      this.protocolV2NeoResourcesConfigError = error;
+      Log.warn('[DataConfig] Ignoring invalid Neo release resources config:', error);
+    });
     this.deviceMap = {
       [EDeviceType.Classic]: this.enrichFirmwareReleaseInfo(data.classic),
       [EDeviceType.Classic1s]: this.enrichFirmwareReleaseInfo(data.classic1s),
@@ -504,14 +519,8 @@ export default class DataManager {
       [EDeviceType.Mini]: this.enrichFirmwareReleaseInfo(data.mini),
       [EDeviceType.Touch]: this.enrichFirmwareReleaseInfo(data.touch),
       [EDeviceType.Pro]: this.enrichFirmwareReleaseInfo(data.pro),
-      [EDeviceType.Pro2]: {
-        ...pro2Config,
-        ...(pro2Resources ? { resources: pro2Resources } : undefined),
-      },
-      [EDeviceType.Neo]: {
-        ...neoConfig,
-        ...(neoResources ? { resources: neoResources } : undefined),
-      },
+      [EDeviceType.Pro2]: pro2Config,
+      [EDeviceType.Neo]: neoConfig,
     };
     this.assets = {
       bridge: data.bridge,
@@ -589,10 +598,8 @@ export default class DataManager {
     this.lastCheckTimestamp = getTimeStamp();
   }
 
-  static getProtocolV2ResourceSource(
-    deviceType: EDeviceType.Pro2 | EDeviceType.Neo = EDeviceType.Pro2
-  ) {
-    return this.deviceMap[deviceType]?.resources?.source;
+  static getProtocolV2ResourceSource(release: IFirmwareReleaseInfo | undefined) {
+    return release?.resources?.source;
   }
 
   static getProtobufMessages(schema: ProtobufMessageSchema = 'v1CurrentSchema'): JSON {

--- a/packages/core/src/types/settings.ts
+++ b/packages/core/src/types/settings.ts
@@ -116,6 +116,8 @@ export type IFirmwareReleaseInfo = {
   upgradeType?: 'payload-package-set' | string;
   components?: Record<string, IProtocolV2FirmwareComponent>;
   installOrder?: string[];
+  /** Protocol V2 resources matched to this firmware release. */
+  resources?: IProtocolV2Resources;
   bootloaderChangelog?: {
     [k in ILocale]: string;
   };
@@ -152,8 +154,6 @@ type IDeviceReleaseInfo = {
   'firmware-v8'?: IFirmwareReleaseInfo[];
   'firmware-btc-v8'?: IFirmwareReleaseInfo[];
   ble?: IBLEFirmwareReleaseInfo[];
-  /** Independent Protocol V2 resource release configuration. */
-  resources?: IProtocolV2Resources;
 };
 
 export type DeviceTypeMap = {

--- a/packages/hd-transport-lowlevel/src/index.ts
+++ b/packages/hd-transport-lowlevel/src/index.ts
@@ -261,6 +261,19 @@ export default class LowlevelTransport {
     return this.callProtocolV1(uuid, name, data, options);
   }
 
+  async post(uuid: string, name: string, data: Record<string, unknown>) {
+    if (this.getProtocolType(uuid) === 'V2') {
+      await this.protocolV2Links.sendFlowControl(
+        uuid,
+        () => this.createProtocolV2Adapter(uuid),
+        name,
+        data
+      );
+      return;
+    }
+    await this.callProtocolV1(uuid, name, data);
+  }
+
   private async callProtocolV1(
     uuid: string,
     name: string,

--- a/packages/hd-transport-react-native/src/index.ts
+++ b/packages/hd-transport-react-native/src/index.ts
@@ -1253,6 +1253,15 @@ export default class ReactNativeBleTransport {
   }
 
   async post(session: string, name: string, data: Record<string, unknown>) {
+    if (this.getProtocolType(session) === 'V2') {
+      await this.protocolV2Links.sendFlowControl(
+        session,
+        () => this.createProtocolV2Adapter(session),
+        name,
+        data
+      );
+      return;
+    }
     await this.call(session, name, data);
   }
 

--- a/packages/hd-transport-usb/src/index.ts
+++ b/packages/hd-transport-usb/src/index.ts
@@ -277,6 +277,10 @@ export default class NodeUsbTransport extends ProtocolV2UsbTransportBase<string>
     if (!this.messages) {
       throw ERRORS.TypedError(HardwareErrorCode.TransportNotConfigured);
     }
+    if (this.deviceProtocol.get(path) === 'V2') {
+      await this.sendProtocolV2UsbFlowControl(path, name, data);
+      return;
+    }
     const encodeBuffers = ProtocolV1.encodeMessageChunks(this.messages, name, data);
     await this.sendAllChunksWithRetry(path, encodeBuffers);
   }

--- a/packages/hd-transport-web-device/__tests__/electron-ble-transport.test.ts
+++ b/packages/hd-transport-web-device/__tests__/electron-ble-transport.test.ts
@@ -294,6 +294,10 @@ describe('ElectronBleTransport protocol detection', () => {
         })
       );
       expect(transport.getProtocolType(device.id)).toBe('V2');
+      expect(nobleBle.connect).toHaveBeenCalledTimes(1);
+      expect(nobleBle.subscribe).toHaveBeenCalledTimes(1);
+      expect(nobleBle.unsubscribe).not.toHaveBeenCalled();
+      expect(nobleBle.disconnect).not.toHaveBeenCalled();
     } finally {
       await transport.release(device.id);
     }

--- a/packages/hd-transport-web-device/src/electron-ble-transport.ts
+++ b/packages/hd-transport-web-device/src/electron-ble-transport.ts
@@ -493,7 +493,8 @@ export default class ElectronBleTransport {
     for (let i = 0; i < probeOrder.length; i += 1) {
       const protocol = probeOrder[i];
       if (i > 0) {
-        // Reset subscriptions and buffers after a failed probe before trying another protocol.
+        // Keep the physical BLE link while switching probes. Reconnecting here can
+        // summon a second OS pairing prompt for a device that is still onboarding.
         await this.resetProbeStateAfterProtocolProbe(uuid, probeOrder[i - 1]);
       }
       const detected =
@@ -540,36 +541,13 @@ export default class ElectronBleTransport {
       this.runPromiseDeviceId = null;
     }
 
-    const notifyCleanup = this.notificationCleanups.get(uuid);
-    if (notifyCleanup) {
-      notifyCleanup();
-      this.notificationCleanups.delete(uuid);
+    // A timed-out V1 probe retires its renderer notification token so a late V1
+    // response cannot satisfy the V2 probe. Install a fresh listener without
+    // touching the native GATT subscription or physical connection.
+    if (!this.notificationCleanups.has(uuid)) {
+      const cleanup = this.createNotificationSubscription(uuid);
+      this.notificationCleanups.set(uuid, cleanup);
     }
-    this.notificationTokens.delete(uuid);
-
-    try {
-      await window.desktopApi?.nobleBle?.unsubscribe(uuid);
-    } catch (error) {
-      this.Log?.debug(`[Electron BLE] unsubscribe after Protocol ${protocol} probe failed:`, error);
-    }
-    try {
-      await window.desktopApi?.nobleBle?.disconnect(uuid);
-    } catch (error) {
-      this.Log?.debug(`[Electron BLE] disconnect after Protocol ${protocol} probe failed:`, error);
-    }
-    this.connectedDevices.delete(uuid);
-    try {
-      await window.desktopApi?.nobleBle?.connect(uuid);
-      this.connectedDevices.add(uuid);
-      await window.desktopApi?.nobleBle?.subscribe(uuid);
-      await this.refreshBlePacketCapacity(uuid);
-    } catch (error) {
-      this.Log?.debug(`[Electron BLE] reconnect after Protocol ${protocol} probe failed:`, error);
-      throw error;
-    }
-
-    const cleanup = this.createNotificationSubscription(uuid);
-    this.notificationCleanups.set(uuid, cleanup);
   }
 
   private async probeProtocolV1(uuid: string) {
@@ -809,6 +787,19 @@ export default class ElectronBleTransport {
       return this.callProtocolV2(uuid, name, data, options);
     }
     return this.callProtocolV1(uuid, name, data, options);
+  }
+
+  async post(uuid: string, name: string, data: Record<string, unknown>) {
+    if (this.deviceProtocol.get(uuid) === 'V2') {
+      await this.protocolV2Links.sendFlowControl(
+        uuid,
+        () => this.createProtocolV2Adapter(uuid),
+        name,
+        data
+      );
+      return;
+    }
+    await this.callProtocolV1(uuid, name, data);
   }
 
   private async callProtocolV1(

--- a/packages/hd-transport-web-device/src/webusb.ts
+++ b/packages/hd-transport-web-device/src/webusb.ts
@@ -481,6 +481,10 @@ export default class WebUsbTransport extends ProtocolV2UsbTransportBase<string> 
   }
 
   async post(session: string, name: string, data: Record<string, unknown>) {
+    if (this.deviceProtocol.get(session) === 'V2') {
+      await this.sendProtocolV2UsbFlowControl(session, name, data);
+      return;
+    }
     await this.call(session, name, data);
   }
 

--- a/packages/hd-transport/__tests__/protocol-v2-link-manager.test.js
+++ b/packages/hd-transport/__tests__/protocol-v2-link-manager.test.js
@@ -26,6 +26,9 @@ const protocolV2Messages = parseConfigure({
         message: { type: 'string', id: 1 },
       },
     },
+    Cancel: {
+      fields: {},
+    },
     Success: {
       fields: {
         message: { type: 'string', id: 1 },
@@ -35,6 +38,7 @@ const protocolV2Messages = parseConfigure({
       values: {
         MessageType_Ping: 60206,
         MessageType_Success: 60207,
+        MessageType_Cancel: 60004,
       },
     },
   },
@@ -311,6 +315,58 @@ describe('ProtocolV2LinkManager', () => {
       'write:device-a:2',
       'read:device-a:2',
     ]);
+  });
+
+  test('writes flow control while the active call is waiting for its response', async () => {
+    const sentSeqs = [];
+    let releaseRead;
+    let markReadStarted;
+    const readStarted = new Promise(resolve => {
+      markReadStarted = resolve;
+    });
+    const readBlocked = new Promise(resolve => {
+      releaseRead = resolve;
+    });
+    const success = ProtocolV2.encodeFrame(
+      schemas,
+      'Success',
+      { message: 'ok' },
+      { router: 1, packetSrc: 0, seq: 1 }
+    );
+    let requestSeq = 0;
+    const adapter = {
+      router: 1,
+      generation: 1,
+      prepareCall: jest.fn(),
+      writeFrame: jest.fn(frame => {
+        [, , , , , , requestSeq] = frame;
+        sentSeqs.push(requestSeq);
+        return Promise.resolve();
+      }),
+      readFrame: jest.fn(async () => {
+        markReadStarted();
+        await readBlocked;
+        return rewriteSeq(success, 1);
+      }),
+      reset: jest.fn(),
+    };
+    const manager = new ProtocolV2LinkManager({
+      getSchemas: () => schemas,
+      classifyError: () => 'recoverable',
+    });
+    const createAdapter = jest.fn(() => adapter);
+
+    const activeCall = manager.call('device-a', createAdapter, 'Ping', { message: 'pending' });
+    await readStarted;
+    await expect(manager.sendFlowControl('device-a', createAdapter, 'Cancel', {})).resolves.toEqual(
+      { type: 'WriteCompleted', message: {} }
+    );
+
+    expect(sentSeqs).toEqual([1, 2]);
+    expect(adapter.prepareCall).toHaveBeenCalledTimes(1);
+    expect(adapter.readFrame).toHaveBeenCalledTimes(1);
+    releaseRead();
+    await activeCall;
   });
 
   test('keeps a recoverable link after a call error', async () => {

--- a/packages/hd-transport/src/protocols/v2/link-manager.ts
+++ b/packages/hd-transport/src/protocols/v2/link-manager.ts
@@ -78,6 +78,17 @@ export class ProtocolV2LinkManager<Key> {
     return result;
   }
 
+  sendFlowControl(
+    key: Key,
+    createAdapter: () => ProtocolV2LinkAdapter,
+    name: string,
+    data: Record<string, unknown>
+  ): Promise<MessageFromOneKey> {
+    const generation = this.generations.get(key) ?? 0;
+    this.assertCallGeneration(key, generation);
+    return this.getOrCreateLink(key, createAdapter).session.sendFlowControl(name, data);
+  }
+
   async invalidateLink(key: Key, reason: string): Promise<void> {
     const generation = (this.generations.get(key) ?? 0) + 1;
     this.generations.set(key, generation);

--- a/packages/hd-transport/src/protocols/v2/session.ts
+++ b/packages/hd-transport/src/protocols/v2/session.ts
@@ -195,6 +195,10 @@ export class ProtocolV2Session {
   // in-flight calls on the same session would steal each other's responses.
   private pendingCall: Promise<unknown> = Promise.resolve();
 
+  // Flow-control messages may interrupt a call that is waiting for a device UI
+  // response, but their frames must never interleave with the active request write.
+  private pendingWrite: Promise<unknown> = Promise.resolve();
+
   private lastResponseSequence?: number;
 
   constructor(options: ProtocolV2SessionOptions) {
@@ -212,6 +216,47 @@ export class ProtocolV2Session {
     // Keep the chain alive even when a call fails; errors still propagate to
     // the per-call promise returned below.
     this.pendingCall = result.catch(() => undefined);
+    return result;
+  }
+
+  sendFlowControl(name: string, data: Record<string, unknown>): Promise<MessageFromOneKey> {
+    const {
+      schemas,
+      router,
+      packetSrc = PROTOCOL_V2_PACKET_SRC_COMMAND,
+      maxFrameBytes,
+      writeFrame,
+      generation = 0,
+    } = this.options;
+    const abortController = new AbortController();
+    const context: ProtocolV2CallContext = {
+      messageName: name,
+      highThroughput: false,
+      generation,
+      signal: abortController.signal,
+    };
+    const protoSeq = this.sequenceCursor.next();
+    const frame = ProtocolV2.encodeFrame(schemas, name, data, {
+      packetSrc,
+      router,
+      seq: protoSeq,
+    });
+
+    if (maxFrameBytes !== undefined && frame.length > maxFrameBytes) {
+      return Promise.reject(
+        new Error(`Protocol V2 frame too large for transport: ${frame.length} > ${maxFrameBytes}`)
+      );
+    }
+
+    return this.serializeWrite(() => writeFrame(frame, context)).then(() => ({
+      type: 'WriteCompleted',
+      message: {},
+    }));
+  }
+
+  private serializeWrite<T>(write: () => Promise<T>): Promise<T> {
+    const result = this.pendingWrite.then(write, write);
+    this.pendingWrite = result.catch(() => undefined);
     return result;
   }
 
@@ -267,7 +312,7 @@ export class ProtocolV2Session {
       }
 
       const writeStartedAt = Date.now();
-      await writeFrame(frame, baseCallContext);
+      await this.serializeWrite(() => writeFrame(frame, baseCallContext));
       try {
         callOptions.onWriteCompleted?.({
           elapsedMs: Math.max(Date.now() - writeStartedAt, 0),

--- a/packages/hd-transport/src/protocols/v2/usb-transport-base.ts
+++ b/packages/hd-transport/src/protocols/v2/usb-transport-base.ts
@@ -93,6 +93,19 @@ export abstract class ProtocolV2UsbTransportBase<Key> {
     );
   }
 
+  protected sendProtocolV2UsbFlowControl(
+    key: Key,
+    name: string,
+    data: Record<string, unknown>
+  ): Promise<MessageFromOneKey> {
+    return this.protocolV2UsbLinks.sendFlowControl(
+      key,
+      () => this.createProtocolV2UsbAdapter(key),
+      name,
+      data
+    );
+  }
+
   protected invalidateProtocolV2UsbLink(key: Key, reason: string): Promise<void> {
     return this.protocolV2UsbLinks.invalidateLink(key, reason);
   }


### PR DESCRIPTION
## Summary

- harden the Protocol V2 firmware installation flow across confirmation, reconnect, polling, and transport-session boundaries
- bind Pro2 and Neo resource archives to the selected `firmware-v1` release instead of reading a device-global resource entry
- validate release resource metadata and prepared resource archive readers before downloading or reading an approved ZIP artifact
- align USB, WebUSB, React Native, low-level, and Electron BLE transports with the reconnect-safe Protocol V2 session lifecycle
- document the relevant Protocol V2 device-management and firmware UI events

## Root cause

Protocol V2 installation spans multiple device modes and transport reconnects. The previous flow could lose confirmation or session state while the device rebooted, and polling could confuse stale status records with the current installation. Resource metadata was also modeled globally per device, so an archive was not guaranteed to match the firmware release being installed. Separately, the prepared-resource path allowed an optional reader to reach an API that requires a concrete reader.

## What changed

### Firmware installation and progress

- make the install request return after the write so the SDK can continue tracking the device through the expected disconnect
- distinguish current installation evidence from stale or unrelated status records
- preserve Protocol V2 session/link state across supported transport reconnects
- emit the confirmation and firmware progress events needed by clients to represent the installation lifecycle correctly

### Release-scoped resources

- parse and retain `resources` on each Pro2/Neo `firmware-v1` release
- resolve the resource archive from the selected firmware release and firmware type
- validate the archive URL, SHA-256 metadata, prepared artifact, and resource reader before installation
- ignore invalid optional resource metadata without breaking base device communication, while surfacing an explicit error when that resource is required

### Transport and documentation updates

- make Protocol V2 reconnect behavior consistent across USB, WebUSB, React Native, low-level, and Electron BLE transports
- add focused transport/session regression coverage
- update Protocol V1/V2, Pro2 device-management, and SDK event documentation

## Impact

Pro2 and Neo updates now install resources that belong to the exact firmware release being applied, maintain the expected Protocol V2 lifecycle through reconnects, and provide deterministic confirmation/progress behavior to App clients. Invalid or unavailable resource artifacts fail with a targeted error instead of producing an ambiguous runtime failure.

## Validation

- `yarn test firmware-prepared-resource-archive.test.ts --runInBand` — 6 tests passed
- added focused coverage for Protocol V2 resources, install polling, link management, sessions, and Electron BLE reconnect behavior
- focused ESLint checks passed
- `@onekeyfe/hd-core` build passed without the `FirmwarePreparedResourceArchive` TS2322 error
