### PR TITLE
fix(core): compress Pro2 BLE wallpapers

### DIFF
--- a/packages/core/__tests__/pro2Wallpaper.test.ts
+++ b/packages/core/__tests__/pro2Wallpaper.test.ts
@@ -1,5 +1,48 @@
 import { encodePro2Wallpaper } from '../src/utils/pro2Wallpaper';
 
+// The test decoder mirrors LZ4's bit-packed token and offset format.
+/* eslint-disable no-bitwise */
+
+function decodeLz4Block(data: Uint8Array, expectedLength: number) {
+  const output = new Uint8Array(expectedLength);
+  let inputOffset = 0;
+  let outputOffset = 0;
+
+  const readLength = (initialLength: number) => {
+    let length = initialLength;
+    if (length === 0x0f) {
+      let extension = 0xff;
+      while (extension === 0xff) {
+        extension = data[inputOffset];
+        inputOffset += 1;
+        length += extension;
+      }
+    }
+    return length;
+  };
+
+  while (inputOffset < data.byteLength) {
+    const token = data[inputOffset];
+    inputOffset += 1;
+    const literalLength = readLength(token >> 4);
+    output.set(data.subarray(inputOffset, inputOffset + literalLength), outputOffset);
+    inputOffset += literalLength;
+    outputOffset += literalLength;
+    if (inputOffset >= data.byteLength) break;
+
+    const matchOffset = data[inputOffset] | (data[inputOffset + 1] << 8);
+    inputOffset += 2;
+    const matchLength = readLength(token & 0x0f) + 4;
+    for (let index = 0; index < matchLength; index += 1) {
+      output[outputOffset] = output[outputOffset - matchOffset];
+      outputOffset += 1;
+    }
+  }
+
+  expect(outputOffset).toBe(expectedLength);
+  return output;
+}
+
 describe('encodePro2Wallpaper', () => {
   test('encodes opaque pixels as aligned LVGL v9 RGB565 data', () => {
     const result = encodePro2Wallpaper({
@@ -26,6 +69,29 @@ describe('encodePro2Wallpaper', () => {
     expect(result.data[1]).toBe(0x14);
     expect(Array.from(result.data.slice(8, 10))).toEqual([4, 0]);
     expect(Array.from(result.data.slice(12))).toEqual([0x1f, 0x00, 0xff, 0xff, 128, 255]);
+  });
+
+  test('encodes an I8 palette and pixel indices as an LVGL LZ4 block', () => {
+    const result = encodePro2Wallpaper({
+      width: 2,
+      height: 1,
+      rgba: new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255]),
+      encoding: 'i8-lz4',
+    });
+
+    expect(result.colorFormat).toBe('I8');
+    expect(Array.from(result.data.slice(0, 12))).toEqual([
+      0x19, 0x0a, 0x08, 0, 2, 0, 1, 0, 2, 0, 0, 0,
+    ]);
+    const view = new DataView(result.data.buffer, result.data.byteOffset, result.data.byteLength);
+    expect(view.getUint32(12, true)).toBe(2);
+    expect(view.getUint32(16, true)).toBe(result.data.byteLength - 24);
+    expect(view.getUint32(20, true)).toBe(1026);
+
+    const rawData = decodeLz4Block(result.data.slice(24), 1026);
+    expect(Array.from(rawData.slice(210 * 4, 210 * 4 + 4))).toEqual([0, 0, 255, 255]);
+    expect(Array.from(rawData.slice(36 * 4, 36 * 4 + 4))).toEqual([0, 255, 0, 255]);
+    expect(Array.from(rawData.slice(-2))).toEqual([210, 36]);
   });
 
   test('rejects invalid dimensions and RGBA byte length', () => {

--- a/packages/core/__tests__/protocol-v2.test.ts
+++ b/packages/core/__tests__/protocol-v2.test.ts
@@ -194,7 +194,13 @@ describe('DeviceUploadWallpaper', () => {
       refreshProtocolV2SettingsAfterMutation: jest.fn().mockResolvedValue({}),
     });
 
-  test('encodes, uploads and applies a Pro2 wallpaper', async () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('uses I8 with LZ4 when uploading a Pro2 wallpaper over BLE', async () => {
+    jest.spyOn(DataManager, 'getSettings').mockReturnValue('lowlevel');
+    jest.spyOn(DataManager, 'isBleConnect').mockReturnValue(true);
     const typedCall = jest.fn().mockImplementation((request, _response, params) => {
       if (request === 'FilesystemDirMake') return { message: { message: 'directory ready' } };
       if (request === 'FilesystemFileWrite') {
@@ -237,7 +243,7 @@ describe('DeviceUploadWallpaper', () => {
     });
     expect(device.refreshProtocolV2SettingsAfterMutation).toHaveBeenCalledTimes(1);
     expect(typedCall.mock.calls.some(call => call[0] === 'SetWallpaper')).toBe(false);
-    expect(result).toMatchObject({ colorFormat: 'RGB565', message: 'wallpaper applied' });
+    expect(result).toMatchObject({ colorFormat: 'I8', message: 'wallpaper applied' });
     const fileWriteCallCount = typedCall.mock.calls.filter(
       call => call[0] === 'FilesystemFileWrite'
     ).length;
@@ -275,6 +281,8 @@ describe('DeviceUploadWallpaper', () => {
   });
 
   test('returns success when wallpaper read-back fails after apply', async () => {
+    jest.spyOn(DataManager, 'getSettings').mockReturnValue('desktop-webusb');
+    jest.spyOn(DataManager, 'isBleConnect').mockReturnValue(false);
     const typedCall = jest.fn().mockImplementation((request, _response, params) => {
       if (request === 'FilesystemDirMake') return { message: {} };
       if (request === 'FilesystemFileWrite') {
@@ -300,7 +308,10 @@ describe('DeviceUploadWallpaper', () => {
     (method as any).device = device;
     method.init();
 
-    await expect(method.run()).resolves.toMatchObject({ message: 'wallpaper applied' });
+    await expect(method.run()).resolves.toMatchObject({
+      colorFormat: 'RGB565',
+      message: 'wallpaper applied',
+    });
     expect(device.refreshProtocolV2SettingsAfterMutation).toHaveBeenCalledTimes(1);
   });
 
@@ -315,6 +326,19 @@ describe('DeviceUploadWallpaper', () => {
     });
 
     expect(() => method.init()).toThrow('fileName');
+  });
+
+  test('rejects unsupported wallpaper encodings before device communication', () => {
+    const method = new DeviceUploadWallpaper({
+      id: 1,
+      payload: {
+        method: 'deviceUploadWallpaper',
+        jpegBase64: createJpegBase64(604, 1024),
+        encoding: 'gzip',
+      } as any,
+    });
+
+    expect(() => method.init()).toThrow('encoding');
   });
 
   test('rejects unsupported firmware before creating or writing files', async () => {

--- a/packages/core/src/api/protocol-v2/DeviceUploadWallpaper.ts
+++ b/packages/core/src/api/protocol-v2/DeviceUploadWallpaper.ts
@@ -7,6 +7,7 @@ import { BaseMethod } from '../BaseMethod';
 import { decodeJpegBase64ToRgba } from '../helpers/base64Data';
 import { invalidParameter } from '../helpers/filesystemValidation';
 import { writeProtocolV2File } from '../helpers/protocolV2FileWrite';
+import { DataManager } from '../../data-manager';
 import { UI_REQUEST, createUiMessage } from '../../events/ui-request';
 import { supportsProtocolV2Message } from '../../protocols/protocol-v2/features';
 import { LoggerNames, getLogger } from '../../utils';
@@ -14,6 +15,7 @@ import {
   PRO2_WALLPAPER_HEIGHT,
   PRO2_WALLPAPER_WIDTH,
   type Pro2WallpaperColorFormat,
+  type Pro2WallpaperEncoding,
   encodePro2Wallpaper,
 } from '../../utils/pro2Wallpaper';
 
@@ -21,6 +23,7 @@ export type DeviceUploadWallpaperParams = {
   jpegBase64: string;
   fileName?: string;
   chunkSize?: number;
+  encoding?: Pro2WallpaperEncoding;
 };
 
 export type DeviceUploadWallpaperResponse = {
@@ -61,10 +64,16 @@ export default class DeviceUploadWallpaper extends BaseMethod<DeviceUploadWallpa
   private path = '';
 
   init() {
-    const { jpegBase64, fileName, chunkSize } = this.payload;
+    const { jpegBase64, fileName, chunkSize, encoding } = this.payload;
     if (chunkSize !== undefined && (!Number.isInteger(chunkSize) || chunkSize <= 0)) {
       throw invalidParameter('Parameter [chunkSize] must be a positive integer.');
     }
+    if (encoding !== undefined && encoding !== 'rgb565' && encoding !== 'i8-lz4') {
+      throw invalidParameter('Parameter [encoding] must be either rgb565 or i8-lz4.');
+    }
+    const env = DataManager.getSettings('env');
+    const resolvedEncoding: Pro2WallpaperEncoding =
+      encoding ?? (env && DataManager.isBleConnect(env) ? 'i8-lz4' : 'rgb565');
 
     const decoded = decodeJpegBase64ToRgba({
       jpegBase64,
@@ -76,9 +85,10 @@ export default class DeviceUploadWallpaper extends BaseMethod<DeviceUploadWallpa
       width: PRO2_WALLPAPER_WIDTH,
       height: PRO2_WALLPAPER_HEIGHT,
       rgba: decoded.data,
+      encoding: resolvedEncoding,
     });
     this.path = `${WALLPAPER_DIRECTORY}/${normalizeFileName(fileName, this.encoded.data)}`;
-    this.params = { jpegBase64, fileName, chunkSize };
+    this.params = { jpegBase64, fileName, chunkSize, encoding: resolvedEncoding };
     this.unlockPolicy = 'unlock-before-run';
     // File writes and wallpaper apply require an unlocked device. Either PIN
     // may authorize this device-management action.

--- a/packages/core/src/utils/pro2Wallpaper.ts
+++ b/packages/core/src/utils/pro2Wallpaper.ts
@@ -6,12 +6,26 @@ import { ERRORS, HardwareErrorCode } from '@onekeyfe/hd-shared';
 export const PRO2_WALLPAPER_WIDTH = 604;
 export const PRO2_WALLPAPER_HEIGHT = 1024;
 
-export type Pro2WallpaperColorFormat = 'RGB565' | 'RGB565A8';
+export type Pro2WallpaperColorFormat = 'RGB565' | 'RGB565A8' | 'I8';
+
+export type Pro2WallpaperEncoding = 'rgb565' | 'i8-lz4';
 
 export type Pro2ImageAlphaMode = 'preserve' | 'black-background';
 
 const COLOR_FORMAT_RGB565 = 0x12;
 const COLOR_FORMAT_RGB565A8 = 0x14;
+const COLOR_FORMAT_I8 = 0x0a;
+const IMAGE_FLAG_COMPRESSED = 0x0008;
+const IMAGE_COMPRESSION_LZ4 = 0x00000002;
+const I8_PALETTE_SIZE = 256 * 4;
+const I8_RED_LEVELS = 6;
+const I8_GREEN_LEVELS = 7;
+const I8_BLUE_LEVELS = 6;
+const LZ4_MIN_MATCH = 4;
+const LZ4_LAST_LITERALS = 5;
+const LZ4_MATCH_FIND_LIMIT = 12;
+const LZ4_HASH_BITS = 16;
+const LZ4_HASH_MULTIPLIER = -1640531535;
 
 const RED_THRESHOLD = [
   1, 7, 3, 5, 0, 8, 2, 6, 7, 1, 5, 3, 8, 0, 6, 2, 3, 5, 0, 8, 2, 6, 1, 7, 5, 3, 8, 0, 6, 2, 7, 1, 0,
@@ -36,6 +50,184 @@ function asBytes(rgba: Uint8Array | ArrayBuffer): Uint8Array {
 
 function align(value: number, boundary: number): number {
   return Math.ceil(value / boundary) * boundary;
+}
+
+function writeLz4Length(output: Uint8Array, offset: number, length: number) {
+  let cursor = offset;
+  let remaining = length;
+  while (remaining >= 0xff) {
+    output[cursor] = 0xff;
+    cursor += 1;
+    remaining -= 0xff;
+  }
+  output[cursor] = remaining;
+  return cursor + 1;
+}
+
+function readUint32LittleEndian(data: Uint8Array, offset: number) {
+  return (
+    data[offset] | (data[offset + 1] << 8) | (data[offset + 2] << 16) | (data[offset + 3] << 24)
+  );
+}
+
+function getLz4Hash(sequence: number) {
+  return (Math.imul(sequence, LZ4_HASH_MULTIPLIER) >>> (32 - LZ4_HASH_BITS)) & 0xffff;
+}
+
+function compressLz4Block(input: Uint8Array) {
+  const output = new Uint8Array(input.byteLength + Math.floor(input.byteLength / 0xff) + 16);
+  const hashTable = new Int32Array(1 << LZ4_HASH_BITS);
+  hashTable.fill(-1);
+
+  let anchor = 0;
+  let inputOffset = 0;
+  let outputOffset = 0;
+  const matchFindEnd = input.byteLength - LZ4_MATCH_FIND_LIMIT;
+  const matchCopyEnd = input.byteLength - LZ4_LAST_LITERALS;
+
+  while (inputOffset <= matchFindEnd) {
+    const sequence = readUint32LittleEndian(input, inputOffset);
+    const hash = getLz4Hash(sequence);
+    const reference = hashTable[hash];
+    hashTable[hash] = inputOffset;
+
+    const matchOffset = inputOffset - reference;
+    const hasMatch =
+      reference >= 0 &&
+      matchOffset <= 0xffff &&
+      readUint32LittleEndian(input, reference) === sequence;
+    if (hasMatch) {
+      let matchLength = LZ4_MIN_MATCH;
+      while (
+        inputOffset + matchLength < matchCopyEnd &&
+        input[reference + matchLength] === input[inputOffset + matchLength]
+      ) {
+        matchLength += 1;
+      }
+
+      const literalLength = inputOffset - anchor;
+      const encodedMatchLength = matchLength - LZ4_MIN_MATCH;
+      const tokenOffset = outputOffset;
+      outputOffset += 1;
+      output[tokenOffset] =
+        (Math.min(literalLength, 0x0f) << 4) | Math.min(encodedMatchLength, 0x0f);
+
+      if (literalLength >= 0x0f) {
+        outputOffset = writeLz4Length(output, outputOffset, literalLength - 0x0f);
+      }
+      output.set(input.subarray(anchor, inputOffset), outputOffset);
+      outputOffset += literalLength;
+
+      output[outputOffset] = matchOffset & 0xff;
+      output[outputOffset + 1] = matchOffset >> 8;
+      outputOffset += 2;
+      if (encodedMatchLength >= 0x0f) {
+        outputOffset = writeLz4Length(output, outputOffset, encodedMatchLength - 0x0f);
+      }
+
+      const matchStart = inputOffset;
+      inputOffset += matchLength;
+      anchor = inputOffset;
+      for (
+        let cursor = Math.max(matchStart + 1, inputOffset - 2);
+        cursor < inputOffset;
+        cursor += 1
+      ) {
+        if (cursor <= matchFindEnd) {
+          hashTable[getLz4Hash(readUint32LittleEndian(input, cursor))] = cursor;
+        }
+      }
+    } else {
+      inputOffset += 1;
+    }
+  }
+
+  const literalLength = input.byteLength - anchor;
+  const tokenOffset = outputOffset;
+  outputOffset += 1;
+  output[tokenOffset] = Math.min(literalLength, 0x0f) << 4;
+  if (literalLength >= 0x0f) {
+    outputOffset = writeLz4Length(output, outputOffset, literalLength - 0x0f);
+  }
+  output.set(input.subarray(anchor), outputOffset);
+  outputOffset += literalLength;
+
+  return output.slice(0, outputOffset);
+}
+
+function quantizeChannel(value: number, levels: number) {
+  return Math.floor((value * (levels - 1) + 0x7f) / 0xff);
+}
+
+function expandChannel(value: number, levels: number) {
+  return Math.floor((value * 0xff + Math.floor((levels - 1) / 2)) / (levels - 1));
+}
+
+function encodePro2I8Lz4(options: {
+  width: number;
+  height: number;
+  rgba: Uint8Array | ArrayBuffer;
+}): { data: Uint8Array; colorFormat: Pro2WallpaperColorFormat } {
+  const { width, height } = options;
+  if (!Number.isInteger(width) || width <= 0 || width > 0xffff) {
+    throw invalidParameter('Wallpaper width must be an integer between 1 and 65535.');
+  }
+  if (!Number.isInteger(height) || height <= 0 || height > 0xffff) {
+    throw invalidParameter('Wallpaper height must be an integer between 1 and 65535.');
+  }
+  const rgba = asBytes(options.rgba);
+  const expectedLength = width * height * 4;
+  if (rgba.byteLength !== expectedLength) {
+    throw invalidParameter(
+      `Wallpaper RGBA data length must be ${expectedLength} bytes, received ${rgba.byteLength}.`
+    );
+  }
+  const stride = width;
+  const rawData = new Uint8Array(I8_PALETTE_SIZE + stride * height);
+
+  for (let red = 0; red < I8_RED_LEVELS; red += 1) {
+    for (let green = 0; green < I8_GREEN_LEVELS; green += 1) {
+      for (let blue = 0; blue < I8_BLUE_LEVELS; blue += 1) {
+        const paletteIndex = (red * I8_GREEN_LEVELS + green) * I8_BLUE_LEVELS + blue;
+        const paletteOffset = paletteIndex * 4;
+        // LVGL stores its ARGB8888 palette as B, G, R, A bytes on little-endian devices.
+        rawData[paletteOffset] = expandChannel(blue, I8_BLUE_LEVELS);
+        rawData[paletteOffset + 1] = expandChannel(green, I8_GREEN_LEVELS);
+        rawData[paletteOffset + 2] = expandChannel(red, I8_RED_LEVELS);
+        rawData[paletteOffset + 3] = 0xff;
+      }
+    }
+  }
+
+  for (let pixel = 0; pixel < width * height; pixel += 1) {
+    const sourceOffset = pixel * 4;
+    const alpha = rgba[sourceOffset + 3];
+    const red = Math.round((rgba[sourceOffset] * alpha) / 0xff);
+    const green = Math.round((rgba[sourceOffset + 1] * alpha) / 0xff);
+    const blue = Math.round((rgba[sourceOffset + 2] * alpha) / 0xff);
+    const paletteIndex =
+      (quantizeChannel(red, I8_RED_LEVELS) * I8_GREEN_LEVELS +
+        quantizeChannel(green, I8_GREEN_LEVELS)) *
+        I8_BLUE_LEVELS +
+      quantizeChannel(blue, I8_BLUE_LEVELS);
+    rawData[I8_PALETTE_SIZE + pixel] = paletteIndex;
+  }
+
+  const compressed = compressLz4Block(rawData);
+  const data = new Uint8Array(24 + compressed.byteLength);
+  const view = new DataView(data.buffer);
+  data[0] = 0x19;
+  data[1] = COLOR_FORMAT_I8;
+  view.setUint16(2, IMAGE_FLAG_COMPRESSED, true);
+  view.setUint16(4, width, true);
+  view.setUint16(6, height, true);
+  view.setUint16(8, stride, true);
+  view.setUint16(10, 0, true);
+  view.setUint32(12, IMAGE_COMPRESSION_LZ4, true);
+  view.setUint32(16, compressed.byteLength, true);
+  view.setUint32(20, rawData.byteLength, true);
+  data.set(compressed, 24);
+  return { data, colorFormat: 'I8' };
 }
 
 export function encodePro2Image(options: {
@@ -125,6 +317,10 @@ export function encodePro2Wallpaper(options: {
   width: number;
   height: number;
   rgba: Uint8Array | ArrayBuffer;
+  encoding?: Pro2WallpaperEncoding;
 }): { data: Uint8Array; colorFormat: Pro2WallpaperColorFormat } {
+  if (options.encoding === 'i8-lz4') {
+    return encodePro2I8Lz4(options);
+  }
   return encodePro2Image(options);
 }


### PR DESCRIPTION
## Summary

- encode Pro2 BLE wallpapers as an LVGL I8 image with raw LZ4 compression
- select I8 + LZ4 automatically for BLE transports while preserving RGB565 for USB and Bridge
- keep an explicit encoding override for focused testing and compatibility

## Results

- reduces the three provided 604x1024 wallpaper payloads from 1,237,004 bytes to approximately 200-260 KB
- reduces estimated BLE transfer time from approximately 80 seconds to 13-17 seconds at the observed 15 KiB/s
- leaves firmware and App source unchanged

## Validation

- yarn agent:check --profile commit
- 277 focused SDK tests passed, 4 skipped
- SDK LZ4 output independently decompressed with the firmware repository Python LZ4 implementation
- App Pro2 settings test passed against the locally built SDK