### PR TITLE
fix: align Protocol V2 Cardano derivation with origin/dev

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "submodules/firmware-pro2"]
 	path = submodules/firmware-pro2
 	url = https://github.com/OneKeyHQ/firmware-pro2.git
-	branch = main
+	branch = dev

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -132,13 +132,16 @@ Transport 连接、帧序号、设备端 `session_id` 和钱包标识是四类�
   路径必须抑制底层重复 Event。`protocolV2UiMode='none'` 只抑制普通方法交互提示，
   不得抑制已实际触发的设备端 PIN 提示。
 - `DeviceSessionGet` 的 `session_id` 和 `btc_test_address` 均可选：`session_id` 表示尝试恢复目标
-  Session，`btc_test_address` 表示预期钱包身份；两者都缺省时读取当前 Session。Get 不再携带
-  `seed_domains`。所有调用都必须返回固件最终实际的完整 `DeviceSession`，正常状态错配不返回
-  `InvalidSession`。
+  Session，`btc_test_address` 表示预期钱包身份；两者都缺省时读取当前 Session。Get 同时携带
+  `seed_domains`：非 Cardano 调用发送 `[Standard]`，Cardano 调用发送 `[Standard, Cardano]`。
+  Attach PIN 与 passphrase 关闭的钱包可在 Get 上补 GEN Cardano；隐藏 passphrase 钱包仍只能通过
+  `DeviceSessionAskPassphrase` 生成 Cardano。所有调用都必须返回固件最终实际的完整
+  `DeviceSession`，正常状态错配不返回 `InvalidSession`。
 - Pro2 的 `DeviceSessionAskPassphrase` 必须显式携带输入来源：Host 输入发送
   `{ on_device: false, passphrase, seed_domains }`，设备输入发送 `{ on_device: true, seed_domains }`。
   `seed_domains` 在开钱包和非 Cardano 调用上发送 `[Standard]`；Cardano 调用发送
-  `[Standard, Cardano]`。不得发送空列表。`DeviceSessionGet` 不携带 `seed_domains`。
+  `[Standard, Cardano]`。不得发送空列表。`DeviceSessionGet` 使用同一套 `seed_domains`
+  在当前 SE 钱包上补齐 Cardano（仅 Attach PIN / passphrase 关闭）。
   不得省略 `on_device`，也不得同时发送设备输入标记和
   Host Passphrase。Attach-to-PIN 继续使用 `DeviceSessionAskPin(AttachToPin)`。
 - `DeviceSessionAskPin` 的 PIN 类型由目标钱包意图决定，而不是由调用前的当前上下文决定：
@@ -150,8 +153,8 @@ Transport 连接、帧序号、设备端 `session_id` 和钱包标识是四类�
   `DeviceSessionAskPin(Main)`，否则直接调用钱包 Session 协议。调用期间返回的结构化
   `DeviceLocked` 必须原样向上抛出，避免重复有副作用的请求。Attach-to-PIN 分支仍只执行
   `DeviceSessionAskPin(AttachToPin)`。
-- 空参数 `DeviceSessionGet()` 只读取固件当前钱包 Session，不是标准钱包选择命令。标准钱包首次打开时
-  执行 `AskPin(Main) -> Get()`；缓存恢复结果不匹配时执行一次相同流程重建。
+- `DeviceSessionGet({ seed_domains })` 只读取固件当前钱包 Session，不是标准钱包选择命令。标准钱包首次打开时
+  执行 `AskPin(Main) -> Get(seed_domains)`；缓存恢复结果不匹配时执行一次相同流程重建。
   隐藏钱包缓存恢复结果不匹配时执行一次统一钱包选择，再执行 Ask 与 `Get()`。恢复不得删除同设备
   的其他钱包 Session。
 - V2 的 `DeviceSessionGet` 成功响应必须同时包含非空 `session_id` 和

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -138,9 +138,10 @@ Transport 连接、帧序号、设备端 `session_id` 和钱包标识是四类�
 - Pro2 的 `DeviceSessionAskPassphrase` 必须显式携带输入来源：Host 输入发送
   `{ on_device: false, passphrase, seed_domains }`，设备输入发送 `{ on_device: true, seed_domains }`。
   `seed_domains` 在开钱包和非 Cardano 调用上发送 `[Standard]`；Cardano 调用发送
-  `[Standard, Cardano]`。不得发送空列表。Attach PIN 会话不得发送 `AskPassphrase`（包括空
-  Host passphrase）：origin/dev 会 `SESSION_NEW` 并清掉 attach-pin 标记。不得省略 `on_device`，
-  也不得同时发送设备输入标记和 Host Passphrase。Attach-to-PIN 解锁仍使用
+  `[Standard, Cardano]`。不得发送空列表。Attach PIN 补 Cardano 时发送空 Host
+  passphrase：`AskPassphrase({ passphrase: '', on_device: false, seed_domains: [Standard, Cardano] })`，
+  不弹出 passphrase UI。固件会清掉 attach-pin 标记，SDK 仍把当前会话视为 Attach PIN。
+  不得省略 `on_device`，也不得同时发送设备输入标记和 Host Passphrase。Attach-to-PIN 解锁仍使用
   `DeviceSessionAskPin(AttachToPin)`。
 - `DeviceSessionAskPin` 的 PIN 类型由目标钱包意图决定，而不是由调用前的当前上下文决定：
   `Main` 用于选择标准钱包，也用于从 Attach-to-PIN 隐藏钱包上下文切回标准钱包；

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -132,18 +132,16 @@ Transport 连接、帧序号、设备端 `session_id` 和钱包标识是四类�
   路径必须抑制底层重复 Event。`protocolV2UiMode='none'` 只抑制普通方法交互提示，
   不得抑制已实际触发的设备端 PIN 提示。
 - `DeviceSessionGet` 的 `session_id` 和 `btc_test_address` 均可选：`session_id` 表示尝试恢复目标
-  Session，`btc_test_address` 表示预期钱包身份；两者都缺省时读取当前 Session。Get 同时携带
-  `seed_domains`：非 Cardano 调用发送 `[Standard]`，Cardano 调用发送 `[Standard, Cardano]`。
-  Attach PIN 与 passphrase 关闭的钱包可在 Get 上补 GEN Cardano；隐藏 passphrase 钱包仍只能通过
-  `DeviceSessionAskPassphrase` 生成 Cardano。所有调用都必须返回固件最终实际的完整
+  Session，`btc_test_address` 表示预期钱包身份；两者都缺省时读取当前 Session。Get 不携带
+  `seed_domains`。派生发生在 `DeviceSessionAskPassphrase`。所有调用都必须返回固件最终实际的完整
   `DeviceSession`，正常状态错配不返回 `InvalidSession`。
 - Pro2 的 `DeviceSessionAskPassphrase` 必须显式携带输入来源：Host 输入发送
   `{ on_device: false, passphrase, seed_domains }`，设备输入发送 `{ on_device: true, seed_domains }`。
   `seed_domains` 在开钱包和非 Cardano 调用上发送 `[Standard]`；Cardano 调用发送
-  `[Standard, Cardano]`。不得发送空列表。`DeviceSessionGet` 使用同一套 `seed_domains`
-  在当前 SE 钱包上补齐 Cardano（仅 Attach PIN / passphrase 关闭）。
-  不得省略 `on_device`，也不得同时发送设备输入标记和
-  Host Passphrase。Attach-to-PIN 继续使用 `DeviceSessionAskPin(AttachToPin)`。
+  `[Standard, Cardano]`。不得发送空列表。Attach PIN 补 Cardano 时发送空 Host
+  passphrase：`AskPassphrase({ passphrase: '', on_device: false, seed_domains: [Standard, Cardano] })`，
+  不弹出 passphrase UI。不得省略 `on_device`，也不得同时发送设备输入标记和
+  Host Passphrase。Attach-to-PIN 解锁仍使用 `DeviceSessionAskPin(AttachToPin)`。
 - `DeviceSessionAskPin` 的 PIN 类型由目标钱包意图决定，而不是由调用前的当前上下文决定：
   `Main` 用于选择标准钱包，也用于从 Attach-to-PIN 隐藏钱包上下文切回标准钱包；
   `AttachToPin` 只用于选择该 Attach PIN 绑定的隐藏钱包。`unlockedAttachPin=true` 是当前上下文状态，
@@ -153,8 +151,8 @@ Transport 连接、帧序号、设备端 `session_id` 和钱包标识是四类�
   `DeviceSessionAskPin(Main)`，否则直接调用钱包 Session 协议。调用期间返回的结构化
   `DeviceLocked` 必须原样向上抛出，避免重复有副作用的请求。Attach-to-PIN 分支仍只执行
   `DeviceSessionAskPin(AttachToPin)`。
-- `DeviceSessionGet({ seed_domains })` 只读取固件当前钱包 Session，不是标准钱包选择命令。标准钱包首次打开时
-  执行 `AskPin(Main) -> Get(seed_domains)`；缓存恢复结果不匹配时执行一次相同流程重建。
+- 空参数 `DeviceSessionGet()` 只读取固件当前钱包 Session，不是标准钱包选择命令。标准钱包首次打开时
+  执行 `AskPin(Main) -> AskPassphrase('', seed_domains) -> Get()`；缓存恢复结果不匹配时执行一次相同流程重建。
   隐藏钱包缓存恢复结果不匹配时执行一次统一钱包选择，再执行 Ask 与 `Get()`。恢复不得删除同设备
   的其他钱包 Session。
 - V2 的 `DeviceSessionGet` 成功响应必须同时包含非空 `session_id` 和

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -138,10 +138,10 @@ Transport 连接、帧序号、设备端 `session_id` 和钱包标识是四类�
 - Pro2 的 `DeviceSessionAskPassphrase` 必须显式携带输入来源：Host 输入发送
   `{ on_device: false, passphrase, seed_domains }`，设备输入发送 `{ on_device: true, seed_domains }`。
   `seed_domains` 在开钱包和非 Cardano 调用上发送 `[Standard]`；Cardano 调用发送
-  `[Standard, Cardano]`。不得发送空列表。Attach PIN 补 Cardano 时发送空 Host
-  passphrase：`AskPassphrase({ passphrase: '', on_device: false, seed_domains: [Standard, Cardano] })`，
-  不弹出 passphrase UI。不得省略 `on_device`，也不得同时发送设备输入标记和
-  Host Passphrase。Attach-to-PIN 解锁仍使用 `DeviceSessionAskPin(AttachToPin)`。
+  `[Standard, Cardano]`。不得发送空列表。Attach PIN 会话不得发送 `AskPassphrase`（包括空
+  Host passphrase）：origin/dev 会 `SESSION_NEW` 并清掉 attach-pin 标记。不得省略 `on_device`，
+  也不得同时发送设备输入标记和 Host Passphrase。Attach-to-PIN 解锁仍使用
+  `DeviceSessionAskPin(AttachToPin)`。
 - `DeviceSessionAskPin` 的 PIN 类型由目标钱包意图决定，而不是由调用前的当前上下文决定：
   `Main` 用于选择标准钱包，也用于从 Attach-to-PIN 隐藏钱包上下文切回标准钱包；
   `AttachToPin` 只用于选择该 Attach PIN 绑定的隐藏钱包。`unlockedAttachPin=true` 是当前上下文状态，

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -137,9 +137,9 @@ Transport 连接、帧序号、设备端 `session_id` 和钱包标识是四类�
   `InvalidSession`。
 - Pro2 的 `DeviceSessionAskPassphrase` 必须显式携带输入来源：Host 输入发送
   `{ on_device: false, passphrase, seed_domains }`，设备输入发送 `{ on_device: true, seed_domains }`。
-  `seed_domains` 仅在当前调用明确需要 Cardano 时携带 `[Standard, Cardano]`；开钱包以及
-  `deriveCardano !== true` 时发送空列表，保留固件“派生全部支持域”的默认行为。不得把 V1 的
-  `deriveCardano: false` 映射成 `[Standard]`。不得省略 `on_device`，也不得同时发送设备输入标记和
+  `seed_domains` 在开钱包和非 Cardano 调用上发送 `[Standard]`；Cardano 调用发送
+  `[Standard, Cardano]`。不得发送空列表。`DeviceSessionGet` 不携带 `seed_domains`。
+  不得省略 `on_device`，也不得同时发送设备输入标记和
   Host Passphrase。Attach-to-PIN 继续使用 `DeviceSessionAskPin(AttachToPin)`。
 - `DeviceSessionAskPin` 的 PIN 类型由目标钱包意图决定，而不是由调用前的当前上下文决定：
   `Main` 用于选择标准钱包，也用于从 Attach-to-PIN 隐藏钱包上下文切回标准钱包；

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -132,13 +132,14 @@ Transport 连接、帧序号、设备端 `session_id` 和钱包标识是四类�
   路径必须抑制底层重复 Event。`protocolV2UiMode='none'` 只抑制普通方法交互提示，
   不得抑制已实际触发的设备端 PIN 提示。
 - `DeviceSessionGet` 的 `session_id` 和 `btc_test_address` 均可选：`session_id` 表示尝试恢复目标
-  Session，`btc_test_address` 表示预期钱包身份；两者都缺省时读取当前 Session。`seed_domains`
-  根据调用派生意图携带 `[Standard]` 或 `[Standard, Cardano]`，没有派生意图时在线路上省略。
-  所有调用都必须返回固件最终实际的完整 `DeviceSession`，正常状态错配不返回 `InvalidSession`。
+  Session，`btc_test_address` 表示预期钱包身份；两者都缺省时读取当前 Session。Get 不再携带
+  `seed_domains`。所有调用都必须返回固件最终实际的完整 `DeviceSession`，正常状态错配不返回
+  `InvalidSession`。
 - Pro2 的 `DeviceSessionAskPassphrase` 必须显式携带输入来源：Host 输入发送
-  `{ on_device: false, passphrase }`，设备输入发送 `{ on_device: true }`。不得省略
-  `on_device`，也不得同时发送设备输入标记和 Host Passphrase。Attach-to-PIN 继续使用
-  `DeviceSessionAskPin(AttachToPin)`。
+  `{ on_device: false, passphrase, seed_domains }`，设备输入发送 `{ on_device: true, seed_domains }`。
+  `seed_domains` 根据调用派生意图携带 `[Standard]` 或 `[Standard, Cardano]`，没有派生意图时在线路上
+  省略，保留固件“派生全部支持域”的兼容行为。不得省略 `on_device`，也不得同时发送设备输入标记和
+  Host Passphrase。Attach-to-PIN 继续使用 `DeviceSessionAskPin(AttachToPin)`。
 - `DeviceSessionAskPin` 的 PIN 类型由目标钱包意图决定，而不是由调用前的当前上下文决定：
   `Main` 用于选择标准钱包，也用于从 Attach-to-PIN 隐藏钱包上下文切回标准钱包；
   `AttachToPin` 只用于选择该 Attach PIN 绑定的隐藏钱包。`unlockedAttachPin=true` 是当前上下文状态，

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -137,8 +137,9 @@ Transport 连接、帧序号、设备端 `session_id` 和钱包标识是四类�
   `InvalidSession`。
 - Pro2 的 `DeviceSessionAskPassphrase` 必须显式携带输入来源：Host 输入发送
   `{ on_device: false, passphrase, seed_domains }`，设备输入发送 `{ on_device: true, seed_domains }`。
-  `seed_domains` 根据调用派生意图携带 `[Standard]` 或 `[Standard, Cardano]`，没有派生意图时在线路上
-  省略，保留固件“派生全部支持域”的兼容行为。不得省略 `on_device`，也不得同时发送设备输入标记和
+  `seed_domains` 仅在当前调用明确需要 Cardano 时携带 `[Standard, Cardano]`；开钱包以及
+  `deriveCardano !== true` 时发送空列表，保留固件“派生全部支持域”的默认行为。不得把 V1 的
+  `deriveCardano: false` 映射成 `[Standard]`。不得省略 `on_device`，也不得同时发送设备输入标记和
   Host Passphrase。Attach-to-PIN 继续使用 `DeviceSessionAskPin(AttachToPin)`。
 - `DeviceSessionAskPin` 的 PIN 类型由目标钱包意图决定，而不是由调用前的当前上下文决定：
   `Main` 用于选择标准钱包，也用于从 Attach-to-PIN 隐藏钱包上下文切回标准钱包；

--- a/docs/device/wallet-session-and-security.md
+++ b/docs/device/wallet-session-and-security.md
@@ -51,20 +51,25 @@
   最终 `passphraseState`。V1 缺少本地 Session 缓存时仍返回 `WalletSessionInvalid`。
 - Protocol V2 的 `DeviceSessionGet` 成功响应必须同时包含非空 `session_id` 和
   `btc_test_address`；缺少任一字段都按不完整协议响应处理，不得识别为标准钱包。
-- Protocol V2 空参数 `DeviceSessionGet()` 只读取固件当前钱包 Session，不保证当前钱包是标准钱包。
-  标准钱包首次打开时调用 `DeviceSessionAskPin(Main)`，成功后调用 `DeviceSessionGet()`；缓存有效时
-  先调用 `DeviceSessionGet(session_id, btc_test_address)` 恢复，恢复结果不匹配时再执行一次
-  `AskPin(Main) -> Get()` 重建。Core 使用返回的真实
+- Protocol V2 `DeviceSessionGet({ seed_domains })` 只读取固件当前钱包 Session，不保证当前钱包是标准钱包。
+  标准钱包首次打开时调用 `DeviceSessionAskPin(Main)`，成功后调用带 `seed_domains` 的
+  `DeviceSessionGet`；缓存有效时先调用 `DeviceSessionGet(session_id, btc_test_address, seed_domains)`
+  恢复，恢复结果不匹配时再执行一次 `AskPin(Main) -> Get(seed_domains)` 重建。Core 使用返回的真实
   `btc_test_address` 建立标准钱包内部索引，不引入 SDK 自造的 `STANDARD_WALLET_KEY`。
 - Protocol V2 进入 `select-hidden` 时，如果实时状态明确设备已经由 Attach PIN 解锁，Core 会再次
-  校验原始 `DeviceStatus`，然后直接用空参数 `DeviceSessionGet()` 读取当前隐藏钱包，不重新发起
+  校验原始 `DeviceStatus`，然后直接用带 `seed_domains` 的 `DeviceSessionGet` 读取当前隐藏钱包，不重新发起
   Passphrase 选择、`DeviceSessionAskPassphrase` 或 `DeviceSessionAskPin`。复核状态不一致时失败关闭，
   不回退到钱包重选。
-- V1 `Initialize.derive_cardano` 仍是按次 opt-in。V2 由 `DeviceSessionAskPassphrase.seed_domains`
-  决定这次生成哪些种子：开钱包和非 Cardano 调用发送 `[Standard]`；Cardano 调用发送
-  `[Standard, Cardano]`。`DeviceSessionGet` 不携带、也不生成 Cardano。`DeviceSession` 响应用
-  同一套 `seed_domains` 枚举回报已经生成的域。若 Get 显示还没有 Cardano，而当前调用需要 ADA，
-  SDK 再 Ask 一次带上 Cardano，然后 Get。
+- V1 `Initialize.derive_cardano` 仍是按次 opt-in。V2 由 `seed_domains` 决定这次生成哪些种子：
+  开钱包和非 Cardano 调用发送 `[Standard]`；Cardano 调用发送 `[Standard, Cardano]`。
+  `DeviceSessionAskPassphrase` 给隐藏 passphrase 钱包生成种子；`DeviceSessionGet` 携带同一套
+  `seed_domains`，在 Attach PIN / passphrase 关闭的当前 SE 钱包上补 GEN Cardano。Attach PIN
+  不得调用 `DeviceSessionAskPassphrase`。`DeviceSession` 响应用同一套枚举回报已经生成的域。
+  若 Get 显示还没有 Cardano，而当前调用需要 ADA：Attach PIN 再 Get 一次；隐藏 passphrase
+  再 Ask 一次带上 Cardano，然后 Get。从 Attach PIN 切到标准钱包或另一个 passphrase 钱包前，
+  SDK 会 `lockDevice`（标准钱包先尝试 `AskPin(Main)`），然后抛出
+  `DeviceCheckUnlockTypeError`，由 App 在用户解锁后重试。`select-hidden` 在已经由 Attach PIN
+  解锁时仍读取当前隐藏钱包，不重新选择。
 - `DeviceSessionAskPin` 的类型按业务意图选择：标准钱包和安全操作使用 `Main`；普通业务调用已携带目标
   `passphraseState` 时，预解锁使用 `Any`，允许主 PIN 或 Attach PIN 进入，随后仍以返回的
   `btc_test_address` 校验目标隐藏钱包；用户明确选择 Attach PIN 打开隐藏钱包时使用 `AttachToPin`。

--- a/docs/device/wallet-session-and-security.md
+++ b/docs/device/wallet-session-and-security.md
@@ -57,15 +57,16 @@
   `DeviceSessionGet(session_id, btc_test_address)` 恢复。Core 使用返回的真实
   `btc_test_address` 建立标准钱包内部索引，不引入 SDK 自造的 `STANDARD_WALLET_KEY`。
 - Protocol V2 进入 `select-hidden` 时，如果实时状态明确设备已经由 Attach PIN 解锁，Core 会再次
-  校验原始 `DeviceStatus`，然后用空参数 `DeviceSessionGet()` 读取当前隐藏钱包。需要 Cardano 且
-  响应还没有时，再发送空 Host passphrase 的 `AskPassphrase({ seed_domains: [Standard, Cardano] })`，
-  不弹出 passphrase UI。复核状态不一致时失败关闭，不回退到钱包重选。
+  校验原始 `DeviceStatus`，然后用空参数 `DeviceSessionGet()` 读取当前隐藏钱包，不发送
+  `AskPassphrase`。origin/dev 的 AskPassphrase 会 `SESSION_NEW` 并清掉
+  `unlocked_by_attach_to_pin`，随后 Host 可以输入 passphrase，SE 会失败。复核状态不一致时失败关闭，
+  不回退到钱包重选。从 Attach PIN 切到另一个 passphrase 钱包前，SDK 会 `lockDevice`。
 - V1 `Initialize.derive_cardano` 仍是按次 opt-in。V2 由 `DeviceSessionAskPassphrase.seed_domains`
   决定这次生成哪些种子：开钱包和非 Cardano 调用发送 `[Standard]`；Cardano 调用发送
   `[Standard, Cardano]`。`DeviceSessionGet` 不携带、也不生成 Cardano（passphrase 关闭时固件
   Get 会自己要 Cardano）。`DeviceSession` 响应用同一套枚举回报已经生成的域。若 Get 显示还没有
-  Cardano，而当前调用需要 ADA：Attach PIN / 标准钱包发送空 Host passphrase 的 Ask；隐藏
-  passphrase 再 Ask 一次带上 Cardano，然后 Get。从 Attach PIN 切到另一个非空 passphrase 钱包前，
+  Cardano，而当前调用需要 ADA：标准钱包发送空 Host passphrase 的 Ask；隐藏
+  passphrase 再 Ask 一次带上 Cardano，然后 Get。Attach PIN 不 Ask。从 Attach PIN 切到另一个非空 passphrase 钱包前，
   SDK 会 `lockDevice`，然后抛出 `DeviceCheckUnlockTypeError`。
 - `DeviceSessionAskPin` 的类型按业务意图选择：标准钱包和安全操作使用 `Main`；普通业务调用已携带目标
   `passphraseState` 时，预解锁使用 `Any`，允许主 PIN 或 Attach PIN 进入，随后仍以返回的
@@ -341,8 +342,8 @@ await HardwareSDK.clearSessionCache({ deviceId, passphraseState });
    匹配才抛出 `DeviceCheckPassphraseStateError`。SDK 不为普通过期主动 `LockDevice`。
 8. Pro2 隐藏钱包选择通过统一弹窗提供 Host 输入、设备输入和 Attach PIN。Host Passphrase 编码为
    `{ passphrase, on_device: false, seed_domains }`，仅用于当前阻塞请求，不缓存、记录或写入钱包引用；设备输入
-   编码为 `{ on_device: true, seed_domains }`，不携带明文。Attach PIN 独立使用 `DeviceSessionAskPin`；
-   需要 Cardano 时再发送空 Host passphrase 的 `AskPassphrase`，不弹出 UI。
+   编码为 `{ on_device: true, seed_domains }`，不携带明文。Attach PIN 独立使用 `DeviceSessionAskPin`，
+   不发送 `AskPassphrase`。
 9. Pro2 固件返回 `DeviceSession`：`session_id` 和 `btc_test_address`，SDK 将 `btc_test_address` 映射为上层 `passphraseState`。
 10. Pro V1 仍走 `GetPassphraseState -> PassphraseState`，返回 `passphrase_state/session_id/unlocked_attach_pin`。
 11. 如果 features 显示未开启 passphrase 但现在拿到了 state，会按需刷新设备状态。

--- a/docs/device/wallet-session-and-security.md
+++ b/docs/device/wallet-session-and-security.md
@@ -56,10 +56,10 @@
   `DeviceSessionAskPassphrase` 再 `DeviceSessionGet()`；缓存有效时先调用
   `DeviceSessionGet(session_id, btc_test_address)` 恢复。Core 使用返回的真实
   `btc_test_address` 建立标准钱包内部索引，不引入 SDK 自造的 `STANDARD_WALLET_KEY`。
-- Protocol V2 进入 `select-hidden` 时，如果实时状态明确设备已经由 Attach PIN 解锁，Core 会
-  `lockDevice` 并抛出 `DeviceCheckUnlockTypeError`，不读取当前 Attach PIN 会话，也不弹出
-  passphrase UI。用户用主 PIN 解锁后再选新的隐藏钱包。Attach PIN 会话上补 Cardano 仍走空 Host
-  `AskPassphrase({ seed_domains: [Standard, Cardano] })`，不经过 `select-hidden`。
+- Protocol V2 进入 `select-hidden` 时，如果实时状态明确设备已经由 Attach PIN 解锁，Core 读取当前
+  Attach PIN 会话，不弹出 passphrase UI（与 Pro1 一致：同一 PIN 已绑定该隐藏钱包）。要新建
+  passphrase 隐藏钱包，用户需先锁屏、用主 PIN 解锁后再点一次「+ Hidden wallet」。Attach PIN 上补
+  Cardano 走空 Host `AskPassphrase({ seed_domains: [Standard, Cardano] })`。
 - V1 `Initialize.derive_cardano` 仍是按次 opt-in。V2 由 `DeviceSessionAskPassphrase.seed_domains`
   决定这次生成哪些种子：开钱包和非 Cardano 调用发送 `[Standard]`；Cardano 调用发送
   `[Standard, Cardano]`。`DeviceSessionGet` 不携带、也不生成 Cardano（passphrase 关闭时固件

--- a/docs/device/wallet-session-and-security.md
+++ b/docs/device/wallet-session-and-security.md
@@ -57,16 +57,16 @@
   `DeviceSessionGet(session_id, btc_test_address)` 恢复。Core 使用返回的真实
   `btc_test_address` 建立标准钱包内部索引，不引入 SDK 自造的 `STANDARD_WALLET_KEY`。
 - Protocol V2 进入 `select-hidden` 时，如果实时状态明确设备已经由 Attach PIN 解锁，Core 会再次
-  校验原始 `DeviceStatus`，然后用空参数 `DeviceSessionGet()` 读取当前隐藏钱包，不发送
-  `AskPassphrase`。origin/dev 的 AskPassphrase 会 `SESSION_NEW` 并清掉
-  `unlocked_by_attach_to_pin`，随后 Host 可以输入 passphrase，SE 会失败。复核状态不一致时失败关闭，
-  不回退到钱包重选。从 Attach PIN 切到另一个 passphrase 钱包前，SDK 会 `lockDevice`。
+  校验原始 `DeviceStatus`，然后用空参数 `DeviceSessionGet()` 读取当前隐藏钱包。需要 Cardano 且
+  响应还没有时，再发送空 Host passphrase 的 `AskPassphrase({ seed_domains: [Standard, Cardano] })`，
+  不弹出 passphrase UI。固件会清掉 `unlocked_by_attach_to_pin`，SDK 仍把该会话视为 Attach PIN，
+  后续切到另一个 passphrase 钱包前会 `lockDevice`。复核状态不一致时失败关闭，不回退到钱包重选。
 - V1 `Initialize.derive_cardano` 仍是按次 opt-in。V2 由 `DeviceSessionAskPassphrase.seed_domains`
   决定这次生成哪些种子：开钱包和非 Cardano 调用发送 `[Standard]`；Cardano 调用发送
   `[Standard, Cardano]`。`DeviceSessionGet` 不携带、也不生成 Cardano（passphrase 关闭时固件
   Get 会自己要 Cardano）。`DeviceSession` 响应用同一套枚举回报已经生成的域。若 Get 显示还没有
-  Cardano，而当前调用需要 ADA：标准钱包发送空 Host passphrase 的 Ask；隐藏
-  passphrase 再 Ask 一次带上 Cardano，然后 Get。Attach PIN 不 Ask。从 Attach PIN 切到另一个非空 passphrase 钱包前，
+  Cardano，而当前调用需要 ADA：Attach PIN / 标准钱包发送空 Host passphrase 的 Ask；隐藏
+  passphrase 再 Ask 一次带上 Cardano，然后 Get。从 Attach PIN 切到另一个非空 passphrase 钱包前，
   SDK 会 `lockDevice`，然后抛出 `DeviceCheckUnlockTypeError`。
 - `DeviceSessionAskPin` 的类型按业务意图选择：标准钱包和安全操作使用 `Main`；普通业务调用已携带目标
   `passphraseState` 时，预解锁使用 `Any`，允许主 PIN 或 Attach PIN 进入，随后仍以返回的
@@ -342,8 +342,8 @@ await HardwareSDK.clearSessionCache({ deviceId, passphraseState });
    匹配才抛出 `DeviceCheckPassphraseStateError`。SDK 不为普通过期主动 `LockDevice`。
 8. Pro2 隐藏钱包选择通过统一弹窗提供 Host 输入、设备输入和 Attach PIN。Host Passphrase 编码为
    `{ passphrase, on_device: false, seed_domains }`，仅用于当前阻塞请求，不缓存、记录或写入钱包引用；设备输入
-   编码为 `{ on_device: true, seed_domains }`，不携带明文。Attach PIN 独立使用 `DeviceSessionAskPin`，
-   不发送 `AskPassphrase`。
+   编码为 `{ on_device: true, seed_domains }`，不携带明文。Attach PIN 独立使用 `DeviceSessionAskPin`；
+   需要 Cardano 时再发送空 Host passphrase 的 `AskPassphrase`，不弹出 UI。
 9. Pro2 固件返回 `DeviceSession`：`session_id` 和 `btc_test_address`，SDK 将 `btc_test_address` 映射为上层 `passphraseState`。
 10. Pro V1 仍走 `GetPassphraseState -> PassphraseState`，返回 `passphrase_state/session_id/unlocked_attach_pin`。
 11. 如果 features 显示未开启 passphrase 但现在拿到了 state，会按需刷新设备状态。

--- a/docs/device/wallet-session-and-security.md
+++ b/docs/device/wallet-session-and-security.md
@@ -56,11 +56,10 @@
   `DeviceSessionAskPassphrase` 再 `DeviceSessionGet()`；缓存有效时先调用
   `DeviceSessionGet(session_id, btc_test_address)` 恢复。Core 使用返回的真实
   `btc_test_address` 建立标准钱包内部索引，不引入 SDK 自造的 `STANDARD_WALLET_KEY`。
-- Protocol V2 进入 `select-hidden` 时，如果实时状态明确设备已经由 Attach PIN 解锁，Core 会再次
-  校验原始 `DeviceStatus`，然后用空参数 `DeviceSessionGet()` 读取当前隐藏钱包。需要 Cardano 且
-  响应还没有时，再发送空 Host passphrase 的 `AskPassphrase({ seed_domains: [Standard, Cardano] })`，
-  不弹出 passphrase UI。固件会清掉 `unlocked_by_attach_to_pin`，SDK 仍把该会话视为 Attach PIN，
-  后续切到另一个 passphrase 钱包前会 `lockDevice`。复核状态不一致时失败关闭，不回退到钱包重选。
+- Protocol V2 进入 `select-hidden` 时，如果实时状态明确设备已经由 Attach PIN 解锁，Core 会
+  `lockDevice` 并抛出 `DeviceCheckUnlockTypeError`，不读取当前 Attach PIN 会话，也不弹出
+  passphrase UI。用户用主 PIN 解锁后再选新的隐藏钱包。Attach PIN 会话上补 Cardano 仍走空 Host
+  `AskPassphrase({ seed_domains: [Standard, Cardano] })`，不经过 `select-hidden`。
 - V1 `Initialize.derive_cardano` 仍是按次 opt-in。V2 由 `DeviceSessionAskPassphrase.seed_domains`
   决定这次生成哪些种子：开钱包和非 Cardano 调用发送 `[Standard]`；Cardano 调用发送
   `[Standard, Cardano]`。`DeviceSessionGet` 不携带、也不生成 Cardano（passphrase 关闭时固件

--- a/docs/device/wallet-session-and-security.md
+++ b/docs/device/wallet-session-and-security.md
@@ -51,25 +51,22 @@
   最终 `passphraseState`。V1 缺少本地 Session 缓存时仍返回 `WalletSessionInvalid`。
 - Protocol V2 的 `DeviceSessionGet` 成功响应必须同时包含非空 `session_id` 和
   `btc_test_address`；缺少任一字段都按不完整协议响应处理，不得识别为标准钱包。
-- Protocol V2 `DeviceSessionGet({ seed_domains })` 只读取固件当前钱包 Session，不保证当前钱包是标准钱包。
-  标准钱包首次打开时调用 `DeviceSessionAskPin(Main)`，成功后调用带 `seed_domains` 的
-  `DeviceSessionGet`；缓存有效时先调用 `DeviceSessionGet(session_id, btc_test_address, seed_domains)`
-  恢复，恢复结果不匹配时再执行一次 `AskPin(Main) -> Get(seed_domains)` 重建。Core 使用返回的真实
+- Protocol V2 空参数 `DeviceSessionGet()` 只读取固件当前钱包 Session，不保证当前钱包是标准钱包。
+  标准钱包首次打开时调用 `DeviceSessionAskPin(Main)`，成功后调用空 Host passphrase 的
+  `DeviceSessionAskPassphrase` 再 `DeviceSessionGet()`；缓存有效时先调用
+  `DeviceSessionGet(session_id, btc_test_address)` 恢复。Core 使用返回的真实
   `btc_test_address` 建立标准钱包内部索引，不引入 SDK 自造的 `STANDARD_WALLET_KEY`。
 - Protocol V2 进入 `select-hidden` 时，如果实时状态明确设备已经由 Attach PIN 解锁，Core 会再次
-  校验原始 `DeviceStatus`，然后直接用带 `seed_domains` 的 `DeviceSessionGet` 读取当前隐藏钱包，不重新发起
-  Passphrase 选择、`DeviceSessionAskPassphrase` 或 `DeviceSessionAskPin`。复核状态不一致时失败关闭，
-  不回退到钱包重选。
-- V1 `Initialize.derive_cardano` 仍是按次 opt-in。V2 由 `seed_domains` 决定这次生成哪些种子：
-  开钱包和非 Cardano 调用发送 `[Standard]`；Cardano 调用发送 `[Standard, Cardano]`。
-  `DeviceSessionAskPassphrase` 给隐藏 passphrase 钱包生成种子；`DeviceSessionGet` 携带同一套
-  `seed_domains`，在 Attach PIN / passphrase 关闭的当前 SE 钱包上补 GEN Cardano。Attach PIN
-  不得调用 `DeviceSessionAskPassphrase`。`DeviceSession` 响应用同一套枚举回报已经生成的域。
-  若 Get 显示还没有 Cardano，而当前调用需要 ADA：Attach PIN 再 Get 一次；隐藏 passphrase
-  再 Ask 一次带上 Cardano，然后 Get。从 Attach PIN 切到标准钱包或另一个 passphrase 钱包前，
-  SDK 会 `lockDevice`（标准钱包先尝试 `AskPin(Main)`），然后抛出
-  `DeviceCheckUnlockTypeError`，由 App 在用户解锁后重试。`select-hidden` 在已经由 Attach PIN
-  解锁时仍读取当前隐藏钱包，不重新选择。
+  校验原始 `DeviceStatus`，然后用空参数 `DeviceSessionGet()` 读取当前隐藏钱包。需要 Cardano 且
+  响应还没有时，再发送空 Host passphrase 的 `AskPassphrase({ seed_domains: [Standard, Cardano] })`，
+  不弹出 passphrase UI。复核状态不一致时失败关闭，不回退到钱包重选。
+- V1 `Initialize.derive_cardano` 仍是按次 opt-in。V2 由 `DeviceSessionAskPassphrase.seed_domains`
+  决定这次生成哪些种子：开钱包和非 Cardano 调用发送 `[Standard]`；Cardano 调用发送
+  `[Standard, Cardano]`。`DeviceSessionGet` 不携带、也不生成 Cardano（passphrase 关闭时固件
+  Get 会自己要 Cardano）。`DeviceSession` 响应用同一套枚举回报已经生成的域。若 Get 显示还没有
+  Cardano，而当前调用需要 ADA：Attach PIN / 标准钱包发送空 Host passphrase 的 Ask；隐藏
+  passphrase 再 Ask 一次带上 Cardano，然后 Get。从 Attach PIN 切到另一个非空 passphrase 钱包前，
+  SDK 会 `lockDevice`，然后抛出 `DeviceCheckUnlockTypeError`。
 - `DeviceSessionAskPin` 的类型按业务意图选择：标准钱包和安全操作使用 `Main`；普通业务调用已携带目标
   `passphraseState` 时，预解锁使用 `Any`，允许主 PIN 或 Attach PIN 进入，随后仍以返回的
   `btc_test_address` 校验目标隐藏钱包；用户明确选择 Attach PIN 打开隐藏钱包时使用 `AttachToPin`。
@@ -331,18 +328,21 @@ await HardwareSDK.clearSessionCache({ deviceId, passphraseState });
 5. 旧 `initSession=true` 同时携带 `passphraseState` 时，只删除当前连接设备上该
    `deviceId + passphraseState` 对应的本地 Session，不清空该设备的其他隐藏钱包。
 6. Protocol V2 / Pro2 每次钱包预检都发送
-   `ProtocolInfoRequest { eventless_wallet_session: true }`。标准钱包首次打开时发送
-   `DeviceSessionAskPin(Main) -> DeviceSessionGet()`；缓存存在时发送
+   `ProtocolInfoRequest { eventless_wallet_session: true }`。标准钱包首次打开时：passphrase 开启则
+   `AskPin(Main) -> AskPassphrase('', seed_domains) -> Get()`；passphrase 关闭则
+   `AskPin(Main) -> Get()`。缓存存在时发送
    `DeviceSessionGet(session_id, btc_test_address)`。隐藏钱包恢复时携带 `btc_test_address`，按新钱包
    选择时通常先发送 Ask，成功后发送 `DeviceSessionGet()`；设备已经由 Attach PIN 解锁时则复核
-   实时状态并直接读取当前 `DeviceSession`，避免再次询问 Passphrase 或重复输入 Attach PIN。
+   实时状态并直接读取当前 `DeviceSession`，避免弹出 passphrase UI 或重复输入 Attach PIN。
 7. 固件按 `btc_test_address` 校验当前 SE Session，并对带 `session_id` 的 Get 尝试恢复指定 Session。
-   若首次 `passphraseState` 不匹配，标准钱包
-   执行一次 `AskPin(Main) -> Get()`；隐藏钱包执行一次统一钱包选择及 `Ask -> Get()`。第二次仍不
+   若首次 `passphraseState` 不匹配，标准钱包执行一次
+   `AskPin(Main) -> AskPassphrase('', seed_domains) -> Get()`（passphrase 关闭则只 AskPin 再 Get）；
+   隐藏钱包执行一次统一钱包选择及 `Ask -> Get()`。第二次仍不
    匹配才抛出 `DeviceCheckPassphraseStateError`。SDK 不为普通过期主动 `LockDevice`。
 8. Pro2 隐藏钱包选择通过统一弹窗提供 Host 输入、设备输入和 Attach PIN。Host Passphrase 编码为
-   `{ passphrase, on_device: false }`，仅用于当前阻塞请求，不缓存、记录或写入钱包引用；设备输入
-   编码为 `{ on_device: true }`，不携带明文。Attach PIN 独立使用 `DeviceSessionAskPin`。
+   `{ passphrase, on_device: false, seed_domains }`，仅用于当前阻塞请求，不缓存、记录或写入钱包引用；设备输入
+   编码为 `{ on_device: true, seed_domains }`，不携带明文。Attach PIN 独立使用 `DeviceSessionAskPin`；
+   需要 Cardano 时再发送空 Host passphrase 的 `AskPassphrase`，不弹出 UI。
 9. Pro2 固件返回 `DeviceSession`：`session_id` 和 `btc_test_address`，SDK 将 `btc_test_address` 映射为上层 `passphraseState`。
 10. Pro V1 仍走 `GetPassphraseState -> PassphraseState`，返回 `passphrase_state/session_id/unlocked_attach_pin`。
 11. 如果 features 显示未开启 passphrase 但现在拿到了 state，会按需刷新设备状态。

--- a/docs/device/wallet-session-and-security.md
+++ b/docs/device/wallet-session-and-security.md
@@ -60,9 +60,10 @@
   校验原始 `DeviceStatus`，然后直接用空参数 `DeviceSessionGet()` 读取当前隐藏钱包，不重新发起
   Passphrase 选择、`DeviceSessionAskPassphrase` 或 `DeviceSessionAskPin`。复核状态不一致时失败关闭，
   不回退到钱包重选。
-- Core 把现有 `deriveCardano` 意图映射为 `DeviceSessionGet.seed_domains`：普通业务请求
+- Core 把现有 `deriveCardano` 意图映射为 `DeviceSessionAskPassphrase.seed_domains`：普通业务请求
   `[Standard]`，Cardano 业务请求 `[Standard, Cardano]`。调用链没有提供派生意图时省略该字段，
-  保持固件“派生全部支持域”的兼容行为。
+  保持固件“派生全部支持域”的兼容行为。`DeviceSessionGet` 只恢复或读取当前 Session，不再携带
+  `seed_domains`；新固件会拒绝 Get 上的未知字段。
 - `DeviceSessionAskPin` 的类型按业务意图选择：标准钱包和安全操作使用 `Main`；普通业务调用已携带目标
   `passphraseState` 时，预解锁使用 `Any`，允许主 PIN 或 Attach PIN 进入，随后仍以返回的
   `btc_test_address` 校验目标隐藏钱包；用户明确选择 Attach PIN 打开隐藏钱包时使用 `AttachToPin`。

--- a/docs/device/wallet-session-and-security.md
+++ b/docs/device/wallet-session-and-security.md
@@ -60,10 +60,13 @@
   校验原始 `DeviceStatus`，然后直接用空参数 `DeviceSessionGet()` 读取当前隐藏钱包，不重新发起
   Passphrase 选择、`DeviceSessionAskPassphrase` 或 `DeviceSessionAskPin`。复核状态不一致时失败关闭，
   不回退到钱包重选。
-- Core 把现有 `deriveCardano` 意图映射为 `DeviceSessionAskPassphrase.seed_domains`：普通业务请求
-  `[Standard]`，Cardano 业务请求 `[Standard, Cardano]`。调用链没有提供派生意图时省略该字段，
-  保持固件“派生全部支持域”的兼容行为。`DeviceSessionGet` 只恢复或读取当前 Session，不再携带
-  `seed_domains`；新固件会拒绝 Get 上的未知字段。
+- V1 `Initialize.derive_cardano` 仍是按次 opt-in：只有当前调用明确需要 Cardano 时才置位，
+  省略或 `false` 只表示这次不派生，之后仍可再 Initialize。V2 的 seed domain 只在
+  `DeviceSessionAskPassphrase` 上生效，`DeviceSessionGet` 不能补域。因此 V2 不得把 V1 的
+  `deriveCardano: false` 映射成 `[Standard]`（那会把会话永久收窄）。开钱包
+  `openWalletSession` 不转发该 CommonParams 字段，AskPassphrase 发送空 `seed_domains`，
+  由固件默认派生全部支持域。后续 Cardano 方法若必须重建会话，才显式请求
+  `[Standard, Cardano]`。`DeviceSessionGet` 不再携带 `seed_domains`；新固件会拒绝 Get 上的未知字段。
 - `DeviceSessionAskPin` 的类型按业务意图选择：标准钱包和安全操作使用 `Main`；普通业务调用已携带目标
   `passphraseState` 时，预解锁使用 `Any`，允许主 PIN 或 Attach PIN 进入，随后仍以返回的
   `btc_test_address` 校验目标隐藏钱包；用户明确选择 Attach PIN 打开隐藏钱包时使用 `AttachToPin`。

--- a/docs/device/wallet-session-and-security.md
+++ b/docs/device/wallet-session-and-security.md
@@ -60,13 +60,11 @@
   校验原始 `DeviceStatus`，然后直接用空参数 `DeviceSessionGet()` 读取当前隐藏钱包，不重新发起
   Passphrase 选择、`DeviceSessionAskPassphrase` 或 `DeviceSessionAskPin`。复核状态不一致时失败关闭，
   不回退到钱包重选。
-- V1 `Initialize.derive_cardano` 仍是按次 opt-in：只有当前调用明确需要 Cardano 时才置位，
-  省略或 `false` 只表示这次不派生，之后仍可再 Initialize。V2 的 seed domain 只在
-  `DeviceSessionAskPassphrase` 上生效，`DeviceSessionGet` 不能补域。因此 V2 不得把 V1 的
-  `deriveCardano: false` 映射成 `[Standard]`（那会把会话永久收窄）。开钱包
-  `openWalletSession` 不转发该 CommonParams 字段，AskPassphrase 发送空 `seed_domains`，
-  由固件默认派生全部支持域。后续 Cardano 方法若必须重建会话，才显式请求
-  `[Standard, Cardano]`。`DeviceSessionGet` 不再携带 `seed_domains`；新固件会拒绝 Get 上的未知字段。
+- V1 `Initialize.derive_cardano` 仍是按次 opt-in。V2 由 `DeviceSessionAskPassphrase.seed_domains`
+  决定这次生成哪些种子：开钱包和非 Cardano 调用发送 `[Standard]`；Cardano 调用发送
+  `[Standard, Cardano]`。`DeviceSessionGet` 不携带、也不生成 Cardano。`DeviceSession` 响应用
+  同一套 `seed_domains` 枚举回报已经生成的域。若 Get 显示还没有 Cardano，而当前调用需要 ADA，
+  SDK 再 Ask 一次带上 Cardano，然后 Get。
 - `DeviceSessionAskPin` 的类型按业务意图选择：标准钱包和安全操作使用 `Main`；普通业务调用已携带目标
   `passphraseState` 时，预解锁使用 `Any`，允许主 PIN 或 Attach PIN 进入，随后仍以返回的
   `btc_test_address` 校验目标隐藏钱包；用户明确选择 Attach PIN 打开隐藏钱包时使用 `AttachToPin`。

--- a/docs/sdk/pro2-eventless-migration.md
+++ b/docs/sdk/pro2-eventless-migration.md
@@ -52,18 +52,20 @@ SDK 内部根据协议版本选择 Event 来源和后续动作。
 - `DeviceSessionAskPassphrase` 与 `DeviceSessionAskPin` 完成验证和钱包切换并返回 `Success`；
   前者通过必填 `on_device` 区分设备输入与 Host 输入。Host 输入同时携带非空 `passphrase`；
   设备输入不携带明文。Attach-to-PIN 始终使用 `DeviceSessionAskPin(AttachToPin)`。
-- `DeviceSessionGet({ session_id, btc_test_address, seed_domains })` 承接原
-  `Initialize(session_id, passphrase_state, derive_cardano)` 的 Session 恢复与 Cardano 补齐语义。
-  AskPassphrase 仍为隐藏 passphrase 钱包选择种子域：开钱包为 `[Standard]`，Cardano 为
-  `[Standard, Cardano]`。Get 使用同一套 `seed_domains`；Attach PIN 不得再走 AskPassphrase。
+- `DeviceSessionGet({ session_id, btc_test_address })` 承接原
+  `Initialize(session_id, passphrase_state)` 的 Session 恢复语义。V2 只在 AskPassphrase 上携带
+  `seed_domains`：开钱包为 `[Standard]`，Cardano 为 `[Standard, Cardano]`。Get 不携带该字段。
+  Attach PIN 补 Cardano 发送空 Host passphrase 的 AskPassphrase。
   这不是 `PassphraseAck` 原有能力。
 - `ButtonRequest/ButtonAck` 不改名；它们从 V2 firmware 状态机中删除，设备页面由显式 Ask 命令
   打开，对 App 的阶段提示由 SDK 合成。
 
 ```text
-PassphraseAck(passphrase)                -> DeviceSessionAskPassphrase({ on_device: false, passphrase }) -> Success -> DeviceSessionGet()
-PassphraseAck(on_device)                 -> DeviceSessionAskPassphrase({ on_device: true }) -> Success -> DeviceSessionGet()
-PassphraseAck(on_device_attach_pin)      -> DeviceSessionAskPin(AttachToPin) -> Success -> DeviceSessionGet()
+PassphraseAck(passphrase)                -> DeviceSessionAskPassphrase({ on_device: false, passphrase, seed_domains }) -> Success -> DeviceSessionGet()
+PassphraseAck(on_device)                 -> DeviceSessionAskPassphrase({ on_device: true, seed_domains }) -> Success -> DeviceSessionGet()
+PassphraseAck(on_device_attach_pin)      -> DeviceSessionAskPin(AttachToPin) -> Success
+                                         -> [Cardano: empty AskPassphrase({ passphrase: '', on_device: false, seed_domains: [Standard, Cardano] })]
+                                         -> DeviceSessionGet()
 Initialize(session_id, passphrase_state) -> DeviceSessionGet({ session_id, btc_test_address })
 ```
 
@@ -120,7 +122,7 @@ App 的 Pro2 分支继续返回现有三种选择形状：
 - 用户取消。
 
 SDK 将响应转换为 `DeviceSessionAskPassphrase` 或 `DeviceSessionAskPin(AttachToPin)`；Ask 只返回
-`Success`，之后用带 `seed_domains` 的 `DeviceSessionGet` 获取实际 Session，不发送 `PassphraseAck`。
+`Success`，之后用空参数 `DeviceSessionGet` 获取实际 Session，不发送 `PassphraseAck`。
 显式 `resume-hidden` 有缓存时先通过带 `session_id` 的 `DeviceSessionGet` 尝试恢复。没有缓存、
 句柄失效或固件返回的实际钱包状态不匹配时，SDK 合成一次 `REQUEST_PASSPHRASE` 让用户重新进入
 目标钱包；最终仍不匹配才报安全错误。`session_id` 只作为恢复提示，钱包身份以
@@ -307,9 +309,10 @@ Cancel 必须绑定当前设备和 Transport source；断连时清理请求、UI
 - 标准钱包公共响应固定返回 `passphraseState=null`；隐藏钱包返回非空 `passphraseState`。
   钱包分类仍只使用 `walletType`，不得根据 `passphraseState` 是否为空反推底层协议。
 - Host Passphrase 映射到
-  `DeviceSessionAskPassphrase({ passphrase, on_device: false })`；设备端 Passphrase 映射到
-  `DeviceSessionAskPassphrase({ on_device: true })`；Attach PIN 映射到
-  `DeviceSessionAskPin(AttachToPin)`；Ask 成功后统一调用带 `seed_domains` 的 `DeviceSessionGet`。
+  `DeviceSessionAskPassphrase({ passphrase, on_device: false, seed_domains })`；设备端 Passphrase 映射到
+  `DeviceSessionAskPassphrase({ on_device: true, seed_domains })`；Attach PIN 映射到
+  `DeviceSessionAskPin(AttachToPin)`。Ask 成功后统一调用空参数 `DeviceSessionGet()`；Get 不携带
+  `seed_domains`。Attach PIN 补 Cardano 再发送空 Host passphrase 的 `AskPassphrase`。
 - Host Passphrase 先做 NFKD 规范化，并校验为 1–50 个 UTF-8 字节且不含 NUL。
 - `DeviceWalletSessionStore` 以 `deviceKey + passphraseState` 保存真实钱包映射，并为每台设备维护
   一个指向真实标准钱包记录的内部索引；该索引只由显式标准钱包意图读取。

--- a/docs/sdk/pro2-eventless-migration.md
+++ b/docs/sdk/pro2-eventless-migration.md
@@ -55,7 +55,7 @@ SDK 内部根据协议版本选择 Event 来源和后续动作。
 - `DeviceSessionGet({ session_id, btc_test_address })` 承接原
   `Initialize(session_id, passphrase_state)` 的 Session 恢复语义。V2 只在 AskPassphrase 上携带
   `seed_domains`：开钱包为 `[Standard]`，Cardano 为 `[Standard, Cardano]`。Get 不携带该字段。
-  Attach PIN 会话不发送 AskPassphrase。
+  Attach PIN 补 Cardano 发送空 Host passphrase 的 AskPassphrase。
   这不是 `PassphraseAck` 原有能力。
 - `ButtonRequest/ButtonAck` 不改名；它们从 V2 firmware 状态机中删除，设备页面由显式 Ask 命令
   打开，对 App 的阶段提示由 SDK 合成。
@@ -63,7 +63,9 @@ SDK 内部根据协议版本选择 Event 来源和后续动作。
 ```text
 PassphraseAck(passphrase)                -> DeviceSessionAskPassphrase({ on_device: false, passphrase, seed_domains }) -> Success -> DeviceSessionGet()
 PassphraseAck(on_device)                 -> DeviceSessionAskPassphrase({ on_device: true, seed_domains }) -> Success -> DeviceSessionGet()
-PassphraseAck(on_device_attach_pin)      -> DeviceSessionAskPin(AttachToPin) -> Success -> DeviceSessionGet()
+PassphraseAck(on_device_attach_pin)      -> DeviceSessionAskPin(AttachToPin) -> Success
+                                         -> [Cardano: empty AskPassphrase({ passphrase: '', on_device: false, seed_domains: [Standard, Cardano] })]
+                                         -> DeviceSessionGet()
 Initialize(session_id, passphrase_state) -> DeviceSessionGet({ session_id, btc_test_address })
 ```
 
@@ -310,7 +312,7 @@ Cancel 必须绑定当前设备和 Transport source；断连时清理请求、UI
   `DeviceSessionAskPassphrase({ passphrase, on_device: false, seed_domains })`；设备端 Passphrase 映射到
   `DeviceSessionAskPassphrase({ on_device: true, seed_domains })`；Attach PIN 映射到
   `DeviceSessionAskPin(AttachToPin)`。Ask 成功后统一调用空参数 `DeviceSessionGet()`；Get 不携带
-  `seed_domains`。Attach PIN 会话不发送 `AskPassphrase`。
+  `seed_domains`。Attach PIN 补 Cardano 再发送空 Host passphrase 的 `AskPassphrase`。
 - Host Passphrase 先做 NFKD 规范化，并校验为 1–50 个 UTF-8 字节且不含 NUL。
 - `DeviceWalletSessionStore` 以 `deviceKey + passphraseState` 保存真实钱包映射，并为每台设备维护
   一个指向真实标准钱包记录的内部索引；该索引只由显式标准钱包意图读取。

--- a/docs/sdk/pro2-eventless-migration.md
+++ b/docs/sdk/pro2-eventless-migration.md
@@ -55,7 +55,7 @@ SDK 内部根据协议版本选择 Event 来源和后续动作。
 - `DeviceSessionGet({ session_id, btc_test_address })` 承接原
   `Initialize(session_id, passphrase_state)` 的 Session 恢复语义。V2 只在 AskPassphrase 上携带
   `seed_domains`：开钱包为 `[Standard]`，Cardano 为 `[Standard, Cardano]`。Get 不携带该字段。
-  Attach PIN 补 Cardano 发送空 Host passphrase 的 AskPassphrase。
+  Attach PIN 会话不发送 AskPassphrase。
   这不是 `PassphraseAck` 原有能力。
 - `ButtonRequest/ButtonAck` 不改名；它们从 V2 firmware 状态机中删除，设备页面由显式 Ask 命令
   打开，对 App 的阶段提示由 SDK 合成。
@@ -63,9 +63,7 @@ SDK 内部根据协议版本选择 Event 来源和后续动作。
 ```text
 PassphraseAck(passphrase)                -> DeviceSessionAskPassphrase({ on_device: false, passphrase, seed_domains }) -> Success -> DeviceSessionGet()
 PassphraseAck(on_device)                 -> DeviceSessionAskPassphrase({ on_device: true, seed_domains }) -> Success -> DeviceSessionGet()
-PassphraseAck(on_device_attach_pin)      -> DeviceSessionAskPin(AttachToPin) -> Success
-                                         -> [Cardano: empty AskPassphrase({ passphrase: '', on_device: false, seed_domains: [Standard, Cardano] })]
-                                         -> DeviceSessionGet()
+PassphraseAck(on_device_attach_pin)      -> DeviceSessionAskPin(AttachToPin) -> Success -> DeviceSessionGet()
 Initialize(session_id, passphrase_state) -> DeviceSessionGet({ session_id, btc_test_address })
 ```
 
@@ -312,7 +310,7 @@ Cancel 必须绑定当前设备和 Transport source；断连时清理请求、UI
   `DeviceSessionAskPassphrase({ passphrase, on_device: false, seed_domains })`；设备端 Passphrase 映射到
   `DeviceSessionAskPassphrase({ on_device: true, seed_domains })`；Attach PIN 映射到
   `DeviceSessionAskPin(AttachToPin)`。Ask 成功后统一调用空参数 `DeviceSessionGet()`；Get 不携带
-  `seed_domains`。Attach PIN 补 Cardano 再发送空 Host passphrase 的 `AskPassphrase`。
+  `seed_domains`。Attach PIN 会话不发送 `AskPassphrase`。
 - Host Passphrase 先做 NFKD 规范化，并校验为 1–50 个 UTF-8 字节且不含 NUL。
 - `DeviceWalletSessionStore` 以 `deviceKey + passphraseState` 保存真实钱包映射，并为每台设备维护
   一个指向真实标准钱包记录的内部索引；该索引只由显式标准钱包意图读取。

--- a/docs/sdk/pro2-eventless-migration.md
+++ b/docs/sdk/pro2-eventless-migration.md
@@ -52,9 +52,10 @@ SDK 内部根据协议版本选择 Event 来源和后续动作。
 - `DeviceSessionAskPassphrase` 与 `DeviceSessionAskPin` 完成验证和钱包切换并返回 `Success`；
   前者通过必填 `on_device` 区分设备输入与 Host 输入。Host 输入同时携带非空 `passphrase`；
   设备输入不携带明文。Attach-to-PIN 始终使用 `DeviceSessionAskPin(AttachToPin)`。
-- `DeviceSessionGet({ session_id, btc_test_address })` 承接原
-  `Initialize(session_id, passphrase_state)` 的 Session 恢复语义。V2 只在 AskPassphrase 上携带
-  `seed_domains`：开钱包为 `[Standard]`，Cardano 为 `[Standard, Cardano]`。Get 不携带该字段。
+- `DeviceSessionGet({ session_id, btc_test_address, seed_domains })` 承接原
+  `Initialize(session_id, passphrase_state, derive_cardano)` 的 Session 恢复与 Cardano 补齐语义。
+  AskPassphrase 仍为隐藏 passphrase 钱包选择种子域：开钱包为 `[Standard]`，Cardano 为
+  `[Standard, Cardano]`。Get 使用同一套 `seed_domains`；Attach PIN 不得再走 AskPassphrase。
   这不是 `PassphraseAck` 原有能力。
 - `ButtonRequest/ButtonAck` 不改名；它们从 V2 firmware 状态机中删除，设备页面由显式 Ask 命令
   打开，对 App 的阶段提示由 SDK 合成。
@@ -119,7 +120,7 @@ App 的 Pro2 分支继续返回现有三种选择形状：
 - 用户取消。
 
 SDK 将响应转换为 `DeviceSessionAskPassphrase` 或 `DeviceSessionAskPin(AttachToPin)`；Ask 只返回
-`Success`，之后用空参数 `DeviceSessionGet` 获取实际 Session，不发送 `PassphraseAck`。
+`Success`，之后用带 `seed_domains` 的 `DeviceSessionGet` 获取实际 Session，不发送 `PassphraseAck`。
 显式 `resume-hidden` 有缓存时先通过带 `session_id` 的 `DeviceSessionGet` 尝试恢复。没有缓存、
 句柄失效或固件返回的实际钱包状态不匹配时，SDK 合成一次 `REQUEST_PASSPHRASE` 让用户重新进入
 目标钱包；最终仍不匹配才报安全错误。`session_id` 只作为恢复提示，钱包身份以
@@ -308,7 +309,7 @@ Cancel 必须绑定当前设备和 Transport source；断连时清理请求、UI
 - Host Passphrase 映射到
   `DeviceSessionAskPassphrase({ passphrase, on_device: false })`；设备端 Passphrase 映射到
   `DeviceSessionAskPassphrase({ on_device: true })`；Attach PIN 映射到
-  `DeviceSessionAskPin(AttachToPin)`；Ask 成功后统一调用空参数 `DeviceSessionGet`。
+  `DeviceSessionAskPin(AttachToPin)`；Ask 成功后统一调用带 `seed_domains` 的 `DeviceSessionGet`。
 - Host Passphrase 先做 NFKD 规范化，并校验为 1–50 个 UTF-8 字节且不含 NUL。
 - `DeviceWalletSessionStore` 以 `deviceKey + passphraseState` 保存真实钱包映射，并为每台设备维护
   一个指向真实标准钱包记录的内部索引；该索引只由显式标准钱包意图读取。

--- a/docs/sdk/pro2-eventless-migration.md
+++ b/docs/sdk/pro2-eventless-migration.md
@@ -52,9 +52,9 @@ SDK 内部根据协议版本选择 Event 来源和后续动作。
 - `DeviceSessionAskPassphrase` 与 `DeviceSessionAskPin` 完成验证和钱包切换并返回 `Success`；
   前者通过必填 `on_device` 区分设备输入与 Host 输入。Host 输入同时携带非空 `passphrase`；
   设备输入不携带明文。Attach-to-PIN 始终使用 `DeviceSessionAskPin(AttachToPin)`。
-- `DeviceSessionGet({ session_id, btc_test_address, seed_domains })` 承接原
-  `Initialize(session_id, passphrase_state, derive_cardano)` 的 Session 恢复与派生语义，
-  这不是 `PassphraseAck` 原有能力。
+- `DeviceSessionGet({ session_id, btc_test_address })` 承接原
+  `Initialize(session_id, passphrase_state)` 的 Session 恢复语义；`derive_cardano` 映射到
+  `DeviceSessionAskPassphrase.seed_domains`，这不是 `PassphraseAck` 原有能力。
 - `ButtonRequest/ButtonAck` 不改名；它们从 V2 firmware 状态机中删除，设备页面由显式 Ask 命令
   打开，对 App 的阶段提示由 SDK 合成。
 
@@ -62,7 +62,7 @@ SDK 内部根据协议版本选择 Event 来源和后续动作。
 PassphraseAck(passphrase)                -> DeviceSessionAskPassphrase({ on_device: false, passphrase }) -> Success -> DeviceSessionGet()
 PassphraseAck(on_device)                 -> DeviceSessionAskPassphrase({ on_device: true }) -> Success -> DeviceSessionGet()
 PassphraseAck(on_device_attach_pin)      -> DeviceSessionAskPin(AttachToPin) -> Success -> DeviceSessionGet()
-Initialize(session_id, passphrase_state) -> DeviceSessionGet({ session_id, btc_test_address, seed_domains })
+Initialize(session_id, passphrase_state) -> DeviceSessionGet({ session_id, btc_test_address })
 ```
 
 ## 不在删除范围

--- a/docs/sdk/pro2-eventless-migration.md
+++ b/docs/sdk/pro2-eventless-migration.md
@@ -53,8 +53,9 @@ SDK 内部根据协议版本选择 Event 来源和后续动作。
   前者通过必填 `on_device` 区分设备输入与 Host 输入。Host 输入同时携带非空 `passphrase`；
   设备输入不携带明文。Attach-to-PIN 始终使用 `DeviceSessionAskPin(AttachToPin)`。
 - `DeviceSessionGet({ session_id, btc_test_address })` 承接原
-  `Initialize(session_id, passphrase_state)` 的 Session 恢复语义；`derive_cardano` 映射到
-  `DeviceSessionAskPassphrase.seed_domains`，这不是 `PassphraseAck` 原有能力。
+  `Initialize(session_id, passphrase_state)` 的 Session 恢复语义；V1 的 `derive_cardano`
+  不再按次映射到 Get。V2 只在 AskPassphrase 上携带 `seed_domains`：Cardano 意图为
+  `[Standard, Cardano]`，其余为空列表（固件默认全部域）。这不是 `PassphraseAck` 原有能力。
 - `ButtonRequest/ButtonAck` 不改名；它们从 V2 firmware 状态机中删除，设备页面由显式 Ask 命令
   打开，对 App 的阶段提示由 SDK 合成。
 

--- a/docs/sdk/pro2-eventless-migration.md
+++ b/docs/sdk/pro2-eventless-migration.md
@@ -53,9 +53,9 @@ SDK 内部根据协议版本选择 Event 来源和后续动作。
   前者通过必填 `on_device` 区分设备输入与 Host 输入。Host 输入同时携带非空 `passphrase`；
   设备输入不携带明文。Attach-to-PIN 始终使用 `DeviceSessionAskPin(AttachToPin)`。
 - `DeviceSessionGet({ session_id, btc_test_address })` 承接原
-  `Initialize(session_id, passphrase_state)` 的 Session 恢复语义；V1 的 `derive_cardano`
-  不再按次映射到 Get。V2 只在 AskPassphrase 上携带 `seed_domains`：Cardano 意图为
-  `[Standard, Cardano]`，其余为空列表（固件默认全部域）。这不是 `PassphraseAck` 原有能力。
+  `Initialize(session_id, passphrase_state)` 的 Session 恢复语义。V2 只在 AskPassphrase 上携带
+  `seed_domains`：开钱包为 `[Standard]`，Cardano 为 `[Standard, Cardano]`。Get 不携带该字段。
+  这不是 `PassphraseAck` 原有能力。
 - `ButtonRequest/ButtonAck` 不改名；它们从 V2 firmware 状态机中删除，设备页面由显式 Ask 命令
   打开，对 App 的阶段提示由 SDK 合成。
 

--- a/docs/sdk/pro2-field-migration.md
+++ b/docs/sdk/pro2-field-migration.md
@@ -293,20 +293,23 @@ label、语言、蓝牙开关、自动锁屏和振动反馈都属于用户配置
 ```text
 DeviceSessionAskPassphrase({ seed_domains }) -> Success -> DeviceSessionGet() -> DeviceSession
 DeviceSessionAskPin(Main/AttachToPin) -> Success -> DeviceSessionGet() -> DeviceSession
+DeviceSessionAskPin(AttachToPin) -> Success
+  -> DeviceSessionAskPassphrase({ passphrase: '', on_device: false, seed_domains: [Standard, Cardano] })
+  -> Success -> DeviceSessionGet() -> DeviceSession
 DeviceSessionGet({ session_id, btc_test_address }) -> DeviceSession
 ```
 
 ### 8.1 字段说明
 
-| Protocol V2 字段/消息                     | 含义                             | SDK 当前处理                                                                                                                                                               |
-| ----------------------------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DeviceSessionGet.session_id`             | 尝试恢复之前的钱包 Session       | Core 内部传入当前钱包缓存值                                                                                                                                                |
-| `DeviceSessionGet.btc_test_address`       | 请求恢复的预期钱包身份           | 从内部 `passphraseState` 映射，和缓存 Session 一起发送                                                                                                                     |
-| `DeviceSessionAskPassphrase.seed_domains` | 本次需要生成的种子域             | 开钱包 / 非 Cardano 为 `[Standard]`；Cardano 为 `[Standard, Cardano]`。Get 不携带该字段。Attach PIN 会话不发送 AskPassphrase。`DeviceSession` 响应用同一枚举回报已生成的域 |
-| `DeviceSessionPinType`                    | `Any/Main/AttachToPin` PIN 路由  | 标准钱包固定 `Main`，Attach 选择固定对应类型                                                                                                                               |
-| `DeviceSessionAskPassphrase`              | 创建 Passphrase 隐藏钱包会话     | Host：`{ passphrase, on_device: false, seed_domains }`；设备：`{ on_device: true, seed_domains }`                                                                          |
-| 响应 `session_id`                         | 当前钱包 Session ID              | 保存到当前钱包缓存                                                                                                                                                         |
-| 响应 `DeviceSession.btc_test_address`     | 用于确认当前钱包上下文的稳定标识 | 映射为内部 `passphraseState`                                                                                                                                               |
+| Protocol V2 字段/消息                     | 含义                             | SDK 当前处理                                                                                                                                                                        |
+| ----------------------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DeviceSessionGet.session_id`             | 尝试恢复之前的钱包 Session       | Core 内部传入当前钱包缓存值                                                                                                                                                         |
+| `DeviceSessionGet.btc_test_address`       | 请求恢复的预期钱包身份           | 从内部 `passphraseState` 映射，和缓存 Session 一起发送                                                                                                                              |
+| `DeviceSessionAskPassphrase.seed_domains` | 本次需要生成的种子域             | 开钱包 / 非 Cardano 为 `[Standard]`；Cardano 为 `[Standard, Cardano]`。Get 不携带该字段。Attach PIN 补 Cardano 发送空 Host passphrase。`DeviceSession` 响应用同一枚举回报已生成的域 |
+| `DeviceSessionPinType`                    | `Any/Main/AttachToPin` PIN 路由  | 标准钱包固定 `Main`，Attach 选择固定对应类型                                                                                                                                        |
+| `DeviceSessionAskPassphrase`              | 创建 Passphrase 隐藏钱包会话     | Host：`{ passphrase, on_device: false, seed_domains }`；设备：`{ on_device: true, seed_domains }`                                                                                   |
+| 响应 `session_id`                         | 当前钱包 Session ID              | 保存到当前钱包缓存                                                                                                                                                                  |
+| 响应 `DeviceSession.btc_test_address`     | 用于确认当前钱包上下文的稳定标识 | 映射为内部 `passphraseState`                                                                                                                                                        |
 
 这里的 `btc_test_address` 用于确认当前打开的是不是预期钱包，不用于用户资产地址展示。
 

--- a/docs/sdk/pro2-field-migration.md
+++ b/docs/sdk/pro2-field-migration.md
@@ -302,7 +302,7 @@ DeviceSessionGet({ session_id, btc_test_address }) -> DeviceSession
 | ------------------------------------- | -------------------------------- | --------------------------------------------------------------------- |
 | `DeviceSessionGet.session_id`         | 尝试恢复之前的钱包 Session       | Core 内部传入当前钱包缓存值                                           |
 | `DeviceSessionGet.btc_test_address`   | 请求恢复的预期钱包身份           | 从内部 `passphraseState` 映射，和缓存 Session 一起发送                |
-| `DeviceSessionAskPassphrase.seed_domains` | 本次需要生成的种子域         | 开钱包 / 非 Cardano 为 `[Standard]`；Cardano 为 `[Standard, Cardano]`。Get 不携带该字段。`DeviceSession` 响应用同一枚举回报已生成的域 |
+| `DeviceSessionAskPassphrase.seed_domains` | 本次需要生成的种子域         | 开钱包 / 非 Cardano 为 `[Standard]`；Cardano 为 `[Standard, Cardano]`。`DeviceSessionGet` 使用同一套字段；Attach PIN 只走 Get。`DeviceSession` 响应用同一枚举回报已生成的域 |
 | `DeviceSessionPinType`                | `Any/Main/AttachToPin` PIN 路由  | 标准钱包固定 `Main`，Attach 选择固定对应类型                          |
 | `DeviceSessionAskPassphrase`          | 创建 Passphrase 隐藏钱包会话     | Host：`{ passphrase, on_device: false, seed_domains }`；设备：`{ on_device: true, seed_domains }` |
 | 响应 `session_id`                     | 当前钱包 Session ID              | 保存到当前钱包缓存                                                    |

--- a/docs/sdk/pro2-field-migration.md
+++ b/docs/sdk/pro2-field-migration.md
@@ -84,12 +84,12 @@ DeviceInfo
 
 ### 5.2 硬件信息
 
-| Protocol V2 字段              | 含义                | SDK 当前处理                           |
-| ----------------------------- | ------------------- | -------------------------------------- |
+| Protocol V2 字段              | 含义                | SDK 当前处理                             |
+| ----------------------------- | ------------------- | ---------------------------------------- |
 | `hw.Device_type`              | 设备型号            | SDK 按协议枚举识别 Pro 2、Neo 等真实型号 |
-| `hw.serial_no`                | 设备序列号          | 转换为 `DeviceState.identity.serialNo` |
-| `hw.hardware_version`         | 可读硬件版本        | 保留在原始 Protocol V2 数据中          |
-| `hw.hardware_version_raw_adc` | 硬件版本 ADC 原始值 | 保留在原始数据中                       |
+| `hw.serial_no`                | 设备序列号          | 转换为 `DeviceState.identity.serialNo`   |
+| `hw.hardware_version`         | 可读硬件版本        | 保留在原始 Protocol V2 数据中            |
+| `hw.hardware_version_raw_adc` | 硬件版本 ADC 原始值 | 保留在原始数据中                         |
 
 序列号和设备 ID 是两个不同概念：
 
@@ -150,12 +150,12 @@ Pro 2 最多提供 `se1` 至 `se4` 四组安全芯片信息。每组可以包含
 
 SDK 当前使用的典型范围：
 
-| 场景        | 读取内容                                           | 原因                         |
-| ----------- | -------------------------------------------------- | ---------------------------- |
+| 场景        | 读取内容                                           | 原因                                         |
+| ----------- | -------------------------------------------------- | -------------------------------------------- |
 | 初始化      | hw、fw、coprocessor；version、specific             | 建立静态信息，结合 ProtocolInfo 识别运行阶段 |
-| 轻量刷新    | hw、fw、coprocessor；version、specific             | 刷新静态信息，不隐式读取状态 |
-| versions    | hw、fw、coprocessor、se1 至 se4；version、specific | 展示所有组件版本             |
-| verify/full | 所有 target；version、build_id、hash、specific     | 设备完整校验                 |
+| 轻量刷新    | hw、fw、coprocessor；version、specific             | 刷新静态信息，不隐式读取状态                 |
+| versions    | hw、fw、coprocessor、se1 至 se4；version、specific | 展示所有组件版本                             |
+| verify/full | 所有 target；version、build_id、hash、specific     | 设备完整校验                                 |
 
 ## 6. 设备实时状态
 
@@ -291,22 +291,25 @@ label、语言、蓝牙开关、自动锁屏和振动反馈都属于用户配置
 钱包会话通过以下消息建立或恢复：
 
 ```text
-DeviceSessionAskPassphrase({ seed_domains }) -> Success -> DeviceSessionGet -> DeviceSession
-DeviceSessionAskPin(Main/AttachToPin) -> Success -> DeviceSessionGet -> DeviceSession
+DeviceSessionAskPassphrase({ seed_domains }) -> Success -> DeviceSessionGet() -> DeviceSession
+DeviceSessionAskPin(Main/AttachToPin) -> Success -> DeviceSessionGet() -> DeviceSession
+DeviceSessionAskPin(AttachToPin) -> Success
+  -> DeviceSessionAskPassphrase({ passphrase: '', on_device: false, seed_domains: [Standard, Cardano] })
+  -> Success -> DeviceSessionGet() -> DeviceSession
 DeviceSessionGet({ session_id, btc_test_address }) -> DeviceSession
 ```
 
 ### 8.1 字段说明
 
-| Protocol V2 字段/消息                 | 含义                             | SDK 当前处理                                                          |
-| ------------------------------------- | -------------------------------- | --------------------------------------------------------------------- |
-| `DeviceSessionGet.session_id`         | 尝试恢复之前的钱包 Session       | Core 内部传入当前钱包缓存值                                           |
-| `DeviceSessionGet.btc_test_address`   | 请求恢复的预期钱包身份           | 从内部 `passphraseState` 映射，和缓存 Session 一起发送                |
-| `DeviceSessionAskPassphrase.seed_domains` | 本次需要生成的种子域         | 开钱包 / 非 Cardano 为 `[Standard]`；Cardano 为 `[Standard, Cardano]`。`DeviceSessionGet` 使用同一套字段；Attach PIN 只走 Get。`DeviceSession` 响应用同一枚举回报已生成的域 |
-| `DeviceSessionPinType`                | `Any/Main/AttachToPin` PIN 路由  | 标准钱包固定 `Main`，Attach 选择固定对应类型                          |
-| `DeviceSessionAskPassphrase`          | 创建 Passphrase 隐藏钱包会话     | Host：`{ passphrase, on_device: false, seed_domains }`；设备：`{ on_device: true, seed_domains }` |
-| 响应 `session_id`                     | 当前钱包 Session ID              | 保存到当前钱包缓存                                                    |
-| 响应 `DeviceSession.btc_test_address` | 用于确认当前钱包上下文的稳定标识 | 映射为内部 `passphraseState`                                          |
+| Protocol V2 字段/消息                     | 含义                             | SDK 当前处理                                                                                                                                                                        |
+| ----------------------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DeviceSessionGet.session_id`             | 尝试恢复之前的钱包 Session       | Core 内部传入当前钱包缓存值                                                                                                                                                         |
+| `DeviceSessionGet.btc_test_address`       | 请求恢复的预期钱包身份           | 从内部 `passphraseState` 映射，和缓存 Session 一起发送                                                                                                                              |
+| `DeviceSessionAskPassphrase.seed_domains` | 本次需要生成的种子域             | 开钱包 / 非 Cardano 为 `[Standard]`；Cardano 为 `[Standard, Cardano]`。Get 不携带该字段。Attach PIN 补 Cardano 发送空 Host passphrase。`DeviceSession` 响应用同一枚举回报已生成的域 |
+| `DeviceSessionPinType`                    | `Any/Main/AttachToPin` PIN 路由  | 标准钱包固定 `Main`，Attach 选择固定对应类型                                                                                                                                        |
+| `DeviceSessionAskPassphrase`              | 创建 Passphrase 隐藏钱包会话     | Host：`{ passphrase, on_device: false, seed_domains }`；设备：`{ on_device: true, seed_domains }`                                                                                   |
+| 响应 `session_id`                         | 当前钱包 Session ID              | 保存到当前钱包缓存                                                                                                                                                                  |
+| 响应 `DeviceSession.btc_test_address`     | 用于确认当前钱包上下文的稳定标识 | 映射为内部 `passphraseState`                                                                                                                                                        |
 
 这里的 `btc_test_address` 用于确认当前打开的是不是预期钱包，不用于用户资产地址展示。
 

--- a/docs/sdk/pro2-field-migration.md
+++ b/docs/sdk/pro2-field-migration.md
@@ -293,23 +293,20 @@ label、语言、蓝牙开关、自动锁屏和振动反馈都属于用户配置
 ```text
 DeviceSessionAskPassphrase({ seed_domains }) -> Success -> DeviceSessionGet() -> DeviceSession
 DeviceSessionAskPin(Main/AttachToPin) -> Success -> DeviceSessionGet() -> DeviceSession
-DeviceSessionAskPin(AttachToPin) -> Success
-  -> DeviceSessionAskPassphrase({ passphrase: '', on_device: false, seed_domains: [Standard, Cardano] })
-  -> Success -> DeviceSessionGet() -> DeviceSession
 DeviceSessionGet({ session_id, btc_test_address }) -> DeviceSession
 ```
 
 ### 8.1 字段说明
 
-| Protocol V2 字段/消息                     | 含义                             | SDK 当前处理                                                                                                                                                                        |
-| ----------------------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DeviceSessionGet.session_id`             | 尝试恢复之前的钱包 Session       | Core 内部传入当前钱包缓存值                                                                                                                                                         |
-| `DeviceSessionGet.btc_test_address`       | 请求恢复的预期钱包身份           | 从内部 `passphraseState` 映射，和缓存 Session 一起发送                                                                                                                              |
-| `DeviceSessionAskPassphrase.seed_domains` | 本次需要生成的种子域             | 开钱包 / 非 Cardano 为 `[Standard]`；Cardano 为 `[Standard, Cardano]`。Get 不携带该字段。Attach PIN 补 Cardano 发送空 Host passphrase。`DeviceSession` 响应用同一枚举回报已生成的域 |
-| `DeviceSessionPinType`                    | `Any/Main/AttachToPin` PIN 路由  | 标准钱包固定 `Main`，Attach 选择固定对应类型                                                                                                                                        |
-| `DeviceSessionAskPassphrase`              | 创建 Passphrase 隐藏钱包会话     | Host：`{ passphrase, on_device: false, seed_domains }`；设备：`{ on_device: true, seed_domains }`                                                                                   |
-| 响应 `session_id`                         | 当前钱包 Session ID              | 保存到当前钱包缓存                                                                                                                                                                  |
-| 响应 `DeviceSession.btc_test_address`     | 用于确认当前钱包上下文的稳定标识 | 映射为内部 `passphraseState`                                                                                                                                                        |
+| Protocol V2 字段/消息                     | 含义                             | SDK 当前处理                                                                                                                                                               |
+| ----------------------------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DeviceSessionGet.session_id`             | 尝试恢复之前的钱包 Session       | Core 内部传入当前钱包缓存值                                                                                                                                                |
+| `DeviceSessionGet.btc_test_address`       | 请求恢复的预期钱包身份           | 从内部 `passphraseState` 映射，和缓存 Session 一起发送                                                                                                                     |
+| `DeviceSessionAskPassphrase.seed_domains` | 本次需要生成的种子域             | 开钱包 / 非 Cardano 为 `[Standard]`；Cardano 为 `[Standard, Cardano]`。Get 不携带该字段。Attach PIN 会话不发送 AskPassphrase。`DeviceSession` 响应用同一枚举回报已生成的域 |
+| `DeviceSessionPinType`                    | `Any/Main/AttachToPin` PIN 路由  | 标准钱包固定 `Main`，Attach 选择固定对应类型                                                                                                                               |
+| `DeviceSessionAskPassphrase`              | 创建 Passphrase 隐藏钱包会话     | Host：`{ passphrase, on_device: false, seed_domains }`；设备：`{ on_device: true, seed_domains }`                                                                          |
+| 响应 `session_id`                         | 当前钱包 Session ID              | 保存到当前钱包缓存                                                                                                                                                         |
+| 响应 `DeviceSession.btc_test_address`     | 用于确认当前钱包上下文的稳定标识 | 映射为内部 `passphraseState`                                                                                                                                               |
 
 这里的 `btc_test_address` 用于确认当前打开的是不是预期钱包，不用于用户资产地址展示。
 

--- a/docs/sdk/pro2-field-migration.md
+++ b/docs/sdk/pro2-field-migration.md
@@ -302,7 +302,7 @@ DeviceSessionGet({ session_id, btc_test_address }) -> DeviceSession
 | ------------------------------------- | -------------------------------- | --------------------------------------------------------------------- |
 | `DeviceSessionGet.session_id`         | 尝试恢复之前的钱包 Session       | Core 内部传入当前钱包缓存值                                           |
 | `DeviceSessionGet.btc_test_address`   | 请求恢复的预期钱包身份           | 从内部 `passphraseState` 映射，和缓存 Session 一起发送                |
-| `DeviceSessionAskPassphrase.seed_domains` | 本次需要派生的 Seed 域       | Cardano 意图为 `[Standard, Cardano]`；开钱包 / 非 Cardano / `false` 均为空列表，固件默认派生全部域。不得映射成仅 `[Standard]` |
+| `DeviceSessionAskPassphrase.seed_domains` | 本次需要生成的种子域         | 开钱包 / 非 Cardano 为 `[Standard]`；Cardano 为 `[Standard, Cardano]`。Get 不携带该字段。`DeviceSession` 响应用同一枚举回报已生成的域 |
 | `DeviceSessionPinType`                | `Any/Main/AttachToPin` PIN 路由  | 标准钱包固定 `Main`，Attach 选择固定对应类型                          |
 | `DeviceSessionAskPassphrase`          | 创建 Passphrase 隐藏钱包会话     | Host：`{ passphrase, on_device: false, seed_domains }`；设备：`{ on_device: true, seed_domains }` |
 | 响应 `session_id`                     | 当前钱包 Session ID              | 保存到当前钱包缓存                                                    |

--- a/docs/sdk/pro2-field-migration.md
+++ b/docs/sdk/pro2-field-migration.md
@@ -302,7 +302,7 @@ DeviceSessionGet({ session_id, btc_test_address }) -> DeviceSession
 | ------------------------------------- | -------------------------------- | --------------------------------------------------------------------- |
 | `DeviceSessionGet.session_id`         | 尝试恢复之前的钱包 Session       | Core 内部传入当前钱包缓存值                                           |
 | `DeviceSessionGet.btc_test_address`   | 请求恢复的预期钱包身份           | 从内部 `passphraseState` 映射，和缓存 Session 一起发送                |
-| `DeviceSessionAskPassphrase.seed_domains` | 本次需要派生的 Seed 域       | 普通业务为 `[Standard]`，Cardano 为 `[Standard, Cardano]`；省略则派生全部域 |
+| `DeviceSessionAskPassphrase.seed_domains` | 本次需要派生的 Seed 域       | Cardano 意图为 `[Standard, Cardano]`；开钱包 / 非 Cardano / `false` 均为空列表，固件默认派生全部域。不得映射成仅 `[Standard]` |
 | `DeviceSessionPinType`                | `Any/Main/AttachToPin` PIN 路由  | 标准钱包固定 `Main`，Attach 选择固定对应类型                          |
 | `DeviceSessionAskPassphrase`          | 创建 Passphrase 隐藏钱包会话     | Host：`{ passphrase, on_device: false, seed_domains }`；设备：`{ on_device: true, seed_domains }` |
 | 响应 `session_id`                     | 当前钱包 Session ID              | 保存到当前钱包缓存                                                    |

--- a/docs/sdk/pro2-field-migration.md
+++ b/docs/sdk/pro2-field-migration.md
@@ -291,9 +291,9 @@ label、语言、蓝牙开关、自动锁屏和振动反馈都属于用户配置
 钱包会话通过以下消息建立或恢复：
 
 ```text
-DeviceSessionAskPassphrase -> Success -> DeviceSessionGet -> DeviceSession
+DeviceSessionAskPassphrase({ seed_domains }) -> Success -> DeviceSessionGet -> DeviceSession
 DeviceSessionAskPin(Main/AttachToPin) -> Success -> DeviceSessionGet -> DeviceSession
-DeviceSessionGet({ session_id, btc_test_address, seed_domains }) -> DeviceSession
+DeviceSessionGet({ session_id, btc_test_address }) -> DeviceSession
 ```
 
 ### 8.1 字段说明
@@ -302,9 +302,9 @@ DeviceSessionGet({ session_id, btc_test_address, seed_domains }) -> DeviceSessio
 | ------------------------------------- | -------------------------------- | --------------------------------------------------------------------- |
 | `DeviceSessionGet.session_id`         | 尝试恢复之前的钱包 Session       | Core 内部传入当前钱包缓存值                                           |
 | `DeviceSessionGet.btc_test_address`   | 请求恢复的预期钱包身份           | 从内部 `passphraseState` 映射，和缓存 Session 一起发送                |
-| `DeviceSessionGet.seed_domains`       | 本次需要派生的 Seed 域           | 普通业务为 `[Standard]`，Cardano 为 `[Standard, Cardano]`             |
+| `DeviceSessionAskPassphrase.seed_domains` | 本次需要派生的 Seed 域       | 普通业务为 `[Standard]`，Cardano 为 `[Standard, Cardano]`；省略则派生全部域 |
 | `DeviceSessionPinType`                | `Any/Main/AttachToPin` PIN 路由  | 标准钱包固定 `Main`，Attach 选择固定对应类型                          |
-| `DeviceSessionAskPassphrase`          | 创建 Passphrase 隐藏钱包会话     | Host：`{ passphrase, on_device: false }`；设备：`{ on_device: true }` |
+| `DeviceSessionAskPassphrase`          | 创建 Passphrase 隐藏钱包会话     | Host：`{ passphrase, on_device: false, seed_domains }`；设备：`{ on_device: true, seed_domains }` |
 | 响应 `session_id`                     | 当前钱包 Session ID              | 保存到当前钱包缓存                                                    |
 | 响应 `DeviceSession.btc_test_address` | 用于确认当前钱包上下文的稳定标识 | 映射为内部 `passphraseState`                                          |
 
@@ -314,7 +314,7 @@ DeviceSessionGet({ session_id, btc_test_address, seed_domains }) -> DeviceSessio
 
 ```text
 读取当前隐藏钱包缓存 session_id
-    -> DeviceSessionGet({ session_id, btc_test_address, seed_domains })
+    -> DeviceSessionGet({ session_id, btc_test_address })
     -> 返回 DeviceSession
     -> 校验 btc_test_address 是否符合预期钱包
 ```

--- a/packages/connect-examples/electron-example/package.json
+++ b/packages/connect-examples/electron-example/package.json
@@ -2,7 +2,7 @@
   "name": "hardware-example",
   "productName": "HardwareExample",
   "executableName": "onekey-hardware-example",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "author": "OneKey",
   "description": "OneKey Hardware SDK Electron BLE example",
   "main": "dist/index.js",

--- a/packages/connect-examples/electron-example/package.json
+++ b/packages/connect-examples/electron-example/package.json
@@ -2,7 +2,7 @@
   "name": "hardware-example",
   "productName": "HardwareExample",
   "executableName": "onekey-hardware-example",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "author": "OneKey",
   "description": "OneKey Hardware SDK Electron BLE example",
   "main": "dist/index.js",

--- a/packages/connect-examples/electron-example/package.json
+++ b/packages/connect-examples/electron-example/package.json
@@ -2,7 +2,7 @@
   "name": "hardware-example",
   "productName": "HardwareExample",
   "executableName": "onekey-hardware-example",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "author": "OneKey",
   "description": "OneKey Hardware SDK Electron BLE example",
   "main": "dist/index.js",

--- a/packages/connect-examples/electron-example/package.json
+++ b/packages/connect-examples/electron-example/package.json
@@ -2,7 +2,7 @@
   "name": "hardware-example",
   "productName": "HardwareExample",
   "executableName": "onekey-hardware-example",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "author": "OneKey",
   "description": "OneKey Hardware SDK Electron BLE example",
   "main": "dist/index.js",

--- a/packages/connect-examples/electron-example/package.json
+++ b/packages/connect-examples/electron-example/package.json
@@ -2,7 +2,7 @@
   "name": "hardware-example",
   "productName": "HardwareExample",
   "executableName": "onekey-hardware-example",
-  "version": "1.2.2-alpha.0",
+  "version": "1.2.2-alpha.2",
   "author": "OneKey",
   "description": "OneKey Hardware SDK Electron BLE example",
   "main": "dist/index.js",

--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "scripts": {
     "start": "yarn expo start --dev-client",
     "android": "yarn expo run:android",

--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "scripts": {
     "start": "yarn expo start --dev-client",
     "android": "yarn expo run:android",

--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.2.2-alpha.0",
+  "version": "1.2.2-alpha.2",
   "scripts": {
     "start": "yarn expo start --dev-client",
     "android": "yarn expo run:android",

--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "scripts": {
     "start": "yarn expo start --dev-client",
     "android": "yarn expo run:android",

--- a/packages/connect-examples/expo-example/package.json
+++ b/packages/connect-examples/expo-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-example",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "scripts": {
     "start": "yarn expo start --dev-client",
     "android": "yarn expo run:android",

--- a/packages/connect-examples/expo-playground/package.json
+++ b/packages/connect-examples/expo-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onekey-hardware-playground",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "private": true,
   "sideEffects": [
     "app/utils/shim.js",

--- a/packages/connect-examples/expo-playground/package.json
+++ b/packages/connect-examples/expo-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onekey-hardware-playground",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "private": true,
   "sideEffects": [
     "app/utils/shim.js",

--- a/packages/connect-examples/expo-playground/package.json
+++ b/packages/connect-examples/expo-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onekey-hardware-playground",
-  "version": "1.2.2-alpha.0",
+  "version": "1.2.2-alpha.2",
   "private": true,
   "sideEffects": [
     "app/utils/shim.js",

--- a/packages/connect-examples/expo-playground/package.json
+++ b/packages/connect-examples/expo-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onekey-hardware-playground",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "private": true,
   "sideEffects": [
     "app/utils/shim.js",

--- a/packages/connect-examples/expo-playground/package.json
+++ b/packages/connect-examples/expo-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onekey-hardware-playground",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "private": true,
   "sideEffects": [
     "app/utils/shim.js",

--- a/packages/connect-examples/hwk-demo/package.json
+++ b/packages/connect-examples/hwk-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hwk-demo",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/packages/connect-examples/hwk-demo/package.json
+++ b/packages/connect-examples/hwk-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hwk-demo",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/packages/connect-examples/hwk-demo/package.json
+++ b/packages/connect-examples/hwk-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hwk-demo",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/packages/connect-examples/hwk-demo/package.json
+++ b/packages/connect-examples/hwk-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hwk-demo",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/packages/connect-examples/hwk-demo/package.json
+++ b/packages/connect-examples/hwk-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hwk-demo",
-  "version": "1.2.2-alpha.0",
+  "version": "1.2.2-alpha.2",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/packages/core/__tests__/AllNetworkGetAddressBase.tracing.test.ts
+++ b/packages/core/__tests__/AllNetworkGetAddressBase.tracing.test.ts
@@ -95,7 +95,7 @@ describe('AllNetworkGetAddressBase tracing', () => {
       'hidden-state',
       false,
       undefined,
-      false,
+      undefined,
       undefined
     );
     expect(calls).toEqual(['resume-hidden-session', 'run-chain-method']);
@@ -264,7 +264,7 @@ describe('AllNetworkGetAddressBase tracing', () => {
       undefined,
       true,
       undefined,
-      false,
+      undefined,
       true
     );
     expect(calls).toEqual(['resume-standard-session', 'run-chain-method']);

--- a/packages/core/__tests__/open-wallet-session.test.ts
+++ b/packages/core/__tests__/open-wallet-session.test.ts
@@ -702,10 +702,21 @@ describe('openWalletSession', () => {
     );
   });
 
-  test('locks before selecting a new hidden wallet from an Attach PIN session', async () => {
+  test('reuses the current Attach PIN session without reopening wallet selection', async () => {
     const typedCall = jest.fn((request: string) => {
       if (request === 'ProtocolInfoRequest') {
         return { message: { version: 2 } };
+      }
+      if (request === 'DeviceSessionAskPassphrase') {
+        return { message: {} };
+      }
+      if (request === 'DeviceSessionGet') {
+        return {
+          message: {
+            btc_test_address: 'attach-state',
+            session_id: 'attach-session',
+          },
+        };
       }
       throw new Error(`Unexpected request: ${request}`);
     });
@@ -721,10 +732,66 @@ describe('openWalletSession', () => {
     });
     method.device = device as any;
 
+    await expect(method.run()).resolves.toEqual({
+      protocol: 'V2',
+      walletType: 'hidden',
+      deviceId: 'device-1',
+      passphraseState: 'attach-state',
+      resumed: false,
+    });
+    expect(promptPassphrase).not.toHaveBeenCalled();
+    expect(device.unlockDevice).not.toHaveBeenCalled();
+    expect(device.commands.typedCall).toHaveBeenCalledWith(
+      'DeviceSessionGet',
+      'DeviceSession',
+      standardSessionGet
+    );
+    expect(device.commands.typedCall).not.toHaveBeenCalledWith(
+      'DeviceSessionAskPassphrase',
+      'Success',
+      expect.anything()
+    );
+    expect(device.commands.typedCall).not.toHaveBeenCalledWith(
+      'DeviceSessionAskPin',
+      'Success',
+      expect.anything()
+    );
+  });
+
+  test('fails closed when the Attach PIN state changes before reading the current session', async () => {
+    const typedCall = jest.fn((request: string) => {
+      if (request === 'ProtocolInfoRequest') {
+        return { message: { version: 2 } };
+      }
+      if (request === 'DeviceSessionAskPassphrase') {
+        return { message: {} };
+      }
+      if (request === 'DeviceSessionGet') {
+        return {
+          message: {
+            btc_test_address: 'unexpected-state',
+            session_id: 'unexpected-session',
+          },
+        };
+      }
+      throw new Error(`Unexpected request: ${request}`);
+    });
+    const promptPassphrase = jest.fn().mockResolvedValue({ passphrase: 'must not be requested' });
+    const method = new OpenWalletSession({
+      payload: { method: 'openWalletSession', connectId: 'connect-id', mode: 'select-hidden' },
+    });
+    method.init();
+    const device = createDevice({
+      typedCall,
+      promptPassphrase,
+      unlockedAttachPin: true,
+      refreshedUnlockedAttachPin: false,
+    });
+    method.device = device as any;
+
     await expect(method.run()).rejects.toMatchObject({
       errorCode: HardwareErrorCode.DeviceCheckUnlockTypeError,
     });
-    expect(device.lockDevice).toHaveBeenCalled();
     expect(device.clearInternalState).toHaveBeenCalled();
     expect(promptPassphrase).not.toHaveBeenCalled();
     expect(device.commands.typedCall).not.toHaveBeenCalledWith(

--- a/packages/core/__tests__/open-wallet-session.test.ts
+++ b/packages/core/__tests__/open-wallet-session.test.ts
@@ -1,6 +1,14 @@
 import { EDeviceType, HardwareErrorCode } from '@onekeyfe/hd-shared';
 import { DeviceSessionPinType, DeviceSessionSeedDomain } from '@onekeyfe/hd-transport';
 
+const STANDARD_SEED_DOMAINS = [DeviceSessionSeedDomain.SeedDomain_Standard];
+const CARDANO_SEED_DOMAINS = [
+  DeviceSessionSeedDomain.SeedDomain_Standard,
+  DeviceSessionSeedDomain.SeedDomain_Cardano,
+];
+const standardSessionGet = { seed_domains: STANDARD_SEED_DOMAINS };
+const cardanoSessionGet = { seed_domains: CARDANO_SEED_DOMAINS };
+
 import GetPassphraseState from '../src/api/GetPassphraseState';
 import OpenWalletSession from '../src/api/OpenWalletSession';
 import { Device } from '../src/device/Device';
@@ -144,7 +152,7 @@ describe('openWalletSession', () => {
       on_device: false,
       seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', standardSessionGet);
   });
 
   test('selects the Main PIN before opening the standard wallet when passphrase is disabled', async () => {
@@ -176,7 +184,7 @@ describe('openWalletSession', () => {
       'Success',
       expect.anything()
     );
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', standardSessionGet);
   });
 
   test('reuses a Main PIN selected by the current preflight when passphrase is disabled', async () => {
@@ -202,7 +210,7 @@ describe('openWalletSession', () => {
     });
 
     expect(device.unlockDevice).not.toHaveBeenCalled();
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', standardSessionGet);
   });
 
   test('does not treat an Attach PIN DeviceStatus as the Main wallet', async () => {
@@ -331,7 +339,12 @@ describe('openWalletSession', () => {
       on_device: false,
       seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
-    expect(typedCall).toHaveBeenNthCalledWith(3, 'DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenNthCalledWith(
+      3,
+      'DeviceSessionGet',
+      'DeviceSession',
+      standardSessionGet
+    );
   });
 
   test('keeps Legacy Protocol V1 getPassphraseState parameterless', async () => {
@@ -450,7 +463,12 @@ describe('openWalletSession', () => {
       on_device: false,
       seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
-    expect(typedCall).toHaveBeenNthCalledWith(3, 'DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenNthCalledWith(
+      3,
+      'DeviceSessionGet',
+      'DeviceSession',
+      standardSessionGet
+    );
   });
 
   test('refreshes Pro2 status and unlocks before selecting a hidden wallet when locked', async () => {
@@ -724,7 +742,11 @@ describe('openWalletSession', () => {
     });
     expect(promptPassphrase).not.toHaveBeenCalled();
     expect(device.unlockDevice).not.toHaveBeenCalled();
-    expect(device.commands.typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(device.commands.typedCall).toHaveBeenCalledWith(
+      'DeviceSessionGet',
+      'DeviceSession',
+      standardSessionGet
+    );
     expect(device.commands.typedCall).not.toHaveBeenCalledWith(
       'DeviceSessionAskPassphrase',
       'Success',
@@ -822,7 +844,7 @@ describe('openWalletSession', () => {
       on_device: false,
       seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', standardSessionGet);
     expect(promptPassphrase).toHaveBeenCalled();
     expect(deviceWalletSessionStore.get('device-1', 'new-hidden-state')).toBe('new-hidden-session');
   });
@@ -894,6 +916,7 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       session_id: 'known-session',
       btc_test_address: 'hidden-state',
+      ...standardSessionGet,
     });
     expect(promptPassphrase).not.toHaveBeenCalled();
   });
@@ -1078,7 +1101,7 @@ describe('openWalletSession', () => {
       on_device: false,
       seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', standardSessionGet);
     expect(promptPassphrase).not.toHaveBeenCalled();
     expect(device.passphraseState).toBeUndefined();
   });
@@ -1247,7 +1270,7 @@ describe('openWalletSession', () => {
       reason: 'open-wallet',
       deviceOnly: true,
     });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', standardSessionGet);
   });
 
   test('selects a hidden wallet without exposing the internal device session', async () => {
@@ -1282,7 +1305,7 @@ describe('openWalletSession', () => {
       on_device: false,
       seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', standardSessionGet);
     expect(promptPassphrase).toHaveBeenCalled();
     expect(device.passphraseState).toBeUndefined();
     expect(deviceWalletSessionStore.get('device-1', 'hidden-state')).toBe('hidden-session');
@@ -1343,7 +1366,7 @@ describe('openWalletSession', () => {
       on_device: false,
       seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', standardSessionGet);
   });
 
   test('selects an on-device passphrase wallet with an explicit on_device request', async () => {
@@ -1390,7 +1413,12 @@ describe('openWalletSession', () => {
       on_device: true,
       seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
-    expect(typedCall).toHaveBeenNthCalledWith(3, 'DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenNthCalledWith(
+      3,
+      'DeviceSessionGet',
+      'DeviceSession',
+      standardSessionGet
+    );
     expect(device.createProtocolV2UiPhaseMetadata).toHaveBeenNthCalledWith(
       2,
       'passphrase-on-device',
@@ -1443,7 +1471,12 @@ describe('openWalletSession', () => {
       on_device: false,
       seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
-    expect(typedCall).toHaveBeenNthCalledWith(3, 'DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenNthCalledWith(
+      3,
+      'DeviceSessionGet',
+      'DeviceSession',
+      standardSessionGet
+    );
   });
 
   test('normalizes a Unicode Host passphrase before sending it to Pro2 firmware', async () => {
@@ -1525,7 +1558,7 @@ describe('openWalletSession', () => {
     expect(device.unlockDevice).toHaveBeenCalledWith(DeviceSessionPinType.AttachToPin, {
       emitUiEvent: false,
     });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', standardSessionGet);
   });
 
   test('uses the complete Attach PIN wire flow without a main PIN unlock', async () => {
@@ -1554,7 +1587,7 @@ describe('openWalletSession', () => {
       ['ProtocolInfoRequest', 'ProtocolInfo', { eventless_wallet_session: true }],
       ['DeviceSessionAskPin', 'Success', { type: DeviceSessionPinType.AttachToPin }],
       ['DeviceStatusGet', 'DeviceStatus', {}],
-      ['DeviceSessionGet', 'DeviceSession', {}],
+      ['DeviceSessionGet', 'DeviceSession', standardSessionGet],
     ]);
     expect(device.commands.typedCall).not.toHaveBeenCalledWith('DeviceSessionAskPin', 'Success', {
       type: DeviceSessionPinType.Main,
@@ -1766,6 +1799,7 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       session_id: 'known-session',
       btc_test_address: 'hidden-state',
+      ...standardSessionGet,
     });
     expect(promptPassphrase).not.toHaveBeenCalled();
   });
@@ -1825,6 +1859,7 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       session_id: 'known-session',
       btc_test_address: 'hidden-state',
+      ...standardSessionGet,
     });
     const sessionGetCall = typedCall.mock.calls.findIndex(
       ([requestName]) => requestName === 'DeviceSessionGet'
@@ -1922,6 +1957,7 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       session_id: 'expired-session',
       btc_test_address: 'hidden-state',
+      ...standardSessionGet,
     });
     expect(promptPassphrase).toHaveBeenCalledTimes(1);
     expect(deviceWalletSessionStore.get('device-1', 'hidden-state')).toBe('renewed-session');
@@ -1959,6 +1995,7 @@ describe('openWalletSession', () => {
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       btc_test_address: 'hidden-state',
+      ...standardSessionGet,
     });
     expect(promptPassphrase).not.toHaveBeenCalled();
     expect(deviceWalletSessionStore.get('device-1', 'hidden-state')).toBe('new-session');
@@ -2000,7 +2037,11 @@ describe('openWalletSession', () => {
         on_device: false,
         seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
       });
-      expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+      expect(typedCall).toHaveBeenCalledWith(
+        'DeviceSessionGet',
+        'DeviceSession',
+        standardSessionGet
+      );
     }
   );
 
@@ -2043,11 +2084,9 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-      seed_domains: [
-        DeviceSessionSeedDomain.SeedDomain_Standard,
-        DeviceSessionSeedDomain.SeedDomain_Cardano,
-      ],
+      seed_domains: CARDANO_SEED_DOMAINS,
     });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', cardanoSessionGet);
   });
 
   test('asks Cardano seed domains after Get reports a Standard-only session', async () => {
@@ -2095,6 +2134,7 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       session_id: 'cached-session',
       btc_test_address: 'hidden-state',
+      ...cardanoSessionGet,
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
@@ -2116,7 +2156,7 @@ describe('openWalletSession', () => {
           message: {
             btc_test_address: 'attach-state',
             session_id: 'attach-session',
-            seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
+            seed_domains: CARDANO_SEED_DOMAINS,
           },
         };
       }
@@ -2144,7 +2184,7 @@ describe('openWalletSession', () => {
       'Success',
       expect.anything()
     );
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', cardanoSessionGet);
   });
 
   test('does not AskPassphrase after selecting Attach PIN for Cardano intent', async () => {
@@ -2157,7 +2197,7 @@ describe('openWalletSession', () => {
           message: {
             btc_test_address: 'attach-state',
             session_id: 'attach-session',
-            seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
+            seed_domains: CARDANO_SEED_DOMAINS,
           },
         };
       }
@@ -2185,6 +2225,45 @@ describe('openWalletSession', () => {
     expect(device.unlockDevice).toHaveBeenCalledWith(
       DeviceSessionPinType.AttachToPin,
       expect.objectContaining({ emitUiEvent: false })
+    );
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', cardanoSessionGet);
+  });
+
+  test('locks before selecting a passphrase wallet from an Attach PIN session', async () => {
+    const typedCall = jest.fn((request: string) => {
+      if (request === 'ProtocolInfoRequest') {
+        return { message: { version: 2 } };
+      }
+      if (request === 'DeviceStatusGet') {
+        return {
+          message: {
+            device_id: 'device-1',
+            unlocked: true,
+            passphrase_enabled: true,
+            unlocked_by_attach_to_pin: true,
+          },
+        };
+      }
+      throw new Error(`Unexpected request: ${request}`);
+    });
+    const promptPassphrase = jest.fn().mockResolvedValue({ passphrase: 'should-not-ask' });
+    const device = createDevice({
+      typedCall,
+      promptPassphrase,
+      unlockedAttachPin: true,
+    });
+
+    await expect(
+      getProtocolV2WalletSession(device as any, { forceWalletSelection: true })
+    ).rejects.toMatchObject({
+      errorCode: HardwareErrorCode.DeviceCheckUnlockTypeError,
+    });
+    expect(device.lockDevice).toHaveBeenCalled();
+    expect(promptPassphrase).not.toHaveBeenCalled();
+    expect(typedCall).not.toHaveBeenCalledWith(
+      'DeviceSessionAskPassphrase',
+      'Success',
+      expect.anything()
     );
   });
 

--- a/packages/core/__tests__/open-wallet-session.test.ts
+++ b/packages/core/__tests__/open-wallet-session.test.ts
@@ -2134,8 +2134,9 @@ describe('openWalletSession', () => {
         readCurrentAttachPinSession: true,
         deriveCardano: true,
       })
-    ).rejects.toMatchObject({
-      errorCode: HardwareErrorCode.WalletSessionInvalid,
+    ).resolves.toMatchObject({
+      passphraseState: 'attach-state',
+      newSession: 'attach-session',
     });
     expect(promptPassphrase).not.toHaveBeenCalled();
     expect(typedCall).not.toHaveBeenCalledWith(
@@ -2171,8 +2172,9 @@ describe('openWalletSession', () => {
         forceWalletSelection: true,
         deriveCardano: true,
       })
-    ).rejects.toMatchObject({
-      errorCode: HardwareErrorCode.WalletSessionInvalid,
+    ).resolves.toMatchObject({
+      passphraseState: 'attach-state',
+      newSession: 'attach-session',
     });
     expect(promptPassphrase).toHaveBeenCalledTimes(1);
     expect(typedCall).not.toHaveBeenCalledWith(

--- a/packages/core/__tests__/open-wallet-session.test.ts
+++ b/packages/core/__tests__/open-wallet-session.test.ts
@@ -2106,6 +2106,86 @@ describe('openWalletSession', () => {
     });
   });
 
+  test('does not AskPassphrase when an Attach PIN session lacks Cardano', async () => {
+    const typedCall = jest.fn((request: string) => {
+      if (request === 'ProtocolInfoRequest') {
+        return { message: { version: 2 } };
+      }
+      if (request === 'DeviceSessionGet') {
+        return {
+          message: {
+            btc_test_address: 'attach-state',
+            session_id: 'attach-session',
+            seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
+          },
+        };
+      }
+      throw new Error(`Unexpected request: ${request}`);
+    });
+    const promptPassphrase = jest.fn().mockResolvedValue({ passphrase: 'should-not-ask' });
+    const device = createDevice({
+      typedCall,
+      promptPassphrase,
+      unlockedAttachPin: true,
+    });
+
+    await expect(
+      getProtocolV2WalletSession(device as any, {
+        readCurrentAttachPinSession: true,
+        deriveCardano: true,
+      })
+    ).rejects.toMatchObject({
+      errorCode: HardwareErrorCode.WalletSessionInvalid,
+    });
+    expect(promptPassphrase).not.toHaveBeenCalled();
+    expect(typedCall).not.toHaveBeenCalledWith(
+      'DeviceSessionAskPassphrase',
+      'Success',
+      expect.anything()
+    );
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+  });
+
+  test('does not AskPassphrase after selecting Attach PIN for Cardano intent', async () => {
+    const typedCall = jest.fn((request: string) => {
+      if (request === 'ProtocolInfoRequest') {
+        return { message: { version: 2 } };
+      }
+      if (request === 'DeviceSessionGet') {
+        return {
+          message: {
+            btc_test_address: 'attach-state',
+            session_id: 'attach-session',
+            seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
+          },
+        };
+      }
+      throw new Error(`Unexpected request: ${request}`);
+    });
+    const promptPassphrase = jest.fn().mockResolvedValue({ attachPinOnDevice: true });
+    const device = createDevice({ typedCall, promptPassphrase });
+    device.features.attachToPinEnabled = true;
+
+    await expect(
+      getProtocolV2WalletSession(device as any, {
+        forceWalletSelection: true,
+        deriveCardano: true,
+      })
+    ).rejects.toMatchObject({
+      errorCode: HardwareErrorCode.WalletSessionInvalid,
+    });
+    expect(promptPassphrase).toHaveBeenCalledTimes(1);
+    expect(typedCall).not.toHaveBeenCalledWith(
+      'DeviceSessionAskPassphrase',
+      'Success',
+      expect.anything()
+    );
+    expect(device.unlockDevice).toHaveBeenCalledWith(
+      DeviceSessionPinType.AttachToPin,
+      expect.objectContaining({ emitUiEvent: false })
+    );
+  });
+
   test('asks Standard-only seed domains when deriveCardano is false', async () => {
     const typedCall = jest.fn((request: string) => {
       if (request === 'ProtocolInfoRequest') {

--- a/packages/core/__tests__/open-wallet-session.test.ts
+++ b/packages/core/__tests__/open-wallet-session.test.ts
@@ -2144,26 +2144,17 @@ describe('openWalletSession', () => {
     });
   });
 
-  test('uses empty AskPassphrase to add Cardano on an Attach PIN session', async () => {
+  test('does not AskPassphrase when an Attach PIN session lacks Cardano', async () => {
     const typedCall = jest.fn((request: string) => {
       if (request === 'ProtocolInfoRequest') {
         return { message: { version: 2 } };
       }
-      if (request === 'DeviceSessionAskPassphrase') {
-        return { message: {} };
-      }
       if (request === 'DeviceSessionGet') {
-        const askedCardano = typedCall.mock.calls.some(
-          call =>
-            call[0] === 'DeviceSessionAskPassphrase' &&
-            Array.isArray(call[2]?.seed_domains) &&
-            call[2].seed_domains.includes(DeviceSessionSeedDomain.SeedDomain_Cardano)
-        );
         return {
           message: {
             btc_test_address: 'attach-state',
             session_id: 'attach-session',
-            seed_domains: askedCardano ? CARDANO_SEED_DOMAINS : STANDARD_SEED_DOMAINS,
+            seed_domains: STANDARD_SEED_DOMAINS,
           },
         };
       }
@@ -2186,33 +2177,25 @@ describe('openWalletSession', () => {
       newSession: 'attach-session',
     });
     expect(promptPassphrase).not.toHaveBeenCalled();
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
-      passphrase: '',
-      on_device: false,
-      seed_domains: CARDANO_SEED_DOMAINS,
-    });
+    expect(typedCall).not.toHaveBeenCalledWith(
+      'DeviceSessionAskPassphrase',
+      'Success',
+      expect.anything()
+    );
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
-    expect(
-      typedCall.mock.calls
-        .filter(call => call[0] === 'DeviceSessionGet')
-        .every(call => !('seed_domains' in (call[2] ?? {})))
-    ).toBe(true);
   });
 
-  test('uses empty AskPassphrase after selecting Attach PIN for Cardano intent', async () => {
+  test('does not AskPassphrase after selecting Attach PIN for Cardano intent', async () => {
     const typedCall = jest.fn((request: string) => {
       if (request === 'ProtocolInfoRequest') {
         return { message: { version: 2 } };
-      }
-      if (request === 'DeviceSessionAskPassphrase') {
-        return { message: {} };
       }
       if (request === 'DeviceSessionGet') {
         return {
           message: {
             btc_test_address: 'attach-state',
             session_id: 'attach-session',
-            seed_domains: CARDANO_SEED_DOMAINS,
+            seed_domains: STANDARD_SEED_DOMAINS,
           },
         };
       }
@@ -2236,17 +2219,12 @@ describe('openWalletSession', () => {
       DeviceSessionPinType.AttachToPin,
       expect.objectContaining({ emitUiEvent: false })
     );
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
-      passphrase: '',
-      on_device: false,
-      seed_domains: CARDANO_SEED_DOMAINS,
-    });
+    expect(typedCall).not.toHaveBeenCalledWith(
+      'DeviceSessionAskPassphrase',
+      'Success',
+      expect.anything()
+    );
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
-    expect(
-      typedCall.mock.calls
-        .filter(call => call[0] === 'DeviceSessionGet')
-        .every(call => !('seed_domains' in (call[2] ?? {})))
-    ).toBe(true);
   });
 
   test('uses a second Get for Cardano when passphrase protection is off', async () => {

--- a/packages/core/__tests__/open-wallet-session.test.ts
+++ b/packages/core/__tests__/open-wallet-session.test.ts
@@ -1,14 +1,6 @@
 import { EDeviceType, HardwareErrorCode } from '@onekeyfe/hd-shared';
 import { DeviceSessionPinType, DeviceSessionSeedDomain } from '@onekeyfe/hd-transport';
 
-const STANDARD_SEED_DOMAINS = [DeviceSessionSeedDomain.SeedDomain_Standard];
-const CARDANO_SEED_DOMAINS = [
-  DeviceSessionSeedDomain.SeedDomain_Standard,
-  DeviceSessionSeedDomain.SeedDomain_Cardano,
-];
-const standardSessionGet = { seed_domains: STANDARD_SEED_DOMAINS };
-const cardanoSessionGet = { seed_domains: CARDANO_SEED_DOMAINS };
-
 import GetPassphraseState from '../src/api/GetPassphraseState';
 import OpenWalletSession from '../src/api/OpenWalletSession';
 import { Device } from '../src/device/Device';
@@ -18,6 +10,13 @@ import {
   ensureProtocolV2WalletSessionUnlocked,
   getProtocolV2WalletSession,
 } from '../src/protocols/protocol-v2/walletSession';
+
+const STANDARD_SEED_DOMAINS = [DeviceSessionSeedDomain.SeedDomain_Standard];
+const CARDANO_SEED_DOMAINS = [
+  DeviceSessionSeedDomain.SeedDomain_Standard,
+  DeviceSessionSeedDomain.SeedDomain_Cardano,
+];
+const standardSessionGet = {};
 
 jest.mock('../src/data/config', () => ({
   getSDKVersion: jest.fn(() => '1.0.0'),
@@ -2086,7 +2085,7 @@ describe('openWalletSession', () => {
       on_device: false,
       seed_domains: CARDANO_SEED_DOMAINS,
     });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', cardanoSessionGet);
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', standardSessionGet);
   });
 
   test('asks Cardano seed domains after Get reports a Standard-only session', async () => {
@@ -2134,7 +2133,6 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       session_id: 'cached-session',
       btc_test_address: 'hidden-state',
-      ...cardanoSessionGet,
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
@@ -2146,17 +2144,26 @@ describe('openWalletSession', () => {
     });
   });
 
-  test('does not AskPassphrase when an Attach PIN session lacks Cardano', async () => {
+  test('uses empty AskPassphrase to add Cardano on an Attach PIN session', async () => {
     const typedCall = jest.fn((request: string) => {
       if (request === 'ProtocolInfoRequest') {
         return { message: { version: 2 } };
       }
+      if (request === 'DeviceSessionAskPassphrase') {
+        return { message: {} };
+      }
       if (request === 'DeviceSessionGet') {
+        const askedCardano = typedCall.mock.calls.some(
+          call =>
+            call[0] === 'DeviceSessionAskPassphrase' &&
+            Array.isArray(call[2]?.seed_domains) &&
+            call[2].seed_domains.includes(DeviceSessionSeedDomain.SeedDomain_Cardano)
+        );
         return {
           message: {
             btc_test_address: 'attach-state',
             session_id: 'attach-session',
-            seed_domains: CARDANO_SEED_DOMAINS,
+            seed_domains: askedCardano ? CARDANO_SEED_DOMAINS : STANDARD_SEED_DOMAINS,
           },
         };
       }
@@ -2179,18 +2186,26 @@ describe('openWalletSession', () => {
       newSession: 'attach-session',
     });
     expect(promptPassphrase).not.toHaveBeenCalled();
-    expect(typedCall).not.toHaveBeenCalledWith(
-      'DeviceSessionAskPassphrase',
-      'Success',
-      expect.anything()
-    );
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', cardanoSessionGet);
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
+      passphrase: '',
+      on_device: false,
+      seed_domains: CARDANO_SEED_DOMAINS,
+    });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(
+      typedCall.mock.calls
+        .filter(call => call[0] === 'DeviceSessionGet')
+        .every(call => !('seed_domains' in (call[2] ?? {})))
+    ).toBe(true);
   });
 
-  test('does not AskPassphrase after selecting Attach PIN for Cardano intent', async () => {
+  test('uses empty AskPassphrase after selecting Attach PIN for Cardano intent', async () => {
     const typedCall = jest.fn((request: string) => {
       if (request === 'ProtocolInfoRequest') {
         return { message: { version: 2 } };
+      }
+      if (request === 'DeviceSessionAskPassphrase') {
+        return { message: {} };
       }
       if (request === 'DeviceSessionGet') {
         return {
@@ -2217,16 +2232,61 @@ describe('openWalletSession', () => {
       newSession: 'attach-session',
     });
     expect(promptPassphrase).toHaveBeenCalledTimes(1);
+    expect(device.unlockDevice).toHaveBeenCalledWith(
+      DeviceSessionPinType.AttachToPin,
+      expect.objectContaining({ emitUiEvent: false })
+    );
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
+      passphrase: '',
+      on_device: false,
+      seed_domains: CARDANO_SEED_DOMAINS,
+    });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(
+      typedCall.mock.calls
+        .filter(call => call[0] === 'DeviceSessionGet')
+        .every(call => !('seed_domains' in (call[2] ?? {})))
+    ).toBe(true);
+  });
+
+  test('uses a second Get for Cardano when passphrase protection is off', async () => {
+    const typedCall = jest.fn((request: string) => {
+      if (request === 'ProtocolInfoRequest') {
+        return { message: { version: 2 } };
+      }
+      if (request === 'DeviceSessionGet') {
+        const getCount = typedCall.mock.calls.filter(call => call[0] === 'DeviceSessionGet').length;
+        return {
+          message: {
+            btc_test_address: 'standard-state',
+            session_id: 'standard-session',
+            seed_domains: getCount > 1 ? CARDANO_SEED_DOMAINS : STANDARD_SEED_DOMAINS,
+          },
+        };
+      }
+      throw new Error(`Unexpected request: ${request}`);
+    });
+    const device = createDevice({
+      typedCall,
+      passphraseProtection: false,
+    });
+
+    await expect(
+      getProtocolV2WalletSession(device as any, {
+        onlyMainPin: true,
+        deriveCardano: true,
+      })
+    ).resolves.toMatchObject({
+      passphraseState: 'standard-state',
+      newSession: 'standard-session',
+    });
     expect(typedCall).not.toHaveBeenCalledWith(
       'DeviceSessionAskPassphrase',
       'Success',
       expect.anything()
     );
-    expect(device.unlockDevice).toHaveBeenCalledWith(
-      DeviceSessionPinType.AttachToPin,
-      expect.objectContaining({ emitUiEvent: false })
-    );
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', cardanoSessionGet);
+    expect(typedCall.mock.calls.filter(call => call[0] === 'DeviceSessionGet')).toHaveLength(2);
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
   });
 
   test('locks before selecting a passphrase wallet from an Attach PIN session', async () => {

--- a/packages/core/__tests__/open-wallet-session.test.ts
+++ b/packages/core/__tests__/open-wallet-session.test.ts
@@ -2144,17 +2144,26 @@ describe('openWalletSession', () => {
     });
   });
 
-  test('does not AskPassphrase when an Attach PIN session lacks Cardano', async () => {
+  test('uses empty AskPassphrase to add Cardano on an Attach PIN session', async () => {
     const typedCall = jest.fn((request: string) => {
       if (request === 'ProtocolInfoRequest') {
         return { message: { version: 2 } };
       }
+      if (request === 'DeviceSessionAskPassphrase') {
+        return { message: {} };
+      }
       if (request === 'DeviceSessionGet') {
+        const askedCardano = typedCall.mock.calls.some(
+          call =>
+            call[0] === 'DeviceSessionAskPassphrase' &&
+            Array.isArray(call[2]?.seed_domains) &&
+            call[2].seed_domains.includes(DeviceSessionSeedDomain.SeedDomain_Cardano)
+        );
         return {
           message: {
             btc_test_address: 'attach-state',
             session_id: 'attach-session',
-            seed_domains: STANDARD_SEED_DOMAINS,
+            seed_domains: askedCardano ? CARDANO_SEED_DOMAINS : STANDARD_SEED_DOMAINS,
           },
         };
       }
@@ -2175,27 +2184,36 @@ describe('openWalletSession', () => {
     ).resolves.toMatchObject({
       passphraseState: 'attach-state',
       newSession: 'attach-session',
+      unlockedAttachPin: true,
     });
     expect(promptPassphrase).not.toHaveBeenCalled();
-    expect(typedCall).not.toHaveBeenCalledWith(
-      'DeviceSessionAskPassphrase',
-      'Success',
-      expect.anything()
-    );
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
+      passphrase: '',
+      on_device: false,
+      seed_domains: CARDANO_SEED_DOMAINS,
+    });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(
+      typedCall.mock.calls
+        .filter(call => call[0] === 'DeviceSessionGet')
+        .every(call => !('seed_domains' in (call[2] ?? {})))
+    ).toBe(true);
   });
 
-  test('does not AskPassphrase after selecting Attach PIN for Cardano intent', async () => {
+  test('uses empty AskPassphrase after selecting Attach PIN for Cardano intent', async () => {
     const typedCall = jest.fn((request: string) => {
       if (request === 'ProtocolInfoRequest') {
         return { message: { version: 2 } };
+      }
+      if (request === 'DeviceSessionAskPassphrase') {
+        return { message: {} };
       }
       if (request === 'DeviceSessionGet') {
         return {
           message: {
             btc_test_address: 'attach-state',
             session_id: 'attach-session',
-            seed_domains: STANDARD_SEED_DOMAINS,
+            seed_domains: CARDANO_SEED_DOMAINS,
           },
         };
       }
@@ -2213,18 +2231,63 @@ describe('openWalletSession', () => {
     ).resolves.toMatchObject({
       passphraseState: 'attach-state',
       newSession: 'attach-session',
+      unlockedAttachPin: true,
     });
     expect(promptPassphrase).toHaveBeenCalledTimes(1);
     expect(device.unlockDevice).toHaveBeenCalledWith(
       DeviceSessionPinType.AttachToPin,
       expect.objectContaining({ emitUiEvent: false })
     );
-    expect(typedCall).not.toHaveBeenCalledWith(
-      'DeviceSessionAskPassphrase',
-      'Success',
-      expect.anything()
-    );
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
+      passphrase: '',
+      on_device: false,
+      seed_domains: CARDANO_SEED_DOMAINS,
+    });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(
+      typedCall.mock.calls
+        .filter(call => call[0] === 'DeviceSessionGet')
+        .every(call => !('seed_domains' in (call[2] ?? {})))
+    ).toBe(true);
+  });
+
+  test('still locks before a passphrase picker after Attach PIN Cardano empty Ask', async () => {
+    const typedCall = jest.fn((request: string) => {
+      if (request === 'ProtocolInfoRequest') {
+        return { message: { version: 2 } };
+      }
+      if (request === 'DeviceSessionAskPassphrase') {
+        return { message: {} };
+      }
+      if (request === 'DeviceSessionGet') {
+        return {
+          message: {
+            btc_test_address: 'attach-state',
+            session_id: 'attach-session',
+            seed_domains: CARDANO_SEED_DOMAINS,
+          },
+        };
+      }
+      throw new Error(`Unexpected request: ${request}`);
+    });
+    const promptPassphrase = jest.fn().mockResolvedValue({ passphrase: 'should-not-ask' });
+    const device = createDevice({
+      typedCall,
+      promptPassphrase,
+      unlockedAttachPin: true,
+    });
+
+    await getProtocolV2WalletSession(device as any, {
+      readCurrentAttachPinSession: true,
+      deriveCardano: true,
+    });
+    await expect(
+      getProtocolV2WalletSession(device as any, { forceWalletSelection: true })
+    ).rejects.toMatchObject({
+      errorCode: HardwareErrorCode.DeviceCheckUnlockTypeError,
+    });
+    expect(device.lockDevice).toHaveBeenCalled();
+    expect(promptPassphrase).not.toHaveBeenCalled();
   });
 
   test('uses a second Get for Cardano when passphrase protection is off', async () => {

--- a/packages/core/__tests__/open-wallet-session.test.ts
+++ b/packages/core/__tests__/open-wallet-session.test.ts
@@ -2330,6 +2330,42 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
   });
 
+  test('fails closed when Cardano fallback still lacks Cardano', async () => {
+    const typedCall = jest.fn((request: string) => {
+      if (request === 'ProtocolInfoRequest') {
+        return { message: { version: 2 } };
+      }
+      if (request === 'DeviceSessionAskPassphrase') {
+        return { message: {} };
+      }
+      if (request === 'DeviceSessionGet') {
+        return {
+          message: {
+            btc_test_address: 'hidden-state',
+            session_id: 'hidden-session',
+            seed_domains: STANDARD_SEED_DOMAINS,
+          },
+        };
+      }
+      throw new Error(`Unexpected request: ${request}`);
+    });
+    const device = createDevice({
+      typedCall,
+      promptPassphrase: jest.fn().mockResolvedValue({ passphrase: 'host hidden wallet' }),
+    });
+    deviceWalletSessionStore.set('device-1', 'hidden-state', 'cached-session');
+
+    await expect(
+      getProtocolV2WalletSession(device as any, {
+        expectedPassphraseState: 'hidden-state',
+        deriveCardano: true,
+      })
+    ).rejects.toMatchObject({
+      errorCode: HardwareErrorCode.WalletSessionInvalid,
+    });
+    expect(device.clearInternalState).toHaveBeenCalled();
+  });
+
   test('locks before selecting a passphrase wallet from an Attach PIN session', async () => {
     const typedCall = jest.fn((request: string) => {
       if (request === 'ProtocolInfoRequest') {

--- a/packages/core/__tests__/open-wallet-session.test.ts
+++ b/packages/core/__tests__/open-wallet-session.test.ts
@@ -702,21 +702,10 @@ describe('openWalletSession', () => {
     );
   });
 
-  test('reuses the current Attach PIN session without reopening wallet selection', async () => {
+  test('locks before selecting a new hidden wallet from an Attach PIN session', async () => {
     const typedCall = jest.fn((request: string) => {
       if (request === 'ProtocolInfoRequest') {
         return { message: { version: 2 } };
-      }
-      if (request === 'DeviceSessionAskPassphrase') {
-        return { message: {} };
-      }
-      if (request === 'DeviceSessionGet') {
-        return {
-          message: {
-            btc_test_address: 'attach-state',
-            session_id: 'attach-session',
-          },
-        };
       }
       throw new Error(`Unexpected request: ${request}`);
     });
@@ -729,69 +718,13 @@ describe('openWalletSession', () => {
       typedCall,
       promptPassphrase,
       unlockedAttachPin: true,
-    });
-    method.device = device as any;
-
-    await expect(method.run()).resolves.toEqual({
-      protocol: 'V2',
-      walletType: 'hidden',
-      deviceId: 'device-1',
-      passphraseState: 'attach-state',
-      resumed: false,
-    });
-    expect(promptPassphrase).not.toHaveBeenCalled();
-    expect(device.unlockDevice).not.toHaveBeenCalled();
-    expect(device.commands.typedCall).toHaveBeenCalledWith(
-      'DeviceSessionGet',
-      'DeviceSession',
-      standardSessionGet
-    );
-    expect(device.commands.typedCall).not.toHaveBeenCalledWith(
-      'DeviceSessionAskPassphrase',
-      'Success',
-      expect.anything()
-    );
-    expect(device.commands.typedCall).not.toHaveBeenCalledWith(
-      'DeviceSessionAskPin',
-      'Success',
-      expect.anything()
-    );
-  });
-
-  test('fails closed when the Attach PIN state changes before reading the current session', async () => {
-    const typedCall = jest.fn((request: string) => {
-      if (request === 'ProtocolInfoRequest') {
-        return { message: { version: 2 } };
-      }
-      if (request === 'DeviceSessionAskPassphrase') {
-        return { message: {} };
-      }
-      if (request === 'DeviceSessionGet') {
-        return {
-          message: {
-            btc_test_address: 'unexpected-state',
-            session_id: 'unexpected-session',
-          },
-        };
-      }
-      throw new Error(`Unexpected request: ${request}`);
-    });
-    const promptPassphrase = jest.fn().mockResolvedValue({ passphrase: 'must not be requested' });
-    const method = new OpenWalletSession({
-      payload: { method: 'openWalletSession', connectId: 'connect-id', mode: 'select-hidden' },
-    });
-    method.init();
-    const device = createDevice({
-      typedCall,
-      promptPassphrase,
-      unlockedAttachPin: true,
-      refreshedUnlockedAttachPin: false,
     });
     method.device = device as any;
 
     await expect(method.run()).rejects.toMatchObject({
       errorCode: HardwareErrorCode.DeviceCheckUnlockTypeError,
     });
+    expect(device.lockDevice).toHaveBeenCalled();
     expect(device.clearInternalState).toHaveBeenCalled();
     expect(promptPassphrase).not.toHaveBeenCalled();
     expect(device.commands.typedCall).not.toHaveBeenCalledWith(

--- a/packages/core/__tests__/open-wallet-session.test.ts
+++ b/packages/core/__tests__/open-wallet-session.test.ts
@@ -142,7 +142,7 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: '',
       on_device: false,
-      seed_domains: [],
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
   });
@@ -329,7 +329,7 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenNthCalledWith(2, 'DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-      seed_domains: [],
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(typedCall).toHaveBeenNthCalledWith(3, 'DeviceSessionGet', 'DeviceSession', {});
   });
@@ -448,7 +448,7 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenNthCalledWith(2, 'DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-      seed_domains: [],
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(typedCall).toHaveBeenNthCalledWith(3, 'DeviceSessionGet', 'DeviceSession', {});
   });
@@ -820,7 +820,7 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-      seed_domains: [],
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
     expect(promptPassphrase).toHaveBeenCalled();
@@ -1076,7 +1076,7 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: '',
       on_device: false,
-      seed_domains: [],
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
     expect(promptPassphrase).not.toHaveBeenCalled();
@@ -1280,7 +1280,7 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-      seed_domains: [],
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
     expect(promptPassphrase).toHaveBeenCalled();
@@ -1341,7 +1341,7 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-      seed_domains: [],
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
   });
@@ -1388,7 +1388,7 @@ describe('openWalletSession', () => {
     });
     expect(typedCall).toHaveBeenNthCalledWith(2, 'DeviceSessionAskPassphrase', 'Success', {
       on_device: true,
-      seed_domains: [],
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(typedCall).toHaveBeenNthCalledWith(3, 'DeviceSessionGet', 'DeviceSession', {});
     expect(device.createProtocolV2UiPhaseMetadata).toHaveBeenNthCalledWith(
@@ -1441,7 +1441,7 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenNthCalledWith(2, 'DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-      seed_domains: [],
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(typedCall).toHaveBeenNthCalledWith(3, 'DeviceSessionGet', 'DeviceSession', {});
   });
@@ -1465,7 +1465,7 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenNthCalledWith(2, 'DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'cafe\u0301',
       on_device: false,
-      seed_domains: [],
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
   });
 
@@ -1489,7 +1489,7 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenNthCalledWith(2, 'DeviceSessionAskPassphrase', 'Success', {
       passphrase,
       on_device: false,
-      seed_domains: [],
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
   });
 
@@ -1998,7 +1998,7 @@ describe('openWalletSession', () => {
       expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
         passphrase: 'host hidden wallet',
         on_device: false,
-        seed_domains: [],
+        seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
       });
       expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
     }
@@ -2017,6 +2017,10 @@ describe('openWalletSession', () => {
           message: {
             btc_test_address: 'hidden-state',
             session_id: 'new-session',
+            seed_domains: [
+              DeviceSessionSeedDomain.SeedDomain_Standard,
+              DeviceSessionSeedDomain.SeedDomain_Cardano,
+            ],
           },
         };
       }
@@ -2046,7 +2050,63 @@ describe('openWalletSession', () => {
     });
   });
 
-  test('does not freeze a V2 session to Standard-only when deriveCardano is false', async () => {
+  test('asks Cardano seed domains after Get reports a Standard-only session', async () => {
+    const typedCall = jest.fn((request: string) => {
+      if (request === 'ProtocolInfoRequest') {
+        return { message: { version: 2 } };
+      }
+      if (request === 'DeviceSessionAskPassphrase') {
+        return { message: {} };
+      }
+      if (request === 'DeviceSessionGet') {
+        const hasCardanoAsk = typedCall.mock.calls.some(
+          call =>
+            call[0] === 'DeviceSessionAskPassphrase' &&
+            Array.isArray(call[2]?.seed_domains) &&
+            call[2].seed_domains.includes(DeviceSessionSeedDomain.SeedDomain_Cardano)
+        );
+        return {
+          message: {
+            btc_test_address: 'hidden-state',
+            session_id: 'new-session',
+            seed_domains: hasCardanoAsk
+              ? [
+                  DeviceSessionSeedDomain.SeedDomain_Standard,
+                  DeviceSessionSeedDomain.SeedDomain_Cardano,
+                ]
+              : [DeviceSessionSeedDomain.SeedDomain_Standard],
+          },
+        };
+      }
+      throw new Error(`Unexpected request: ${request}`);
+    });
+    const device = createDevice({
+      typedCall,
+      promptPassphrase: jest.fn().mockResolvedValue({ passphrase: 'host hidden wallet' }),
+    });
+    device.passphraseState = 'hidden-state';
+    deviceWalletSessionStore.set('device-1', 'hidden-state', 'cached-session');
+
+    await getProtocolV2WalletSession(device as any, {
+      expectedPassphraseState: 'hidden-state',
+      deriveCardano: true,
+    });
+
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
+      session_id: 'cached-session',
+      btc_test_address: 'hidden-state',
+    });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
+      passphrase: 'host hidden wallet',
+      on_device: false,
+      seed_domains: [
+        DeviceSessionSeedDomain.SeedDomain_Standard,
+        DeviceSessionSeedDomain.SeedDomain_Cardano,
+      ],
+    });
+  });
+
+  test('asks Standard-only seed domains when deriveCardano is false', async () => {
     const typedCall = jest.fn((request: string) => {
       if (request === 'ProtocolInfoRequest') {
         return { message: { version: 2 } };
@@ -2076,7 +2136,7 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-      seed_domains: [],
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
   });
 });

--- a/packages/core/__tests__/open-wallet-session.test.ts
+++ b/packages/core/__tests__/open-wallet-session.test.ts
@@ -1964,43 +1964,119 @@ describe('openWalletSession', () => {
     expect(deviceWalletSessionStore.get('device-1', 'hidden-state')).toBe('new-session');
   });
 
-  test.each([false, true])('keeps deriveCardano API compatibility: %s', async deriveCardano => {
-    const typedCall = jest
-      .fn()
-      .mockResolvedValueOnce({ message: { version: 2 } })
-      .mockResolvedValueOnce({ message: {} })
-      .mockResolvedValueOnce({
-        message: {
-          btc_test_address: 'hidden-state',
-          session_id: 'new-session',
+  test.each([false, true])(
+    'openWalletSession does not thread CommonParams.deriveCardano: %s',
+    async deriveCardano => {
+      const typedCall = jest
+        .fn()
+        .mockResolvedValueOnce({ message: { version: 2 } })
+        .mockResolvedValueOnce({ message: {} })
+        .mockResolvedValueOnce({
+          message: {
+            btc_test_address: 'hidden-state',
+            session_id: 'new-session',
+          },
+        });
+      const method = new OpenWalletSession({
+        payload: {
+          method: 'openWalletSession',
+          connectId: 'connect-id',
+          mode: 'select-hidden',
+          deriveCardano,
         },
       });
-    const method = new OpenWalletSession({
-      payload: {
-        method: 'openWalletSession',
-        connectId: 'connect-id',
-        mode: 'select-hidden',
-        deriveCardano,
-      },
+      method.init();
+      method.device = createDevice({
+        typedCall,
+        promptPassphrase: jest.fn().mockResolvedValue({ passphrase: 'host hidden wallet' }),
+      }) as any;
+
+      await expect(method.run()).resolves.toMatchObject({
+        walletType: 'hidden',
+        passphraseState: 'hidden-state',
+      });
+      expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
+        passphrase: 'host hidden wallet',
+        on_device: false,
+        seed_domains: [],
+      });
+      expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    }
+  );
+
+  test('requests Cardano seed domains when a V2 session rebuild has Cardano intent', async () => {
+    const typedCall = jest.fn((request: string) => {
+      if (request === 'ProtocolInfoRequest') {
+        return { message: { version: 2 } };
+      }
+      if (request === 'DeviceSessionAskPassphrase') {
+        return { message: {} };
+      }
+      if (request === 'DeviceSessionGet') {
+        return {
+          message: {
+            btc_test_address: 'hidden-state',
+            session_id: 'new-session',
+          },
+        };
+      }
+      throw new Error(`Unexpected request: ${request}`);
     });
-    method.init();
-    method.device = createDevice({
+    const device = createDevice({
       typedCall,
       promptPassphrase: jest.fn().mockResolvedValue({ passphrase: 'host hidden wallet' }),
-    }) as any;
+    });
 
-    await expect(method.run()).resolves.toMatchObject({
-      walletType: 'hidden',
+    await expect(
+      getProtocolV2WalletSession(device as any, {
+        forceWalletSelection: true,
+        deriveCardano: true,
+      })
+    ).resolves.toMatchObject({
       passphraseState: 'hidden-state',
+      newSession: 'new-session',
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
       seed_domains: [
         DeviceSessionSeedDomain.SeedDomain_Standard,
-        ...(deriveCardano ? [DeviceSessionSeedDomain.SeedDomain_Cardano] : []),
+        DeviceSessionSeedDomain.SeedDomain_Cardano,
       ],
     });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+  });
+
+  test('does not freeze a V2 session to Standard-only when deriveCardano is false', async () => {
+    const typedCall = jest.fn((request: string) => {
+      if (request === 'ProtocolInfoRequest') {
+        return { message: { version: 2 } };
+      }
+      if (request === 'DeviceSessionAskPassphrase') {
+        return { message: {} };
+      }
+      if (request === 'DeviceSessionGet') {
+        return {
+          message: {
+            btc_test_address: 'hidden-state',
+            session_id: 'new-session',
+          },
+        };
+      }
+      throw new Error(`Unexpected request: ${request}`);
+    });
+    const device = createDevice({
+      typedCall,
+      promptPassphrase: jest.fn().mockResolvedValue({ passphrase: 'host hidden wallet' }),
+    });
+
+    await getProtocolV2WalletSession(device as any, {
+      forceWalletSelection: true,
+      deriveCardano: false,
+    });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
+      passphrase: 'host hidden wallet',
+      on_device: false,
+      seed_domains: [],
+    });
   });
 });

--- a/packages/core/__tests__/open-wallet-session.test.ts
+++ b/packages/core/__tests__/open-wallet-session.test.ts
@@ -142,10 +142,9 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: '',
       on_device: false,
-    });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       seed_domains: [],
     });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
   });
 
   test('selects the Main PIN before opening the standard wallet when passphrase is disabled', async () => {
@@ -177,9 +176,7 @@ describe('openWalletSession', () => {
       'Success',
       expect.anything()
     );
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
-      seed_domains: [],
-    });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
   });
 
   test('reuses a Main PIN selected by the current preflight when passphrase is disabled', async () => {
@@ -205,9 +202,7 @@ describe('openWalletSession', () => {
     });
 
     expect(device.unlockDevice).not.toHaveBeenCalled();
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
-      seed_domains: [],
-    });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
   });
 
   test('does not treat an Attach PIN DeviceStatus as the Main wallet', async () => {
@@ -334,10 +329,9 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenNthCalledWith(2, 'DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-    });
-    expect(typedCall).toHaveBeenNthCalledWith(3, 'DeviceSessionGet', 'DeviceSession', {
       seed_domains: [],
     });
+    expect(typedCall).toHaveBeenNthCalledWith(3, 'DeviceSessionGet', 'DeviceSession', {});
   });
 
   test('keeps Legacy Protocol V1 getPassphraseState parameterless', async () => {
@@ -454,10 +448,9 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenNthCalledWith(2, 'DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-    });
-    expect(typedCall).toHaveBeenNthCalledWith(3, 'DeviceSessionGet', 'DeviceSession', {
       seed_domains: [],
     });
+    expect(typedCall).toHaveBeenNthCalledWith(3, 'DeviceSessionGet', 'DeviceSession', {});
   });
 
   test('refreshes Pro2 status and unlocks before selecting a hidden wallet when locked', async () => {
@@ -731,9 +724,7 @@ describe('openWalletSession', () => {
     });
     expect(promptPassphrase).not.toHaveBeenCalled();
     expect(device.unlockDevice).not.toHaveBeenCalled();
-    expect(device.commands.typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
-      seed_domains: [],
-    });
+    expect(device.commands.typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
     expect(device.commands.typedCall).not.toHaveBeenCalledWith(
       'DeviceSessionAskPassphrase',
       'Success',
@@ -829,10 +820,9 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-    });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       seed_domains: [],
     });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
     expect(promptPassphrase).toHaveBeenCalled();
     expect(deviceWalletSessionStore.get('device-1', 'new-hidden-state')).toBe('new-hidden-session');
   });
@@ -904,7 +894,6 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       session_id: 'known-session',
       btc_test_address: 'hidden-state',
-      seed_domains: [],
     });
     expect(promptPassphrase).not.toHaveBeenCalled();
   });
@@ -1087,10 +1076,9 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: '',
       on_device: false,
-    });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       seed_domains: [],
     });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
     expect(promptPassphrase).not.toHaveBeenCalled();
     expect(device.passphraseState).toBeUndefined();
   });
@@ -1259,9 +1247,7 @@ describe('openWalletSession', () => {
       reason: 'open-wallet',
       deviceOnly: true,
     });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
-      seed_domains: [],
-    });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
   });
 
   test('selects a hidden wallet without exposing the internal device session', async () => {
@@ -1294,10 +1280,9 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-    });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       seed_domains: [],
     });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
     expect(promptPassphrase).toHaveBeenCalled();
     expect(device.passphraseState).toBeUndefined();
     expect(deviceWalletSessionStore.get('device-1', 'hidden-state')).toBe('hidden-session');
@@ -1356,10 +1341,9 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-    });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       seed_domains: [],
     });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
   });
 
   test('selects an on-device passphrase wallet with an explicit on_device request', async () => {
@@ -1404,10 +1388,9 @@ describe('openWalletSession', () => {
     });
     expect(typedCall).toHaveBeenNthCalledWith(2, 'DeviceSessionAskPassphrase', 'Success', {
       on_device: true,
-    });
-    expect(typedCall).toHaveBeenNthCalledWith(3, 'DeviceSessionGet', 'DeviceSession', {
       seed_domains: [],
     });
+    expect(typedCall).toHaveBeenNthCalledWith(3, 'DeviceSessionGet', 'DeviceSession', {});
     expect(device.createProtocolV2UiPhaseMetadata).toHaveBeenNthCalledWith(
       2,
       'passphrase-on-device',
@@ -1458,10 +1441,9 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenNthCalledWith(2, 'DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-    });
-    expect(typedCall).toHaveBeenNthCalledWith(3, 'DeviceSessionGet', 'DeviceSession', {
       seed_domains: [],
     });
+    expect(typedCall).toHaveBeenNthCalledWith(3, 'DeviceSessionGet', 'DeviceSession', {});
   });
 
   test('normalizes a Unicode Host passphrase before sending it to Pro2 firmware', async () => {
@@ -1483,6 +1465,7 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenNthCalledWith(2, 'DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'cafe\u0301',
       on_device: false,
+      seed_domains: [],
     });
   });
 
@@ -1506,6 +1489,7 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenNthCalledWith(2, 'DeviceSessionAskPassphrase', 'Success', {
       passphrase,
       on_device: false,
+      seed_domains: [],
     });
   });
 
@@ -1541,9 +1525,7 @@ describe('openWalletSession', () => {
     expect(device.unlockDevice).toHaveBeenCalledWith(DeviceSessionPinType.AttachToPin, {
       emitUiEvent: false,
     });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
-      seed_domains: [],
-    });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
   });
 
   test('uses the complete Attach PIN wire flow without a main PIN unlock', async () => {
@@ -1572,7 +1554,7 @@ describe('openWalletSession', () => {
       ['ProtocolInfoRequest', 'ProtocolInfo', { eventless_wallet_session: true }],
       ['DeviceSessionAskPin', 'Success', { type: DeviceSessionPinType.AttachToPin }],
       ['DeviceStatusGet', 'DeviceStatus', {}],
-      ['DeviceSessionGet', 'DeviceSession', { seed_domains: [] }],
+      ['DeviceSessionGet', 'DeviceSession', {}],
     ]);
     expect(device.commands.typedCall).not.toHaveBeenCalledWith('DeviceSessionAskPin', 'Success', {
       type: DeviceSessionPinType.Main,
@@ -1784,7 +1766,6 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       session_id: 'known-session',
       btc_test_address: 'hidden-state',
-      seed_domains: [],
     });
     expect(promptPassphrase).not.toHaveBeenCalled();
   });
@@ -1844,7 +1825,6 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       session_id: 'known-session',
       btc_test_address: 'hidden-state',
-      seed_domains: [],
     });
     const sessionGetCall = typedCall.mock.calls.findIndex(
       ([requestName]) => requestName === 'DeviceSessionGet'
@@ -1942,7 +1922,6 @@ describe('openWalletSession', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       session_id: 'expired-session',
       btc_test_address: 'hidden-state',
-      seed_domains: [],
     });
     expect(promptPassphrase).toHaveBeenCalledTimes(1);
     expect(deviceWalletSessionStore.get('device-1', 'hidden-state')).toBe('renewed-session');
@@ -1980,7 +1959,6 @@ describe('openWalletSession', () => {
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       btc_test_address: 'hidden-state',
-      seed_domains: [],
     });
     expect(promptPassphrase).not.toHaveBeenCalled();
     expect(deviceWalletSessionStore.get('device-1', 'hidden-state')).toBe('new-session');
@@ -2015,11 +1993,14 @@ describe('openWalletSession', () => {
       walletType: 'hidden',
       passphraseState: 'hidden-state',
     });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
+      passphrase: 'host hidden wallet',
+      on_device: false,
       seed_domains: [
         DeviceSessionSeedDomain.SeedDomain_Standard,
         ...(deriveCardano ? [DeviceSessionSeedDomain.SeedDomain_Cardano] : []),
       ],
     });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
   });
 });

--- a/packages/core/__tests__/protocol-v2.test.ts
+++ b/packages/core/__tests__/protocol-v2.test.ts
@@ -1118,7 +1118,9 @@ describe('Protocol V2 feature adapter', () => {
       on_device: false,
       seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
+    });
     device.passphraseState = 'state-1';
     expect(device.getInternalState()).toBe('session-1');
   });
@@ -1171,10 +1173,13 @@ describe('Protocol V2 feature adapter', () => {
     expect(
       typedCall.mock.calls.filter(call => call[0] === 'DeviceSessionAskPassphrase')
     ).toHaveLength(1);
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
+    });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       session_id: 'standard-session',
       btc_test_address: 'standard-state',
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(deviceWalletSessionStore.getStandard(deviceId)).toEqual({
       passphraseState: 'standard-state',
@@ -1541,7 +1546,9 @@ describe('Protocol V2 feature adapter', () => {
       on_device: false,
       seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
+    });
   });
 
   test('deviceStatusGet returns raw DeviceStatus and updates dynamic features', async () => {
@@ -1650,6 +1657,7 @@ describe('Protocol V2 feature adapter', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       session_id: 'session-a',
       btc_test_address: 'state-a',
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(device.getInternalState()).toBe('session-b');
   });
@@ -1723,6 +1731,7 @@ describe('Protocol V2 feature adapter', () => {
         {
           session_id: 'session-a',
           btc_test_address: 'state-a',
+          seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
         },
       ],
     ]);
@@ -1776,7 +1785,13 @@ describe('Protocol V2 feature adapter', () => {
         },
       ],
       ['DeviceStatusGet', 'DeviceStatus', {}],
-      ['DeviceSessionGet', 'DeviceSession', {}],
+      [
+        'DeviceSessionGet',
+        'DeviceSession',
+        {
+          seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
+        },
+      ],
     ]);
   });
 
@@ -1938,6 +1953,7 @@ describe('Protocol V2 feature adapter', () => {
       expect(promptPassphrase).not.toHaveBeenCalled();
       expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
         btc_test_address: 'expected-state',
+        seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
       });
       expect(typedCall).toHaveBeenCalledWith('LockDevice', 'Success', {});
       expect(typedCall.mock.calls.filter(call => call[0] === 'DeviceSessionGet')).toHaveLength(1);
@@ -2235,7 +2251,7 @@ describe('Protocol V2 feature adapter', () => {
       firmwareVersion: '4.15.0',
       passphraseProtection: true,
       sessionId: 'feature-session',
-      unlockedAttachPin: true,
+      unlockedAttachPin: false,
     };
     const typedCall = jest
       .fn()
@@ -2328,6 +2344,7 @@ describe('Protocol V2 feature adapter', () => {
     ).resolves.toMatchObject({ passphraseState: 'expected-state' });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       btc_test_address: 'expected-state',
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(promptPassphrase).not.toHaveBeenCalled();
   });
@@ -2401,6 +2418,7 @@ describe('Protocol V2 feature adapter', () => {
         {
           session_id: 'session-pro2-app',
           btc_test_address: 'state-pro2-app',
+          seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
         },
       ],
     ]);
@@ -2592,7 +2610,9 @@ describe('Protocol V2 feature adapter', () => {
       on_device: false,
       seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
-    expect(typedCall).toHaveBeenLastCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenLastCalledWith('DeviceSessionGet', 'DeviceSession', {
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
+    });
   });
 
   test('does not mark Pro2 passphrase enabled from a main PIN session alone', async () => {
@@ -2672,6 +2692,7 @@ describe('Protocol V2 feature adapter', () => {
     expect(device.getInternalState()).toBeUndefined();
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       btc_test_address: 'expected-state',
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
@@ -2679,7 +2700,9 @@ describe('Protocol V2 feature adapter', () => {
       seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceStatusGet', 'DeviceStatus', {});
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
+    });
   });
 
   test('fails closed instead of switching to Main PIN during a standard-wallet safety check', async () => {
@@ -2781,7 +2804,9 @@ describe('Protocol V2 feature adapter', () => {
     expect(typedCall).toHaveBeenCalledWith('ProtocolInfoRequest', 'ProtocolInfo', {
       eventless_wallet_session: true,
     });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
+    });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: '',
       on_device: false,

--- a/packages/core/__tests__/protocol-v2.test.ts
+++ b/packages/core/__tests__/protocol-v2.test.ts
@@ -1118,9 +1118,7 @@ describe('Protocol V2 feature adapter', () => {
       on_device: false,
       seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
-      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
-    });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
     device.passphraseState = 'state-1';
     expect(device.getInternalState()).toBe('session-1');
   });
@@ -1173,13 +1171,10 @@ describe('Protocol V2 feature adapter', () => {
     expect(
       typedCall.mock.calls.filter(call => call[0] === 'DeviceSessionAskPassphrase')
     ).toHaveLength(1);
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
-      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
-    });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       session_id: 'standard-session',
       btc_test_address: 'standard-state',
-      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(deviceWalletSessionStore.getStandard(deviceId)).toEqual({
       passphraseState: 'standard-state',
@@ -1546,9 +1541,7 @@ describe('Protocol V2 feature adapter', () => {
       on_device: false,
       seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
-      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
-    });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
   });
 
   test('deviceStatusGet returns raw DeviceStatus and updates dynamic features', async () => {
@@ -1657,7 +1650,6 @@ describe('Protocol V2 feature adapter', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       session_id: 'session-a',
       btc_test_address: 'state-a',
-      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(device.getInternalState()).toBe('session-b');
   });
@@ -1731,7 +1723,6 @@ describe('Protocol V2 feature adapter', () => {
         {
           session_id: 'session-a',
           btc_test_address: 'state-a',
-          seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
         },
       ],
     ]);
@@ -1785,13 +1776,7 @@ describe('Protocol V2 feature adapter', () => {
         },
       ],
       ['DeviceStatusGet', 'DeviceStatus', {}],
-      [
-        'DeviceSessionGet',
-        'DeviceSession',
-        {
-          seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
-        },
-      ],
+      ['DeviceSessionGet', 'DeviceSession', {}],
     ]);
   });
 
@@ -1953,7 +1938,6 @@ describe('Protocol V2 feature adapter', () => {
       expect(promptPassphrase).not.toHaveBeenCalled();
       expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
         btc_test_address: 'expected-state',
-        seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
       });
       expect(typedCall).toHaveBeenCalledWith('LockDevice', 'Success', {});
       expect(typedCall.mock.calls.filter(call => call[0] === 'DeviceSessionGet')).toHaveLength(1);
@@ -2344,7 +2328,6 @@ describe('Protocol V2 feature adapter', () => {
     ).resolves.toMatchObject({ passphraseState: 'expected-state' });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       btc_test_address: 'expected-state',
-      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(promptPassphrase).not.toHaveBeenCalled();
   });
@@ -2418,7 +2401,6 @@ describe('Protocol V2 feature adapter', () => {
         {
           session_id: 'session-pro2-app',
           btc_test_address: 'state-pro2-app',
-          seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
         },
       ],
     ]);
@@ -2610,9 +2592,7 @@ describe('Protocol V2 feature adapter', () => {
       on_device: false,
       seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
-    expect(typedCall).toHaveBeenLastCalledWith('DeviceSessionGet', 'DeviceSession', {
-      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
-    });
+    expect(typedCall).toHaveBeenLastCalledWith('DeviceSessionGet', 'DeviceSession', {});
   });
 
   test('does not mark Pro2 passphrase enabled from a main PIN session alone', async () => {
@@ -2692,7 +2672,6 @@ describe('Protocol V2 feature adapter', () => {
     expect(device.getInternalState()).toBeUndefined();
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       btc_test_address: 'expected-state',
-      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
@@ -2700,9 +2679,7 @@ describe('Protocol V2 feature adapter', () => {
       seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceStatusGet', 'DeviceStatus', {});
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
-      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
-    });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
   });
 
   test('fails closed instead of switching to Main PIN during a standard-wallet safety check', async () => {
@@ -2804,9 +2781,7 @@ describe('Protocol V2 feature adapter', () => {
     expect(typedCall).toHaveBeenCalledWith('ProtocolInfoRequest', 'ProtocolInfo', {
       eventless_wallet_session: true,
     });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
-      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
-    });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: '',
       on_device: false,

--- a/packages/core/__tests__/protocol-v2.test.ts
+++ b/packages/core/__tests__/protocol-v2.test.ts
@@ -1769,7 +1769,11 @@ describe('Protocol V2 feature adapter', () => {
       [
         'DeviceSessionAskPassphrase',
         'Success',
-        { passphrase: 'host hidden wallet', on_device: false, seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard] },
+        {
+          passphrase: 'host hidden wallet',
+          on_device: false,
+          seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
+        },
       ],
       ['DeviceStatusGet', 'DeviceStatus', {}],
       ['DeviceSessionGet', 'DeviceSession', {}],

--- a/packages/core/__tests__/protocol-v2.test.ts
+++ b/packages/core/__tests__/protocol-v2.test.ts
@@ -7,6 +7,7 @@ import { encode as encodeJpeg } from 'jpeg-js';
 import {
   DeviceRebootType,
   DeviceSessionPinType,
+  DeviceSessionSeedDomain,
   DeviceSettingsPage,
   DeviceType,
 } from '@onekeyfe/hd-transport';
@@ -1115,7 +1116,7 @@ describe('Protocol V2 feature adapter', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: '',
       on_device: false,
-      seed_domains: [],
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
     device.passphraseState = 'state-1';
@@ -1538,7 +1539,7 @@ describe('Protocol V2 feature adapter', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-      seed_domains: [],
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
   });
@@ -1768,7 +1769,7 @@ describe('Protocol V2 feature adapter', () => {
       [
         'DeviceSessionAskPassphrase',
         'Success',
-        { passphrase: 'host hidden wallet', on_device: false, seed_domains: [] },
+        { passphrase: 'host hidden wallet', on_device: false, seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard] },
       ],
       ['DeviceStatusGet', 'DeviceStatus', {}],
       ['DeviceSessionGet', 'DeviceSession', {}],
@@ -2585,7 +2586,7 @@ describe('Protocol V2 feature adapter', () => {
     expect(typedCall).toHaveBeenNthCalledWith(2, 'DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-      seed_domains: [],
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(typedCall).toHaveBeenLastCalledWith('DeviceSessionGet', 'DeviceSession', {});
   });
@@ -2671,7 +2672,7 @@ describe('Protocol V2 feature adapter', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-      seed_domains: [],
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceStatusGet', 'DeviceStatus', {});
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
@@ -2780,7 +2781,7 @@ describe('Protocol V2 feature adapter', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: '',
       on_device: false,
-      seed_domains: [],
+      seed_domains: [DeviceSessionSeedDomain.SeedDomain_Standard],
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceStatusGet', 'DeviceStatus', {});
     expect(typedCall.mock.calls.filter(([request]) => request === 'DeviceStatusGet')).toHaveLength(

--- a/packages/core/__tests__/protocol-v2.test.ts
+++ b/packages/core/__tests__/protocol-v2.test.ts
@@ -1115,10 +1115,9 @@ describe('Protocol V2 feature adapter', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: '',
       on_device: false,
-    });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       seed_domains: [],
     });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
     device.passphraseState = 'state-1';
     expect(device.getInternalState()).toBe('session-1');
   });
@@ -1171,13 +1170,10 @@ describe('Protocol V2 feature adapter', () => {
     expect(
       typedCall.mock.calls.filter(call => call[0] === 'DeviceSessionAskPassphrase')
     ).toHaveLength(1);
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
-      seed_domains: [],
-    });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       session_id: 'standard-session',
       btc_test_address: 'standard-state',
-      seed_domains: [],
     });
     expect(deviceWalletSessionStore.getStandard(deviceId)).toEqual({
       passphraseState: 'standard-state',
@@ -1542,10 +1538,9 @@ describe('Protocol V2 feature adapter', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-    });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       seed_domains: [],
     });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
   });
 
   test('deviceStatusGet returns raw DeviceStatus and updates dynamic features', async () => {
@@ -1654,7 +1649,6 @@ describe('Protocol V2 feature adapter', () => {
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       session_id: 'session-a',
       btc_test_address: 'state-a',
-      seed_domains: [],
     });
     expect(device.getInternalState()).toBe('session-b');
   });
@@ -1728,7 +1722,6 @@ describe('Protocol V2 feature adapter', () => {
         {
           session_id: 'session-a',
           btc_test_address: 'state-a',
-          seed_domains: [],
         },
       ],
     ]);
@@ -1775,10 +1768,10 @@ describe('Protocol V2 feature adapter', () => {
       [
         'DeviceSessionAskPassphrase',
         'Success',
-        { passphrase: 'host hidden wallet', on_device: false },
+        { passphrase: 'host hidden wallet', on_device: false, seed_domains: [] },
       ],
       ['DeviceStatusGet', 'DeviceStatus', {}],
-      ['DeviceSessionGet', 'DeviceSession', { seed_domains: [] }],
+      ['DeviceSessionGet', 'DeviceSession', {}],
     ]);
   });
 
@@ -1940,7 +1933,6 @@ describe('Protocol V2 feature adapter', () => {
       expect(promptPassphrase).not.toHaveBeenCalled();
       expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
         btc_test_address: 'expected-state',
-        seed_domains: [],
       });
       expect(typedCall).toHaveBeenCalledWith('LockDevice', 'Success', {});
       expect(typedCall.mock.calls.filter(call => call[0] === 'DeviceSessionGet')).toHaveLength(1);
@@ -2331,7 +2323,6 @@ describe('Protocol V2 feature adapter', () => {
     ).resolves.toMatchObject({ passphraseState: 'expected-state' });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       btc_test_address: 'expected-state',
-      seed_domains: [],
     });
     expect(promptPassphrase).not.toHaveBeenCalled();
   });
@@ -2405,7 +2396,6 @@ describe('Protocol V2 feature adapter', () => {
         {
           session_id: 'session-pro2-app',
           btc_test_address: 'state-pro2-app',
-          seed_domains: [],
         },
       ],
     ]);
@@ -2595,10 +2585,9 @@ describe('Protocol V2 feature adapter', () => {
     expect(typedCall).toHaveBeenNthCalledWith(2, 'DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-    });
-    expect(typedCall).toHaveBeenLastCalledWith('DeviceSessionGet', 'DeviceSession', {
       seed_domains: [],
     });
+    expect(typedCall).toHaveBeenLastCalledWith('DeviceSessionGet', 'DeviceSession', {});
   });
 
   test('does not mark Pro2 passphrase enabled from a main PIN session alone', async () => {
@@ -2678,16 +2667,14 @@ describe('Protocol V2 feature adapter', () => {
     expect(device.getInternalState()).toBeUndefined();
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       btc_test_address: 'expected-state',
-      seed_domains: [],
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: 'host hidden wallet',
       on_device: false,
-    });
-    expect(typedCall).toHaveBeenCalledWith('DeviceStatusGet', 'DeviceStatus', {});
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
       seed_domains: [],
     });
+    expect(typedCall).toHaveBeenCalledWith('DeviceStatusGet', 'DeviceStatus', {});
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
   });
 
   test('fails closed instead of switching to Main PIN during a standard-wallet safety check', async () => {
@@ -2789,12 +2776,11 @@ describe('Protocol V2 feature adapter', () => {
     expect(typedCall).toHaveBeenCalledWith('ProtocolInfoRequest', 'ProtocolInfo', {
       eventless_wallet_session: true,
     });
-    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {
-      seed_domains: [],
-    });
+    expect(typedCall).toHaveBeenCalledWith('DeviceSessionGet', 'DeviceSession', {});
     expect(typedCall).toHaveBeenCalledWith('DeviceSessionAskPassphrase', 'Success', {
       passphrase: '',
       on_device: false,
+      seed_domains: [],
     });
     expect(typedCall).toHaveBeenCalledWith('DeviceStatusGet', 'DeviceStatus', {});
     expect(typedCall.mock.calls.filter(([request]) => request === 'DeviceStatusGet')).toHaveLength(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "description": "Core processes and APIs for communicating with OneKey hardware devices.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.4",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.5",
     "axios": "1.15.2",
     "bignumber.js": "^9.0.2",
     "buffer": "^6.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "description": "Core processes and APIs for communicating with OneKey hardware devices.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.5",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.6",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.6",
     "axios": "1.15.2",
     "bignumber.js": "^9.0.2",
     "buffer": "^6.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "description": "Core processes and APIs for communicating with OneKey hardware devices.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.3",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.4",
     "axios": "1.15.2",
     "bignumber.js": "^9.0.2",
     "buffer": "^6.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "description": "Core processes and APIs for communicating with OneKey hardware devices.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.1",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.1",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.2",
     "axios": "1.15.2",
     "bignumber.js": "^9.0.2",
     "buffer": "^6.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-core",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "description": "Core processes and APIs for communicating with OneKey hardware devices.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -25,8 +25,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.2",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.3",
     "axios": "1.15.2",
     "bignumber.js": "^9.0.2",
     "buffer": "^6.0.3",

--- a/packages/core/src/api/OpenWalletSession.ts
+++ b/packages/core/src/api/OpenWalletSession.ts
@@ -248,13 +248,18 @@ export default class OpenWalletSession extends BaseMethod<OpenWalletSessionParam
       this.device.clearInternalState();
       throw ERRORS.TypedError(HardwareErrorCode.DeviceNotOpenedPassphrase);
     }
-    const readCurrentAttachPinSession =
-      isProtocolV2 && walletStatus.status.unlockedAttachPin === true;
+    if (isProtocolV2 && walletStatus.status.unlockedAttachPin === true) {
+      try {
+        await this.device.lockDevice();
+      } catch {
+        // Reject the Attach PIN context even when an older device cannot be locked.
+      }
+      this.device.clearInternalState();
+      throw ERRORS.TypedError(HardwareErrorCode.DeviceCheckUnlockTypeError);
+    }
     const session = isProtocolV2
       ? await getProtocolV2WalletSession(this.device, {
-          ...(readCurrentAttachPinSession
-            ? { readCurrentAttachPinSession: true }
-            : { forceWalletSelection: true }),
+          forceWalletSelection: true,
         })
       : await getPassphraseStateWithRefreshDeviceInfo(this.device, { initSession: true });
     const refreshedState = isProtocolV2
@@ -266,14 +271,6 @@ export default class OpenWalletSession extends BaseMethod<OpenWalletSessionParam
     if (isProtocolV2 && refreshedState.status.passphraseProtection !== true) {
       this.device.clearInternalState();
       throw ERRORS.TypedError(HardwareErrorCode.DeviceNotOpenedPassphrase);
-    }
-    if (
-      isProtocolV2 &&
-      readCurrentAttachPinSession &&
-      refreshedState.status.unlockedAttachPin !== true
-    ) {
-      this.device.clearInternalState();
-      throw ERRORS.TypedError(HardwareErrorCode.DeviceCheckUnlockTypeError);
     }
     const responseBase = {
       protocol,

--- a/packages/core/src/api/OpenWalletSession.ts
+++ b/packages/core/src/api/OpenWalletSession.ts
@@ -248,18 +248,13 @@ export default class OpenWalletSession extends BaseMethod<OpenWalletSessionParam
       this.device.clearInternalState();
       throw ERRORS.TypedError(HardwareErrorCode.DeviceNotOpenedPassphrase);
     }
-    if (isProtocolV2 && walletStatus.status.unlockedAttachPin === true) {
-      try {
-        await this.device.lockDevice();
-      } catch {
-        // Reject the Attach PIN context even when an older device cannot be locked.
-      }
-      this.device.clearInternalState();
-      throw ERRORS.TypedError(HardwareErrorCode.DeviceCheckUnlockTypeError);
-    }
+    const readCurrentAttachPinSession =
+      isProtocolV2 && walletStatus.status.unlockedAttachPin === true;
     const session = isProtocolV2
       ? await getProtocolV2WalletSession(this.device, {
-          forceWalletSelection: true,
+          ...(readCurrentAttachPinSession
+            ? { readCurrentAttachPinSession: true }
+            : { forceWalletSelection: true }),
         })
       : await getPassphraseStateWithRefreshDeviceInfo(this.device, { initSession: true });
     const refreshedState = isProtocolV2
@@ -271,6 +266,14 @@ export default class OpenWalletSession extends BaseMethod<OpenWalletSessionParam
     if (isProtocolV2 && refreshedState.status.passphraseProtection !== true) {
       this.device.clearInternalState();
       throw ERRORS.TypedError(HardwareErrorCode.DeviceNotOpenedPassphrase);
+    }
+    if (
+      isProtocolV2 &&
+      readCurrentAttachPinSession &&
+      refreshedState.status.unlockedAttachPin !== true
+    ) {
+      this.device.clearInternalState();
+      throw ERRORS.TypedError(HardwareErrorCode.DeviceCheckUnlockTypeError);
     }
     const responseBase = {
       protocol,

--- a/packages/core/src/api/OpenWalletSession.ts
+++ b/packages/core/src/api/OpenWalletSession.ts
@@ -160,7 +160,6 @@ export default class OpenWalletSession extends BaseMethod<OpenWalletSessionParam
       const session = isProtocolV2
         ? await getProtocolV2WalletSession(this.device, {
             onlyMainPin: true,
-            deriveCardano: this.payload.deriveCardano,
             selectMainWalletBeforeRestore:
               !hasAuthoritativeProtocolV2WalletStatus(state) ||
               state.status.unlockedAttachPin === true,
@@ -225,7 +224,6 @@ export default class OpenWalletSession extends BaseMethod<OpenWalletSessionParam
       const session = isProtocolV2
         ? await getProtocolV2WalletSession(this.device, {
             expectedPassphraseState: this.params.passphraseState,
-            deriveCardano: this.payload.deriveCardano,
           })
         : await getPassphraseStateWithRefreshDeviceInfo(this.device, {
             expectPassphraseState: this.params.passphraseState,
@@ -257,7 +255,6 @@ export default class OpenWalletSession extends BaseMethod<OpenWalletSessionParam
           ...(readCurrentAttachPinSession
             ? { readCurrentAttachPinSession: true }
             : { forceWalletSelection: true }),
-          deriveCardano: this.payload.deriveCardano,
         })
       : await getPassphraseStateWithRefreshDeviceInfo(this.device, { initSession: true });
     const refreshedState = isProtocolV2

--- a/packages/core/src/api/allnetwork/AllNetworkGetAddressBase.ts
+++ b/packages/core/src/api/allnetwork/AllNetworkGetAddressBase.ts
@@ -394,7 +394,7 @@ export default abstract class AllNetworkGetAddressBase extends BaseMethod<
           // requested standard or hidden wallet before sending its device command.
           const useEmptyPassphrase = this.payload.useEmptyPassphrase === true;
           // Nested Cardano methods opt in to [Standard, Cardano] if Ask rebuilds.
-          // Other chains omit the flag so V2 keeps firmware's default domains.
+          // Other chains stay Standard-only.
           const deriveCardano = method.name.startsWith('cardano') ? true : undefined;
           const shouldResumeWalletSession = useEmptyPassphrase || !!this.payload.passphraseState;
           if (this.device.isProtocolV2() && shouldResumeWalletSession) {

--- a/packages/core/src/api/allnetwork/AllNetworkGetAddressBase.ts
+++ b/packages/core/src/api/allnetwork/AllNetworkGetAddressBase.ts
@@ -393,7 +393,9 @@ export default abstract class AllNetworkGetAddressBase extends BaseMethod<
           // the root fingerprint, so each nested chain method must resume the
           // requested standard or hidden wallet before sending its device command.
           const useEmptyPassphrase = this.payload.useEmptyPassphrase === true;
-          const deriveCardano = method.name.startsWith('cardano');
+          // false would AskPassphrase with [Standard] only and permanently drop Cardano
+          // from a reused session. Omit the flag for non-Cardano nested methods.
+          const deriveCardano = method.name.startsWith('cardano') ? true : undefined;
           const shouldResumeWalletSession = useEmptyPassphrase || !!this.payload.passphraseState;
           if (this.device.isProtocolV2() && shouldResumeWalletSession) {
             const passphraseStateSafety = await this.device.checkPassphraseStateSafety(

--- a/packages/core/src/api/allnetwork/AllNetworkGetAddressBase.ts
+++ b/packages/core/src/api/allnetwork/AllNetworkGetAddressBase.ts
@@ -393,8 +393,8 @@ export default abstract class AllNetworkGetAddressBase extends BaseMethod<
           // the root fingerprint, so each nested chain method must resume the
           // requested standard or hidden wallet before sending its device command.
           const useEmptyPassphrase = this.payload.useEmptyPassphrase === true;
-          // false would AskPassphrase with [Standard] only and permanently drop Cardano
-          // from a reused session. Omit the flag for non-Cardano nested methods.
+          // Nested Cardano methods opt in to [Standard, Cardano] if Ask rebuilds.
+          // Other chains omit the flag so V2 keeps firmware's default domains.
           const deriveCardano = method.name.startsWith('cardano') ? true : undefined;
           const shouldResumeWalletSession = useEmptyPassphrase || !!this.payload.passphraseState;
           if (this.device.isProtocolV2() && shouldResumeWalletSession) {

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -105,8 +105,8 @@ function resolveDeriveCardano(method: BaseMethod): boolean | undefined {
   if (method.name.startsWith('cardano')) {
     return true;
   }
-  // V1 Initialize only acts on a true opt-in. V2 AskPassphrase must not treat
-  // false as Standard-only, so never forward an explicit false.
+  // V1 Initialize only sends derive_cardano on an explicit true.
+  // V2 AskPassphrase maps true to [Standard, Cardano] and anything else to [Standard].
   if (method.payload?.deriveCardano === true) {
     return true;
   }

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -105,8 +105,10 @@ function resolveDeriveCardano(method: BaseMethod): boolean | undefined {
   if (method.name.startsWith('cardano')) {
     return true;
   }
-  if (typeof method.payload?.deriveCardano === 'boolean') {
-    return method.payload.deriveCardano;
+  // V1 Initialize only acts on a true opt-in. V2 AskPassphrase must not treat
+  // false as Standard-only, so never forward an explicit false.
+  if (method.payload?.deriveCardano === true) {
+    return true;
   }
   return undefined;
 }

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -92,7 +92,7 @@ const preWarmDoneAt = new Map<string, number>();
 
 export type CoreContext = ReturnType<Core['getCoreContext']>;
 
-function hasDeriveCardano(method: BaseMethod): boolean {
+function resolveDeriveCardano(method: BaseMethod): boolean | undefined {
   if (
     method.name.startsWith('allNetworkGetAddress') &&
     method.payload &&
@@ -102,15 +102,20 @@ function hasDeriveCardano(method: BaseMethod): boolean {
   ) {
     return true;
   }
-
-  return method.name.startsWith('cardano') || method.payload?.deriveCardano;
+  if (method.name.startsWith('cardano')) {
+    return true;
+  }
+  if (typeof method.payload?.deriveCardano === 'boolean') {
+    return method.payload.deriveCardano;
+  }
+  return undefined;
 }
 
 const parseInitOptions = (method?: BaseMethod): InitOptions => ({
   initSession: method?.payload.initSession,
   passphraseState: method?.payload.useEmptyPassphrase ? undefined : method?.payload.passphraseState,
   deviceId: method?.payload.deviceId,
-  deriveCardano: method && hasDeriveCardano(method),
+  deriveCardano: method ? resolveDeriveCardano(method) : undefined,
   connectProtocol: method?.payload.connectProtocol,
   forceProtocolDetection: method?.payload.forceProtocolDetection,
   protocolV2DeviceInfoTimeoutMs: method?.payload.protocolV2DeviceInfoTimeoutMs,
@@ -651,7 +656,7 @@ const onCallDevice = async (
                 method.payload?.passphraseState,
                 method.payload?.useEmptyPassphrase,
                 method.payload?.skipPassphraseCheck,
-                hasDeriveCardano(method),
+                resolveDeriveCardano(method),
                 method.protocolV2UnlockContext?.preflightMainPinSelected
               );
 

--- a/packages/core/src/data/messages/messages-protocol-v2.json
+++ b/packages/core/src/data/messages/messages-protocol-v2.json
@@ -12322,6 +12322,11 @@
         "btc_test_address": {
           "type": "string",
           "id": 2
+        },
+        "seed_domains": {
+          "rule": "repeated",
+          "type": "DeviceSessionSeedDomain",
+          "id": 3
         }
       }
     },
@@ -12852,57 +12857,36 @@
       },
       "reserved": [[2, 2], "placeholder"]
     },
-    "ViewContentPreview": {
+    "ViewData": {
       "fields": {
-        "content_key": {
-          "rule": "required",
-          "type": "uint32",
-          "id": 1
-        },
         "preview": {
           "rule": "required",
           "type": "bytes",
-          "id": 2
-        },
-        "total_bytes": {
-          "type": "uint32",
-          "id": 3
-        }
-      }
-    },
-    "ViewContentEntry": {
-      "fields": {
-        "entry_key": {
-          "rule": "required",
-          "type": "uint32",
           "id": 1
         },
-        "value": {
+        "total_bytes": {
           "rule": "required",
-          "type": "bytes",
+          "type": "uint32",
           "id": 2
         }
       }
     },
-    "ViewContentPage": {
+    "ViewDataPage": {
       "fields": {
+        "chunk": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 1
+        },
         "page_index": {
           "rule": "required",
           "type": "uint32",
-          "id": 1
+          "id": 2
         },
         "page_count": {
           "rule": "required",
           "type": "uint32",
-          "id": 2
-        },
-        "chunk": {
-          "type": "bytes",
           "id": 3
-        },
-        "entry": {
-          "type": "ViewContentEntry",
-          "id": 4
         }
       }
     },
@@ -12961,8 +12945,8 @@
           "type": "string",
           "id": 9
         },
-        "content": {
-          "type": "ViewContentPreview",
+        "data": {
+          "type": "ViewData",
           "id": 10
         },
         "custom_field": {
@@ -12986,10 +12970,6 @@
         "text_arg": {
           "type": "string",
           "id": 3
-        },
-        "cancellable": {
-          "type": "bool",
-          "id": 4
         }
       }
     },
@@ -13028,10 +13008,6 @@
         "chain_id": {
           "type": "uint32",
           "id": 8
-        },
-        "content": {
-          "type": "ViewContentPreview",
-          "id": 9
         }
       }
     },

--- a/packages/core/src/data/messages/messages-protocol-v2.json
+++ b/packages/core/src/data/messages/messages-protocol-v2.json
@@ -12852,57 +12852,36 @@
       },
       "reserved": [[2, 2], "placeholder"]
     },
-    "ViewContentPreview": {
+    "ViewData": {
       "fields": {
-        "content_key": {
-          "rule": "required",
-          "type": "uint32",
-          "id": 1
-        },
         "preview": {
           "rule": "required",
           "type": "bytes",
-          "id": 2
-        },
-        "total_bytes": {
-          "type": "uint32",
-          "id": 3
-        }
-      }
-    },
-    "ViewContentEntry": {
-      "fields": {
-        "entry_key": {
-          "rule": "required",
-          "type": "uint32",
           "id": 1
         },
-        "value": {
+        "total_bytes": {
           "rule": "required",
-          "type": "bytes",
+          "type": "uint32",
           "id": 2
         }
       }
     },
-    "ViewContentPage": {
+    "ViewDataPage": {
       "fields": {
+        "chunk": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 1
+        },
         "page_index": {
           "rule": "required",
           "type": "uint32",
-          "id": 1
+          "id": 2
         },
         "page_count": {
           "rule": "required",
           "type": "uint32",
-          "id": 2
-        },
-        "chunk": {
-          "type": "bytes",
           "id": 3
-        },
-        "entry": {
-          "type": "ViewContentEntry",
-          "id": 4
         }
       }
     },
@@ -12961,8 +12940,8 @@
           "type": "string",
           "id": 9
         },
-        "content": {
-          "type": "ViewContentPreview",
+        "data": {
+          "type": "ViewData",
           "id": 10
         },
         "custom_field": {
@@ -12986,10 +12965,6 @@
         "text_arg": {
           "type": "string",
           "id": 3
-        },
-        "cancellable": {
-          "type": "bool",
-          "id": 4
         }
       }
     },
@@ -13028,10 +13003,6 @@
         "chain_id": {
           "type": "uint32",
           "id": 8
-        },
-        "content": {
-          "type": "ViewContentPreview",
-          "id": 9
         }
       }
     },

--- a/packages/core/src/data/messages/messages-protocol-v2.json
+++ b/packages/core/src/data/messages/messages-protocol-v2.json
@@ -12852,36 +12852,57 @@
       },
       "reserved": [[2, 2], "placeholder"]
     },
-    "ViewData": {
+    "ViewContentPreview": {
       "fields": {
+        "content_key": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 1
+        },
         "preview": {
           "rule": "required",
           "type": "bytes",
-          "id": 1
+          "id": 2
         },
         "total_bytes": {
+          "type": "uint32",
+          "id": 3
+        }
+      }
+    },
+    "ViewContentEntry": {
+      "fields": {
+        "entry_key": {
           "rule": "required",
           "type": "uint32",
+          "id": 1
+        },
+        "value": {
+          "rule": "required",
+          "type": "bytes",
           "id": 2
         }
       }
     },
-    "ViewDataPage": {
+    "ViewContentPage": {
       "fields": {
-        "chunk": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 1
-        },
         "page_index": {
           "rule": "required",
           "type": "uint32",
-          "id": 2
+          "id": 1
         },
         "page_count": {
           "rule": "required",
           "type": "uint32",
+          "id": 2
+        },
+        "chunk": {
+          "type": "bytes",
           "id": 3
+        },
+        "entry": {
+          "type": "ViewContentEntry",
+          "id": 4
         }
       }
     },
@@ -12940,8 +12961,8 @@
           "type": "string",
           "id": 9
         },
-        "data": {
-          "type": "ViewData",
+        "content": {
+          "type": "ViewContentPreview",
           "id": 10
         },
         "custom_field": {
@@ -12965,6 +12986,10 @@
         "text_arg": {
           "type": "string",
           "id": 3
+        },
+        "cancellable": {
+          "type": "bool",
+          "id": 4
         }
       }
     },
@@ -13003,6 +13028,10 @@
         "chain_id": {
           "type": "uint32",
           "id": 8
+        },
+        "content": {
+          "type": "ViewContentPreview",
+          "id": 9
         }
       }
     },

--- a/packages/core/src/data/messages/messages-protocol-v2.json
+++ b/packages/core/src/data/messages/messages-protocol-v2.json
@@ -12322,11 +12322,6 @@
         "btc_test_address": {
           "type": "string",
           "id": 2
-        },
-        "seed_domains": {
-          "rule": "repeated",
-          "type": "DeviceSessionSeedDomain",
-          "id": 3
         }
       }
     },
@@ -12857,36 +12852,57 @@
       },
       "reserved": [[2, 2], "placeholder"]
     },
-    "ViewData": {
+    "ViewContentPreview": {
       "fields": {
+        "content_key": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 1
+        },
         "preview": {
           "rule": "required",
           "type": "bytes",
-          "id": 1
+          "id": 2
         },
         "total_bytes": {
+          "type": "uint32",
+          "id": 3
+        }
+      }
+    },
+    "ViewContentEntry": {
+      "fields": {
+        "entry_key": {
           "rule": "required",
           "type": "uint32",
+          "id": 1
+        },
+        "value": {
+          "rule": "required",
+          "type": "bytes",
           "id": 2
         }
       }
     },
-    "ViewDataPage": {
+    "ViewContentPage": {
       "fields": {
-        "chunk": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 1
-        },
         "page_index": {
           "rule": "required",
           "type": "uint32",
-          "id": 2
+          "id": 1
         },
         "page_count": {
           "rule": "required",
           "type": "uint32",
+          "id": 2
+        },
+        "chunk": {
+          "type": "bytes",
           "id": 3
+        },
+        "entry": {
+          "type": "ViewContentEntry",
+          "id": 4
         }
       }
     },
@@ -12945,8 +12961,8 @@
           "type": "string",
           "id": 9
         },
-        "data": {
-          "type": "ViewData",
+        "content": {
+          "type": "ViewContentPreview",
           "id": 10
         },
         "custom_field": {
@@ -12970,6 +12986,10 @@
         "text_arg": {
           "type": "string",
           "id": 3
+        },
+        "cancellable": {
+          "type": "bool",
+          "id": 4
         }
       }
     },
@@ -13008,6 +13028,10 @@
         "chain_id": {
           "type": "uint32",
           "id": 8
+        },
+        "content": {
+          "type": "ViewContentPreview",
+          "id": 9
         }
       }
     },

--- a/packages/core/src/data/messages/messages-protocol-v2.json
+++ b/packages/core/src/data/messages/messages-protocol-v2.json
@@ -1,490 +1,5 @@
 {
   "nested": {
-    "wire_in": {
-      "type": "bool",
-      "id": 50002,
-      "extend": "google.protobuf.EnumValueOptions"
-    },
-    "wire_out": {
-      "type": "bool",
-      "id": 50003,
-      "extend": "google.protobuf.EnumValueOptions"
-    },
-    "wire_debug_in": {
-      "type": "bool",
-      "id": 50004,
-      "extend": "google.protobuf.EnumValueOptions"
-    },
-    "wire_debug_out": {
-      "type": "bool",
-      "id": 50005,
-      "extend": "google.protobuf.EnumValueOptions"
-    },
-    "wire_tiny": {
-      "type": "bool",
-      "id": 50006,
-      "extend": "google.protobuf.EnumValueOptions"
-    },
-    "wire_bootloader": {
-      "type": "bool",
-      "id": 50007,
-      "extend": "google.protobuf.EnumValueOptions"
-    },
-    "wire_no_fsm": {
-      "type": "bool",
-      "id": 50008,
-      "extend": "google.protobuf.EnumValueOptions"
-    },
-    "bitcoin_only": {
-      "type": "bool",
-      "id": 60000,
-      "extend": "google.protobuf.EnumValueOptions"
-    },
-    "has_bitcoin_only_values": {
-      "type": "bool",
-      "id": 51001,
-      "extend": "google.protobuf.EnumOptions"
-    },
-    "experimental_message": {
-      "type": "bool",
-      "id": 52001,
-      "extend": "google.protobuf.MessageOptions"
-    },
-    "wire_type": {
-      "type": "uint32",
-      "id": 52002,
-      "extend": "google.protobuf.MessageOptions"
-    },
-    "experimental_field": {
-      "type": "bool",
-      "id": 53001,
-      "extend": "google.protobuf.FieldOptions"
-    },
-    "include_in_bitcoin_only": {
-      "type": "bool",
-      "id": 60000,
-      "extend": "google.protobuf.FileOptions"
-    },
-    "MessageType": {
-      "options": {
-        "(has_bitcoin_only_values)": true
-      },
-      "values": {
-        "MessageType_Initialize": 0,
-        "MessageType_ChangePin": 4,
-        "MessageType_WipeDevice": 5,
-        "MessageType_GetEntropy": 9,
-        "MessageType_Entropy": 10,
-        "MessageType_LoadDevice": 13,
-        "MessageType_ResetDevice": 14,
-        "MessageType_SetBusy": 16,
-        "MessageType_Features": 17,
-        "MessageType_Cancel": 20,
-        "MessageType_LockDevice": 24,
-        "MessageType_ApplySettings": 25,
-        "MessageType_ButtonRequest": 26,
-        "MessageType_ButtonAck": 27,
-        "MessageType_ApplyFlags": 28,
-        "MessageType_GetNonce": 31,
-        "MessageType_Nonce": 33,
-        "MessageType_BackupDevice": 34,
-        "MessageType_EntropyRequest": 35,
-        "MessageType_EntropyAck": 36,
-        "MessageType_PassphraseRequest": 41,
-        "MessageType_PassphraseAck": 42,
-        "MessageType_RecoveryDevice": 45,
-        "MessageType_WordRequest": 46,
-        "MessageType_WordAck": 47,
-        "MessageType_GetFeatures": 55,
-        "MessageType_SdProtect": 79,
-        "MessageType_ChangeWipeCode": 82,
-        "MessageType_DoPreauthorized": 84,
-        "MessageType_PreauthorizedRequest": 85,
-        "MessageType_CancelAuthorization": 86,
-        "MessageType_GetFirmwareHash": 88,
-        "MessageType_FirmwareHash": 89,
-        "MessageType_UnlockPath": 93,
-        "MessageType_UnlockedPathRequest": 94,
-        "MessageType_SetU2FCounter": 63,
-        "MessageType_GetNextU2FCounter": 80,
-        "MessageType_NextU2FCounter": 81,
-        "MessageType_Deprecated_PassphraseStateRequest": 77,
-        "MessageType_Deprecated_PassphraseStateAck": 78,
-        "MessageType_GetPublicKey": 11,
-        "MessageType_PublicKey": 12,
-        "MessageType_SignTx": 15,
-        "MessageType_TxRequest": 21,
-        "MessageType_TxAck": 22,
-        "MessageType_GetAddress": 29,
-        "MessageType_Address": 30,
-        "MessageType_TxAckPaymentRequest": 37,
-        "MessageType_SignMessage": 38,
-        "MessageType_VerifyMessage": 39,
-        "MessageType_MessageSignature": 40,
-        "MessageType_GetOwnershipId": 43,
-        "MessageType_OwnershipId": 44,
-        "MessageType_GetOwnershipProof": 49,
-        "MessageType_OwnershipProof": 50,
-        "MessageType_AuthorizeCoinJoin": 51,
-        "MessageType_SignPsbt": 10052,
-        "MessageType_SignedPsbt": 10053,
-        "MessageType_CipherKeyValue": 23,
-        "MessageType_CipheredKeyValue": 48,
-        "MessageType_SignIdentity": 53,
-        "MessageType_SignedIdentity": 54,
-        "MessageType_GetECDHSessionKey": 61,
-        "MessageType_ECDHSessionKey": 62,
-        "MessageType_CosiCommit": 71,
-        "MessageType_CosiCommitment": 72,
-        "MessageType_CosiSign": 73,
-        "MessageType_CosiSignature": 74,
-        "MessageType_BatchGetPublickeys": 10016,
-        "MessageType_EcdsaPublicKeys": 10017,
-        "MessageType_EthereumGetPublicKey": 450,
-        "MessageType_EthereumPublicKey": 451,
-        "MessageType_EthereumGetAddress": 56,
-        "MessageType_EthereumAddress": 57,
-        "MessageType_EthereumSignTx": 58,
-        "MessageType_EthereumSignTxEIP1559": 452,
-        "MessageType_EthereumTxRequest": 59,
-        "MessageType_EthereumTxAck": 60,
-        "MessageType_EthereumSignMessage": 64,
-        "MessageType_EthereumVerifyMessage": 65,
-        "MessageType_EthereumMessageSignature": 66,
-        "MessageType_EthereumSignTypedData": 464,
-        "MessageType_EthereumTypedDataStructRequest": 465,
-        "MessageType_EthereumTypedDataStructAck": 466,
-        "MessageType_EthereumTypedDataValueRequest": 467,
-        "MessageType_EthereumTypedDataValueAck": 468,
-        "MessageType_EthereumTypedDataSignature": 469,
-        "MessageType_EthereumSignTypedHash": 470,
-        "MessageType_EthereumGetPublicKeyOneKey": 20100,
-        "MessageType_EthereumPublicKeyOneKey": 20101,
-        "MessageType_EthereumGetAddressOneKey": 20102,
-        "MessageType_EthereumAddressOneKey": 20103,
-        "MessageType_EthereumSignTxOneKey": 20104,
-        "MessageType_EthereumSignTxEIP1559OneKey": 20105,
-        "MessageType_EthereumTxRequestOneKey": 20106,
-        "MessageType_EthereumTxAckOneKey": 20107,
-        "MessageType_EthereumSignMessageOneKey": 20108,
-        "MessageType_EthereumVerifyMessageOneKey": 20109,
-        "MessageType_EthereumMessageSignatureOneKey": 20110,
-        "MessageType_EthereumSignTypedDataOneKey": 20111,
-        "MessageType_EthereumTypedDataStructRequestOneKey": 20112,
-        "MessageType_EthereumTypedDataStructAckOneKey": 20113,
-        "MessageType_EthereumTypedDataValueRequestOneKey": 20114,
-        "MessageType_EthereumTypedDataValueAckOneKey": 20115,
-        "MessageType_EthereumTypedDataSignatureOneKey": 20116,
-        "MessageType_EthereumSignTypedHashOneKey": 20117,
-        "MessageType_EthereumGnosisSafeTxAck": 20118,
-        "MessageType_EthereumGnosisSafeTxRequest": 20119,
-        "MessageType_EthereumSignTxEIP7702OneKey": 20120,
-        "MessageType_EthereumSignTypedDataQR": 20121,
-        "MessageType_NEMGetAddress": 67,
-        "MessageType_NEMAddress": 68,
-        "MessageType_NEMSignTx": 69,
-        "MessageType_NEMSignedTx": 70,
-        "MessageType_NEMDecryptMessage": 75,
-        "MessageType_NEMDecryptedMessage": 76,
-        "MessageType_TezosGetAddress": 150,
-        "MessageType_TezosAddress": 151,
-        "MessageType_TezosSignTx": 152,
-        "MessageType_TezosSignedTx": 153,
-        "MessageType_TezosGetPublicKey": 154,
-        "MessageType_TezosPublicKey": 155,
-        "MessageType_StellarSignTx": 202,
-        "MessageType_StellarTxOpRequest": 203,
-        "MessageType_StellarGetAddress": 207,
-        "MessageType_StellarAddress": 208,
-        "MessageType_StellarCreateAccountOp": 210,
-        "MessageType_StellarPaymentOp": 211,
-        "MessageType_StellarPathPaymentStrictReceiveOp": 212,
-        "MessageType_StellarManageSellOfferOp": 213,
-        "MessageType_StellarCreatePassiveSellOfferOp": 214,
-        "MessageType_StellarSetOptionsOp": 215,
-        "MessageType_StellarChangeTrustOp": 216,
-        "MessageType_StellarAllowTrustOp": 217,
-        "MessageType_StellarAccountMergeOp": 218,
-        "MessageType_StellarManageDataOp": 220,
-        "MessageType_StellarBumpSequenceOp": 221,
-        "MessageType_StellarManageBuyOfferOp": 222,
-        "MessageType_StellarPathPaymentStrictSendOp": 223,
-        "MessageType_StellarSignedTx": 230,
-        "MessageType_CardanoGetPublicKey": 305,
-        "MessageType_CardanoPublicKey": 306,
-        "MessageType_CardanoGetAddress": 307,
-        "MessageType_CardanoAddress": 308,
-        "MessageType_CardanoTxItemAck": 313,
-        "MessageType_CardanoTxAuxiliaryDataSupplement": 314,
-        "MessageType_CardanoTxWitnessRequest": 315,
-        "MessageType_CardanoTxWitnessResponse": 316,
-        "MessageType_CardanoTxHostAck": 317,
-        "MessageType_CardanoTxBodyHash": 318,
-        "MessageType_CardanoSignTxFinished": 319,
-        "MessageType_CardanoSignTxInit": 320,
-        "MessageType_CardanoTxInput": 321,
-        "MessageType_CardanoTxOutput": 322,
-        "MessageType_CardanoAssetGroup": 323,
-        "MessageType_CardanoToken": 324,
-        "MessageType_CardanoTxCertificate": 325,
-        "MessageType_CardanoTxWithdrawal": 326,
-        "MessageType_CardanoTxAuxiliaryData": 327,
-        "MessageType_CardanoPoolOwner": 328,
-        "MessageType_CardanoPoolRelayParameters": 329,
-        "MessageType_CardanoGetNativeScriptHash": 330,
-        "MessageType_CardanoNativeScriptHash": 331,
-        "MessageType_CardanoTxMint": 332,
-        "MessageType_CardanoTxCollateralInput": 333,
-        "MessageType_CardanoTxRequiredSigner": 334,
-        "MessageType_CardanoTxInlineDatumChunk": 335,
-        "MessageType_CardanoTxReferenceScriptChunk": 336,
-        "MessageType_CardanoTxReferenceInput": 337,
-        "MessageType_CardanoSignMessage": 350,
-        "MessageType_CardanoMessageSignature": 351,
-        "MessageType_RippleGetAddress": 400,
-        "MessageType_RippleAddress": 401,
-        "MessageType_RippleSignTx": 402,
-        "MessageType_RippleSignedTx": 403,
-        "MessageType_MoneroTransactionInitRequest": 501,
-        "MessageType_MoneroTransactionInitAck": 502,
-        "MessageType_MoneroTransactionSetInputRequest": 503,
-        "MessageType_MoneroTransactionSetInputAck": 504,
-        "MessageType_MoneroTransactionInputViniRequest": 507,
-        "MessageType_MoneroTransactionInputViniAck": 508,
-        "MessageType_MoneroTransactionAllInputsSetRequest": 509,
-        "MessageType_MoneroTransactionAllInputsSetAck": 510,
-        "MessageType_MoneroTransactionSetOutputRequest": 511,
-        "MessageType_MoneroTransactionSetOutputAck": 512,
-        "MessageType_MoneroTransactionAllOutSetRequest": 513,
-        "MessageType_MoneroTransactionAllOutSetAck": 514,
-        "MessageType_MoneroTransactionSignInputRequest": 515,
-        "MessageType_MoneroTransactionSignInputAck": 516,
-        "MessageType_MoneroTransactionFinalRequest": 517,
-        "MessageType_MoneroTransactionFinalAck": 518,
-        "MessageType_MoneroKeyImageExportInitRequest": 530,
-        "MessageType_MoneroKeyImageExportInitAck": 531,
-        "MessageType_MoneroKeyImageSyncStepRequest": 532,
-        "MessageType_MoneroKeyImageSyncStepAck": 533,
-        "MessageType_MoneroKeyImageSyncFinalRequest": 534,
-        "MessageType_MoneroKeyImageSyncFinalAck": 535,
-        "MessageType_MoneroGetAddress": 540,
-        "MessageType_MoneroAddress": 541,
-        "MessageType_MoneroGetWatchKey": 542,
-        "MessageType_MoneroWatchKey": 543,
-        "MessageType_DebugMoneroDiagRequest": 546,
-        "MessageType_DebugMoneroDiagAck": 547,
-        "MessageType_MoneroGetTxKeyRequest": 550,
-        "MessageType_MoneroGetTxKeyAck": 551,
-        "MessageType_MoneroLiveRefreshStartRequest": 552,
-        "MessageType_MoneroLiveRefreshStartAck": 553,
-        "MessageType_MoneroLiveRefreshStepRequest": 554,
-        "MessageType_MoneroLiveRefreshStepAck": 555,
-        "MessageType_MoneroLiveRefreshFinalRequest": 556,
-        "MessageType_MoneroLiveRefreshFinalAck": 557,
-        "MessageType_EosGetPublicKey": 600,
-        "MessageType_EosPublicKey": 601,
-        "MessageType_EosSignTx": 602,
-        "MessageType_EosTxActionRequest": 603,
-        "MessageType_EosTxActionAck": 604,
-        "MessageType_EosSignedTx": 605,
-        "MessageType_BinanceGetAddress": 700,
-        "MessageType_BinanceAddress": 701,
-        "MessageType_BinanceGetPublicKey": 702,
-        "MessageType_BinancePublicKey": 703,
-        "MessageType_BinanceSignTx": 704,
-        "MessageType_BinanceTxRequest": 705,
-        "MessageType_BinanceTransferMsg": 706,
-        "MessageType_BinanceOrderMsg": 707,
-        "MessageType_BinanceCancelMsg": 708,
-        "MessageType_BinanceSignedTx": 709,
-        "MessageType_StarcoinGetAddress": 10300,
-        "MessageType_StarcoinAddress": 10301,
-        "MessageType_StarcoinGetPublicKey": 10302,
-        "MessageType_StarcoinPublicKey": 10303,
-        "MessageType_StarcoinSignTx": 10304,
-        "MessageType_StarcoinSignedTx": 10305,
-        "MessageType_StarcoinSignMessage": 10306,
-        "MessageType_StarcoinMessageSignature": 10307,
-        "MessageType_StarcoinVerifyMessage": 10308,
-        "MessageType_ConfluxGetAddress": 10112,
-        "MessageType_ConfluxAddress": 10113,
-        "MessageType_ConfluxSignTx": 10114,
-        "MessageType_ConfluxTxRequest": 10115,
-        "MessageType_ConfluxTxAck": 10116,
-        "MessageType_ConfluxSignMessage": 10117,
-        "MessageType_ConfluxSignMessageCIP23": 10118,
-        "MessageType_ConfluxMessageSignature": 10119,
-        "MessageType_TronGetAddress": 10501,
-        "MessageType_TronAddress": 10502,
-        "MessageType_TronSignTx": 10503,
-        "MessageType_TronSignedTx": 10504,
-        "MessageType_TronSignMessage": 10505,
-        "MessageType_TronMessageSignature": 10506,
-        "MessageType_NearGetAddress": 10701,
-        "MessageType_NearAddress": 10702,
-        "MessageType_NearSignTx": 10703,
-        "MessageType_NearSignedTx": 10704,
-        "MessageType_AptosGetAddress": 10600,
-        "MessageType_AptosAddress": 10601,
-        "MessageType_AptosSignTx": 10602,
-        "MessageType_AptosSignedTx": 10603,
-        "MessageType_AptosSignMessage": 10604,
-        "MessageType_AptosMessageSignature": 10605,
-        "MessageType_AptosSignSIWAMessage": 10606,
-        "MessageType_WebAuthnListResidentCredentials": 800,
-        "MessageType_WebAuthnCredentials": 801,
-        "MessageType_WebAuthnAddResidentCredential": 802,
-        "MessageType_WebAuthnRemoveResidentCredential": 803,
-        "MessageType_SolanaGetAddress": 10100,
-        "MessageType_SolanaAddress": 10101,
-        "MessageType_SolanaSignTx": 10102,
-        "MessageType_SolanaSignedTx": 10103,
-        "MessageType_SolanaSignOffChainMessage": 10104,
-        "MessageType_SolanaMessageSignature": 10105,
-        "MessageType_SolanaSignUnsafeMessage": 10106,
-        "MessageType_CosmosGetAddress": 10800,
-        "MessageType_CosmosAddress": 10801,
-        "MessageType_CosmosSignTx": 10802,
-        "MessageType_CosmosSignedTx": 10803,
-        "MessageType_AlgorandGetAddress": 10900,
-        "MessageType_AlgorandAddress": 10901,
-        "MessageType_AlgorandSignTx": 10902,
-        "MessageType_AlgorandSignedTx": 10903,
-        "MessageType_PolkadotGetAddress": 11000,
-        "MessageType_PolkadotAddress": 11001,
-        "MessageType_PolkadotSignTx": 11002,
-        "MessageType_PolkadotSignedTx": 11003,
-        "MessageType_SuiGetAddress": 11100,
-        "MessageType_SuiAddress": 11101,
-        "MessageType_SuiSignTx": 11102,
-        "MessageType_SuiSignedTx": 11103,
-        "MessageType_SuiSignMessage": 11104,
-        "MessageType_SuiMessageSignature": 11105,
-        "MessageType_SuiTxRequest": 11106,
-        "MessageType_SuiTxAck": 11107,
-        "MessageType_FilecoinGetAddress": 11200,
-        "MessageType_FilecoinAddress": 11201,
-        "MessageType_FilecoinSignTx": 11202,
-        "MessageType_FilecoinSignedTx": 11203,
-        "MessageType_KaspaGetAddress": 11300,
-        "MessageType_KaspaAddress": 11301,
-        "MessageType_KaspaSignTx": 11302,
-        "MessageType_KaspaSignedTx": 11303,
-        "MessageType_KaspaTxInputRequest": 11304,
-        "MessageType_KaspaTxInputAck": 11305,
-        "MessageType_NexaGetAddress": 11400,
-        "MessageType_NexaAddress": 11401,
-        "MessageType_NexaSignTx": 11402,
-        "MessageType_NexaSignedTx": 11403,
-        "MessageType_NexaTxInputRequest": 11404,
-        "MessageType_NexaTxInputAck": 11405,
-        "MessageType_NostrGetPublicKey": 11500,
-        "MessageType_NostrPublicKey": 11501,
-        "MessageType_NostrSignEvent": 11502,
-        "MessageType_NostrSignedEvent": 11503,
-        "MessageType_NostrEncryptMessage": 11504,
-        "MessageType_NostrEncryptedMessage": 11505,
-        "MessageType_NostrDecryptMessage": 11506,
-        "MessageType_NostrDecryptedMessage": 11507,
-        "MessageType_NostrSignSchnorr": 11508,
-        "MessageType_NostrSignedSchnorr": 11509,
-        "MessageType_LnurlAuth": 11600,
-        "MessageType_LnurlAuthResp": 11601,
-        "MessageType_NervosGetAddress": 11701,
-        "MessageType_NervosAddress": 11702,
-        "MessageType_NervosSignTx": 11703,
-        "MessageType_NervosSignedTx": 11704,
-        "MessageType_NervosTxRequest": 11705,
-        "MessageType_NervosTxAck": 11706,
-        "MessageType_TonGetAddress": 11901,
-        "MessageType_TonAddress": 11902,
-        "MessageType_TonSignMessage": 11903,
-        "MessageType_TonSignedMessage": 11904,
-        "MessageType_TonSignProof": 11905,
-        "MessageType_TonSignedProof": 11906,
-        "MessageType_TonTxAck": 11907,
-        "MessageType_AlephiumGetAddress": 12101,
-        "MessageType_AlephiumAddress": 12102,
-        "MessageType_AlephiumSignTx": 12103,
-        "MessageType_AlephiumSignedTx": 12104,
-        "MessageType_AlephiumTxRequest": 12105,
-        "MessageType_AlephiumTxAck": 12106,
-        "MessageType_AlephiumBytecodeRequest": 12107,
-        "MessageType_AlephiumBytecodeAck": 12108,
-        "MessageType_AlephiumSignMessage": 12109,
-        "MessageType_AlephiumMessageSignature": 12110,
-        "MessageType_BenfenGetAddress": 12201,
-        "MessageType_BenfenAddress": 12202,
-        "MessageType_BenfenSignTx": 12203,
-        "MessageType_BenfenSignedTx": 12204,
-        "MessageType_BenfenSignMessage": 12205,
-        "MessageType_BenfenMessageSignature": 12206,
-        "MessageType_BenfenTxRequest": 12207,
-        "MessageType_BenfenTxAck": 12208,
-        "MessageType_NeoGetAddress": 12301,
-        "MessageType_NeoAddress": 12302,
-        "MessageType_NeoSignTx": 12303,
-        "MessageType_NeoSignedTx": 12304,
-        "MessageType_DeviceFactoryInfoSet": 60000,
-        "MessageType_DeviceFactoryInfoGet": 60001,
-        "MessageType_DeviceFactoryInfo": 60002,
-        "MessageType_DeviceFactoryPermanentLock": 60003,
-        "MessageType_DeviceFactoryTest": 60004,
-        "MessageType_ProtocolInfoRequest": 60200,
-        "MessageType_ProtocolInfo": 60201,
-        "MessageType_Ping": 60206,
-        "MessageType_Success": 60207,
-        "MessageType_Failure": 60208,
-        "MessageType_DeviceReboot": 60400,
-        "MessageType_DeviceSettings": 60410,
-        "MessageType_DeviceSettingsGet": 60411,
-        "MessageType_DeviceSettingsSet": 60412,
-        "MessageType_DeviceSettingsPageShow": 60413,
-        "MessageType_DeviceCertificate": 60420,
-        "MessageType_DeviceCertificateWrite": 60421,
-        "MessageType_DeviceCertificateRead": 60422,
-        "MessageType_DeviceCertificateSignature": 60423,
-        "MessageType_DeviceCertificateSign": 60424,
-        "MessageType_DeviceMiscUsbMscControl": 60440,
-        "MessageType_DeviceFindMyTokenState": 60450,
-        "MessageType_DeviceFindMyTokenUpdate": 60451,
-        "MessageType_DeviceFindMyTokenStateGet": 60452,
-        "MessageType_DeviceInfoGet": 60600,
-        "MessageType_DeviceInfo": 60601,
-        "MessageType_DeviceStatusGet": 60602,
-        "MessageType_DeviceStatus": 60603,
-        "MessageType_FilesystemPermissionFix": 60800,
-        "MessageType_FilesystemPathInfo": 60801,
-        "MessageType_FilesystemPathInfoQuery": 60802,
-        "MessageType_FilesystemFile": 60803,
-        "MessageType_FilesystemFileRead": 60804,
-        "MessageType_FilesystemFileWrite": 60805,
-        "MessageType_FilesystemFileDelete": 60806,
-        "MessageType_FilesystemDir": 60807,
-        "MessageType_FilesystemDirList": 60808,
-        "MessageType_FilesystemDirMake": 60809,
-        "MessageType_FilesystemDirRemove": 60810,
-        "MessageType_FilesystemFormat": 60811,
-        "MessageType_DeviceFirmwareUpdateStage": 61000,
-        "MessageType_DeviceFirmwareUpdateRequest": 61001,
-        "MessageType_DeviceFirmwareUpdateStatusGet": 61002,
-        "MessageType_DeviceFirmwareUpdateStatus": 61003,
-        "MessageType_DeviceSessionGet": 61200,
-        "MessageType_DeviceSession": 61201,
-        "MessageType_DeviceSessionAskPin": 61202,
-        "MessageType_DeviceSessionAskPassphrase": 61203,
-        "MessageType_PortfolioUpdate": 61400,
-        "MessageType_NftUpdate": 61500,
-        "MessageType_OnboardingStatusGet": 61600,
-        "MessageType_OnboardingStatus": 61601
-      },
-      "reserved": [
-        [90, 92],
-        [114, 122],
-        [300, 304],
-        [309, 312]
-      ]
-    },
     "AlephiumGetAddress": {
       "fields": {
         "address_n": {
@@ -4653,349 +4168,6 @@
         }
       }
     },
-    "EthereumGetPublicKey": {
-      "fields": {
-        "address_n": {
-          "rule": "repeated",
-          "type": "uint32",
-          "id": 1,
-          "options": {
-            "packed": false
-          }
-        },
-        "show_display": {
-          "type": "bool",
-          "id": 2
-        }
-      }
-    },
-    "EthereumPublicKey": {
-      "fields": {
-        "node": {
-          "rule": "required",
-          "type": "HDNodeType",
-          "id": 1
-        },
-        "xpub": {
-          "rule": "required",
-          "type": "string",
-          "id": 2
-        }
-      }
-    },
-    "EthereumGetAddress": {
-      "fields": {
-        "address_n": {
-          "rule": "repeated",
-          "type": "uint32",
-          "id": 1,
-          "options": {
-            "packed": false
-          }
-        },
-        "show_display": {
-          "type": "bool",
-          "id": 2
-        },
-        "encoded_network": {
-          "type": "bytes",
-          "id": 3
-        }
-      }
-    },
-    "EthereumAddress": {
-      "fields": {
-        "_old_address": {
-          "type": "bytes",
-          "id": 1,
-          "options": {
-            "deprecated": true
-          }
-        },
-        "address": {
-          "type": "string",
-          "id": 2
-        }
-      }
-    },
-    "EthereumSignTx": {
-      "fields": {
-        "address_n": {
-          "rule": "repeated",
-          "type": "uint32",
-          "id": 1,
-          "options": {
-            "packed": false
-          }
-        },
-        "nonce": {
-          "type": "bytes",
-          "id": 2,
-          "options": {
-            "default": ""
-          }
-        },
-        "gas_price": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 3
-        },
-        "gas_limit": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 4
-        },
-        "to": {
-          "type": "string",
-          "id": 11,
-          "options": {
-            "default": ""
-          }
-        },
-        "value": {
-          "type": "bytes",
-          "id": 6,
-          "options": {
-            "default": ""
-          }
-        },
-        "data_initial_chunk": {
-          "type": "bytes",
-          "id": 7,
-          "options": {
-            "default": ""
-          }
-        },
-        "data_length": {
-          "type": "uint32",
-          "id": 8,
-          "options": {
-            "default": 0
-          }
-        },
-        "chain_id": {
-          "rule": "required",
-          "type": "uint64",
-          "id": 9
-        },
-        "tx_type": {
-          "type": "uint32",
-          "id": 10
-        },
-        "definitions": {
-          "type": "EthereumDefinitions",
-          "id": 12
-        }
-      }
-    },
-    "EthereumSignTxEIP1559": {
-      "fields": {
-        "address_n": {
-          "rule": "repeated",
-          "type": "uint32",
-          "id": 1,
-          "options": {
-            "packed": false
-          }
-        },
-        "nonce": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 2
-        },
-        "max_gas_fee": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 3
-        },
-        "max_priority_fee": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 4
-        },
-        "gas_limit": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 5
-        },
-        "to": {
-          "type": "string",
-          "id": 6,
-          "options": {
-            "default": ""
-          }
-        },
-        "value": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 7
-        },
-        "data_initial_chunk": {
-          "type": "bytes",
-          "id": 8,
-          "options": {
-            "default": ""
-          }
-        },
-        "data_length": {
-          "rule": "required",
-          "type": "uint32",
-          "id": 9
-        },
-        "chain_id": {
-          "rule": "required",
-          "type": "uint64",
-          "id": 10
-        },
-        "access_list": {
-          "rule": "repeated",
-          "type": "EthereumAccessList",
-          "id": 11
-        },
-        "definitions": {
-          "type": "EthereumDefinitions",
-          "id": 12
-        }
-      },
-      "nested": {
-        "EthereumAccessList": {
-          "fields": {
-            "address": {
-              "rule": "required",
-              "type": "string",
-              "id": 1
-            },
-            "storage_keys": {
-              "rule": "repeated",
-              "type": "bytes",
-              "id": 2
-            }
-          }
-        }
-      }
-    },
-    "EthereumTxRequest": {
-      "fields": {
-        "data_length": {
-          "type": "uint32",
-          "id": 1
-        },
-        "signature_v": {
-          "type": "uint32",
-          "id": 2
-        },
-        "signature_r": {
-          "type": "bytes",
-          "id": 3
-        },
-        "signature_s": {
-          "type": "bytes",
-          "id": 4
-        }
-      }
-    },
-    "EthereumTxAck": {
-      "fields": {
-        "data_chunk": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 1
-        }
-      }
-    },
-    "EthereumSignMessage": {
-      "fields": {
-        "address_n": {
-          "rule": "repeated",
-          "type": "uint32",
-          "id": 1,
-          "options": {
-            "packed": false
-          }
-        },
-        "message": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 2
-        },
-        "encoded_network": {
-          "type": "bytes",
-          "id": 3
-        }
-      }
-    },
-    "EthereumMessageSignature": {
-      "fields": {
-        "signature": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 2
-        },
-        "address": {
-          "rule": "required",
-          "type": "string",
-          "id": 3
-        }
-      }
-    },
-    "EthereumVerifyMessage": {
-      "fields": {
-        "signature": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 2
-        },
-        "message": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 3
-        },
-        "address": {
-          "rule": "required",
-          "type": "string",
-          "id": 4
-        }
-      }
-    },
-    "EthereumSignTypedHash": {
-      "fields": {
-        "address_n": {
-          "rule": "repeated",
-          "type": "uint32",
-          "id": 1,
-          "options": {
-            "packed": false
-          }
-        },
-        "domain_separator_hash": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 2
-        },
-        "message_hash": {
-          "type": "bytes",
-          "id": 3
-        },
-        "encoded_network": {
-          "type": "bytes",
-          "id": 4
-        }
-      }
-    },
-    "EthereumTypedDataSignature": {
-      "fields": {
-        "signature": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 1
-        },
-        "address": {
-          "rule": "required",
-          "type": "string",
-          "id": 2
-        }
-      }
-    },
     "EthereumDefinitionType": {
       "values": {
         "NETWORK": 0,
@@ -5072,122 +4244,6 @@
         "encoded_token": {
           "type": "bytes",
           "id": 2
-        }
-      }
-    },
-    "EthereumSignTypedData": {
-      "fields": {
-        "address_n": {
-          "rule": "repeated",
-          "type": "uint32",
-          "id": 1,
-          "options": {
-            "packed": false
-          }
-        },
-        "primary_type": {
-          "rule": "required",
-          "type": "string",
-          "id": 2
-        },
-        "metamask_v4_compat": {
-          "type": "bool",
-          "id": 3,
-          "options": {
-            "default": true
-          }
-        },
-        "definitions": {
-          "type": "EthereumDefinitions",
-          "id": 4
-        }
-      }
-    },
-    "EthereumTypedDataStructRequest": {
-      "fields": {
-        "name": {
-          "rule": "required",
-          "type": "string",
-          "id": 1
-        }
-      }
-    },
-    "EthereumTypedDataStructAck": {
-      "fields": {
-        "members": {
-          "rule": "repeated",
-          "type": "EthereumStructMember",
-          "id": 1
-        }
-      },
-      "nested": {
-        "EthereumStructMember": {
-          "fields": {
-            "type": {
-              "rule": "required",
-              "type": "EthereumFieldType",
-              "id": 1
-            },
-            "name": {
-              "rule": "required",
-              "type": "string",
-              "id": 2
-            }
-          }
-        },
-        "EthereumFieldType": {
-          "fields": {
-            "data_type": {
-              "rule": "required",
-              "type": "EthereumDataType",
-              "id": 1
-            },
-            "size": {
-              "type": "uint32",
-              "id": 2
-            },
-            "entry_type": {
-              "type": "EthereumFieldType",
-              "id": 3
-            },
-            "struct_name": {
-              "type": "string",
-              "id": 4
-            }
-          }
-        },
-        "EthereumDataType": {
-          "values": {
-            "UINT": 1,
-            "INT": 2,
-            "BYTES": 3,
-            "STRING": 4,
-            "BOOL": 5,
-            "ADDRESS": 6,
-            "ARRAY": 7,
-            "STRUCT": 8
-          }
-        }
-      }
-    },
-    "EthereumTypedDataValueRequest": {
-      "fields": {
-        "member_path": {
-          "rule": "repeated",
-          "type": "uint32",
-          "id": 1,
-          "options": {
-            "packed": false
-          }
-        }
-      }
-    },
-    "EthereumTypedDataValueAck": {
-      "fields": {
-        "value": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 1
         }
       }
     },
@@ -5411,6 +4467,122 @@
         "source_fingerprint": {
           "type": "uint32",
           "id": 6
+        }
+      }
+    },
+    "EthereumSignTypedData": {
+      "fields": {
+        "address_n": {
+          "rule": "repeated",
+          "type": "uint32",
+          "id": 1,
+          "options": {
+            "packed": false
+          }
+        },
+        "primary_type": {
+          "rule": "required",
+          "type": "string",
+          "id": 2
+        },
+        "metamask_v4_compat": {
+          "type": "bool",
+          "id": 3,
+          "options": {
+            "default": true
+          }
+        },
+        "definitions": {
+          "type": "EthereumDefinitions",
+          "id": 4
+        }
+      }
+    },
+    "EthereumTypedDataStructRequest": {
+      "fields": {
+        "name": {
+          "rule": "required",
+          "type": "string",
+          "id": 1
+        }
+      }
+    },
+    "EthereumTypedDataStructAck": {
+      "fields": {
+        "members": {
+          "rule": "repeated",
+          "type": "EthereumStructMember",
+          "id": 1
+        }
+      },
+      "nested": {
+        "EthereumStructMember": {
+          "fields": {
+            "type": {
+              "rule": "required",
+              "type": "EthereumFieldType",
+              "id": 1
+            },
+            "name": {
+              "rule": "required",
+              "type": "string",
+              "id": 2
+            }
+          }
+        },
+        "EthereumFieldType": {
+          "fields": {
+            "data_type": {
+              "rule": "required",
+              "type": "EthereumDataType",
+              "id": 1
+            },
+            "size": {
+              "type": "uint32",
+              "id": 2
+            },
+            "entry_type": {
+              "type": "EthereumFieldType",
+              "id": 3
+            },
+            "struct_name": {
+              "type": "string",
+              "id": 4
+            }
+          }
+        },
+        "EthereumDataType": {
+          "values": {
+            "UINT": 1,
+            "INT": 2,
+            "BYTES": 3,
+            "STRING": 4,
+            "BOOL": 5,
+            "ADDRESS": 6,
+            "ARRAY": 7,
+            "STRUCT": 8
+          }
+        }
+      }
+    },
+    "EthereumTypedDataValueRequest": {
+      "fields": {
+        "member_path": {
+          "rule": "repeated",
+          "type": "uint32",
+          "id": 1,
+          "options": {
+            "packed": false
+          }
+        }
+      }
+    },
+    "EthereumTypedDataValueAck": {
+      "fields": {
+        "value": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 1
         }
       }
     },
@@ -5888,6 +5060,349 @@
       }
     },
     "EthereumTypedDataSignatureOneKey": {
+      "fields": {
+        "signature": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 1
+        },
+        "address": {
+          "rule": "required",
+          "type": "string",
+          "id": 2
+        }
+      }
+    },
+    "EthereumGetPublicKey": {
+      "fields": {
+        "address_n": {
+          "rule": "repeated",
+          "type": "uint32",
+          "id": 1,
+          "options": {
+            "packed": false
+          }
+        },
+        "show_display": {
+          "type": "bool",
+          "id": 2
+        }
+      }
+    },
+    "EthereumPublicKey": {
+      "fields": {
+        "node": {
+          "rule": "required",
+          "type": "HDNodeType",
+          "id": 1
+        },
+        "xpub": {
+          "rule": "required",
+          "type": "string",
+          "id": 2
+        }
+      }
+    },
+    "EthereumGetAddress": {
+      "fields": {
+        "address_n": {
+          "rule": "repeated",
+          "type": "uint32",
+          "id": 1,
+          "options": {
+            "packed": false
+          }
+        },
+        "show_display": {
+          "type": "bool",
+          "id": 2
+        },
+        "encoded_network": {
+          "type": "bytes",
+          "id": 3
+        }
+      }
+    },
+    "EthereumAddress": {
+      "fields": {
+        "_old_address": {
+          "type": "bytes",
+          "id": 1,
+          "options": {
+            "deprecated": true
+          }
+        },
+        "address": {
+          "type": "string",
+          "id": 2
+        }
+      }
+    },
+    "EthereumSignTx": {
+      "fields": {
+        "address_n": {
+          "rule": "repeated",
+          "type": "uint32",
+          "id": 1,
+          "options": {
+            "packed": false
+          }
+        },
+        "nonce": {
+          "type": "bytes",
+          "id": 2,
+          "options": {
+            "default": ""
+          }
+        },
+        "gas_price": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 3
+        },
+        "gas_limit": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 4
+        },
+        "to": {
+          "type": "string",
+          "id": 11,
+          "options": {
+            "default": ""
+          }
+        },
+        "value": {
+          "type": "bytes",
+          "id": 6,
+          "options": {
+            "default": ""
+          }
+        },
+        "data_initial_chunk": {
+          "type": "bytes",
+          "id": 7,
+          "options": {
+            "default": ""
+          }
+        },
+        "data_length": {
+          "type": "uint32",
+          "id": 8,
+          "options": {
+            "default": 0
+          }
+        },
+        "chain_id": {
+          "rule": "required",
+          "type": "uint64",
+          "id": 9
+        },
+        "tx_type": {
+          "type": "uint32",
+          "id": 10
+        },
+        "definitions": {
+          "type": "EthereumDefinitions",
+          "id": 12
+        }
+      }
+    },
+    "EthereumSignTxEIP1559": {
+      "fields": {
+        "address_n": {
+          "rule": "repeated",
+          "type": "uint32",
+          "id": 1,
+          "options": {
+            "packed": false
+          }
+        },
+        "nonce": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 2
+        },
+        "max_gas_fee": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 3
+        },
+        "max_priority_fee": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 4
+        },
+        "gas_limit": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 5
+        },
+        "to": {
+          "type": "string",
+          "id": 6,
+          "options": {
+            "default": ""
+          }
+        },
+        "value": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 7
+        },
+        "data_initial_chunk": {
+          "type": "bytes",
+          "id": 8,
+          "options": {
+            "default": ""
+          }
+        },
+        "data_length": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 9
+        },
+        "chain_id": {
+          "rule": "required",
+          "type": "uint64",
+          "id": 10
+        },
+        "access_list": {
+          "rule": "repeated",
+          "type": "EthereumAccessList",
+          "id": 11
+        },
+        "definitions": {
+          "type": "EthereumDefinitions",
+          "id": 12
+        }
+      },
+      "nested": {
+        "EthereumAccessList": {
+          "fields": {
+            "address": {
+              "rule": "required",
+              "type": "string",
+              "id": 1
+            },
+            "storage_keys": {
+              "rule": "repeated",
+              "type": "bytes",
+              "id": 2
+            }
+          }
+        }
+      }
+    },
+    "EthereumTxRequest": {
+      "fields": {
+        "data_length": {
+          "type": "uint32",
+          "id": 1
+        },
+        "signature_v": {
+          "type": "uint32",
+          "id": 2
+        },
+        "signature_r": {
+          "type": "bytes",
+          "id": 3
+        },
+        "signature_s": {
+          "type": "bytes",
+          "id": 4
+        }
+      }
+    },
+    "EthereumTxAck": {
+      "fields": {
+        "data_chunk": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 1
+        }
+      }
+    },
+    "EthereumSignMessage": {
+      "fields": {
+        "address_n": {
+          "rule": "repeated",
+          "type": "uint32",
+          "id": 1,
+          "options": {
+            "packed": false
+          }
+        },
+        "message": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 2
+        },
+        "encoded_network": {
+          "type": "bytes",
+          "id": 3
+        }
+      }
+    },
+    "EthereumMessageSignature": {
+      "fields": {
+        "signature": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 2
+        },
+        "address": {
+          "rule": "required",
+          "type": "string",
+          "id": 3
+        }
+      }
+    },
+    "EthereumVerifyMessage": {
+      "fields": {
+        "signature": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 2
+        },
+        "message": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 3
+        },
+        "address": {
+          "rule": "required",
+          "type": "string",
+          "id": 4
+        }
+      }
+    },
+    "EthereumSignTypedHash": {
+      "fields": {
+        "address_n": {
+          "rule": "repeated",
+          "type": "uint32",
+          "id": 1,
+          "options": {
+            "packed": false
+          }
+        },
+        "domain_separator_hash": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 2
+        },
+        "message_hash": {
+          "type": "bytes",
+          "id": 3
+        },
+        "encoded_network": {
+          "type": "bytes",
+          "id": 4
+        }
+      }
+    },
+    "EthereumTypedDataSignature": {
       "fields": {
         "signature": {
           "rule": "required",
@@ -11537,6 +11052,491 @@
         }
       }
     },
+    "wire_in": {
+      "type": "bool",
+      "id": 50002,
+      "extend": "google.protobuf.EnumValueOptions"
+    },
+    "wire_out": {
+      "type": "bool",
+      "id": 50003,
+      "extend": "google.protobuf.EnumValueOptions"
+    },
+    "wire_debug_in": {
+      "type": "bool",
+      "id": 50004,
+      "extend": "google.protobuf.EnumValueOptions"
+    },
+    "wire_debug_out": {
+      "type": "bool",
+      "id": 50005,
+      "extend": "google.protobuf.EnumValueOptions"
+    },
+    "wire_tiny": {
+      "type": "bool",
+      "id": 50006,
+      "extend": "google.protobuf.EnumValueOptions"
+    },
+    "wire_bootloader": {
+      "type": "bool",
+      "id": 50007,
+      "extend": "google.protobuf.EnumValueOptions"
+    },
+    "wire_no_fsm": {
+      "type": "bool",
+      "id": 50008,
+      "extend": "google.protobuf.EnumValueOptions"
+    },
+    "bitcoin_only": {
+      "type": "bool",
+      "id": 60000,
+      "extend": "google.protobuf.EnumValueOptions"
+    },
+    "has_bitcoin_only_values": {
+      "type": "bool",
+      "id": 51001,
+      "extend": "google.protobuf.EnumOptions"
+    },
+    "experimental_message": {
+      "type": "bool",
+      "id": 52001,
+      "extend": "google.protobuf.MessageOptions"
+    },
+    "wire_type": {
+      "type": "uint32",
+      "id": 52002,
+      "extend": "google.protobuf.MessageOptions"
+    },
+    "experimental_field": {
+      "type": "bool",
+      "id": 53001,
+      "extend": "google.protobuf.FieldOptions"
+    },
+    "include_in_bitcoin_only": {
+      "type": "bool",
+      "id": 60000,
+      "extend": "google.protobuf.FileOptions"
+    },
+    "MessageType": {
+      "options": {
+        "(has_bitcoin_only_values)": true
+      },
+      "values": {
+        "MessageType_Initialize": 0,
+        "MessageType_ChangePin": 4,
+        "MessageType_WipeDevice": 5,
+        "MessageType_GetEntropy": 9,
+        "MessageType_Entropy": 10,
+        "MessageType_LoadDevice": 13,
+        "MessageType_ResetDevice": 14,
+        "MessageType_SetBusy": 16,
+        "MessageType_Features": 17,
+        "MessageType_Cancel": 20,
+        "MessageType_LockDevice": 24,
+        "MessageType_ApplySettings": 25,
+        "MessageType_ButtonRequest": 26,
+        "MessageType_ButtonAck": 27,
+        "MessageType_ApplyFlags": 28,
+        "MessageType_GetNonce": 31,
+        "MessageType_Nonce": 33,
+        "MessageType_BackupDevice": 34,
+        "MessageType_EntropyRequest": 35,
+        "MessageType_EntropyAck": 36,
+        "MessageType_PassphraseRequest": 41,
+        "MessageType_PassphraseAck": 42,
+        "MessageType_RecoveryDevice": 45,
+        "MessageType_WordRequest": 46,
+        "MessageType_WordAck": 47,
+        "MessageType_GetFeatures": 55,
+        "MessageType_SdProtect": 79,
+        "MessageType_ChangeWipeCode": 82,
+        "MessageType_DoPreauthorized": 84,
+        "MessageType_PreauthorizedRequest": 85,
+        "MessageType_CancelAuthorization": 86,
+        "MessageType_GetFirmwareHash": 88,
+        "MessageType_FirmwareHash": 89,
+        "MessageType_UnlockPath": 93,
+        "MessageType_UnlockedPathRequest": 94,
+        "MessageType_SetU2FCounter": 63,
+        "MessageType_GetNextU2FCounter": 80,
+        "MessageType_NextU2FCounter": 81,
+        "MessageType_Deprecated_PassphraseStateRequest": 77,
+        "MessageType_Deprecated_PassphraseStateAck": 78,
+        "MessageType_GetPublicKey": 11,
+        "MessageType_PublicKey": 12,
+        "MessageType_SignTx": 15,
+        "MessageType_TxRequest": 21,
+        "MessageType_TxAck": 22,
+        "MessageType_GetAddress": 29,
+        "MessageType_Address": 30,
+        "MessageType_TxAckPaymentRequest": 37,
+        "MessageType_SignMessage": 38,
+        "MessageType_VerifyMessage": 39,
+        "MessageType_MessageSignature": 40,
+        "MessageType_GetOwnershipId": 43,
+        "MessageType_OwnershipId": 44,
+        "MessageType_GetOwnershipProof": 49,
+        "MessageType_OwnershipProof": 50,
+        "MessageType_AuthorizeCoinJoin": 51,
+        "MessageType_SignPsbt": 10052,
+        "MessageType_SignedPsbt": 10053,
+        "MessageType_CipherKeyValue": 23,
+        "MessageType_CipheredKeyValue": 48,
+        "MessageType_SignIdentity": 53,
+        "MessageType_SignedIdentity": 54,
+        "MessageType_GetECDHSessionKey": 61,
+        "MessageType_ECDHSessionKey": 62,
+        "MessageType_CosiCommit": 71,
+        "MessageType_CosiCommitment": 72,
+        "MessageType_CosiSign": 73,
+        "MessageType_CosiSignature": 74,
+        "MessageType_BatchGetPublickeys": 10016,
+        "MessageType_EcdsaPublicKeys": 10017,
+        "MessageType_EthereumGetPublicKey": 450,
+        "MessageType_EthereumPublicKey": 451,
+        "MessageType_EthereumGetAddress": 56,
+        "MessageType_EthereumAddress": 57,
+        "MessageType_EthereumSignTx": 58,
+        "MessageType_EthereumSignTxEIP1559": 452,
+        "MessageType_EthereumTxRequest": 59,
+        "MessageType_EthereumTxAck": 60,
+        "MessageType_EthereumSignMessage": 64,
+        "MessageType_EthereumVerifyMessage": 65,
+        "MessageType_EthereumMessageSignature": 66,
+        "MessageType_EthereumSignTypedData": 464,
+        "MessageType_EthereumTypedDataStructRequest": 465,
+        "MessageType_EthereumTypedDataStructAck": 466,
+        "MessageType_EthereumTypedDataValueRequest": 467,
+        "MessageType_EthereumTypedDataValueAck": 468,
+        "MessageType_EthereumTypedDataSignature": 469,
+        "MessageType_EthereumSignTypedHash": 470,
+        "MessageType_EthereumGetPublicKeyOneKey": 20100,
+        "MessageType_EthereumPublicKeyOneKey": 20101,
+        "MessageType_EthereumGetAddressOneKey": 20102,
+        "MessageType_EthereumAddressOneKey": 20103,
+        "MessageType_EthereumSignTxOneKey": 20104,
+        "MessageType_EthereumSignTxEIP1559OneKey": 20105,
+        "MessageType_EthereumTxRequestOneKey": 20106,
+        "MessageType_EthereumTxAckOneKey": 20107,
+        "MessageType_EthereumSignMessageOneKey": 20108,
+        "MessageType_EthereumVerifyMessageOneKey": 20109,
+        "MessageType_EthereumMessageSignatureOneKey": 20110,
+        "MessageType_EthereumSignTypedDataOneKey": 20111,
+        "MessageType_EthereumTypedDataStructRequestOneKey": 20112,
+        "MessageType_EthereumTypedDataStructAckOneKey": 20113,
+        "MessageType_EthereumTypedDataValueRequestOneKey": 20114,
+        "MessageType_EthereumTypedDataValueAckOneKey": 20115,
+        "MessageType_EthereumTypedDataSignatureOneKey": 20116,
+        "MessageType_EthereumSignTypedHashOneKey": 20117,
+        "MessageType_EthereumGnosisSafeTxAck": 20118,
+        "MessageType_EthereumGnosisSafeTxRequest": 20119,
+        "MessageType_EthereumSignTxEIP7702OneKey": 20120,
+        "MessageType_EthereumSignTypedDataQR": 20121,
+        "MessageType_NEMGetAddress": 67,
+        "MessageType_NEMAddress": 68,
+        "MessageType_NEMSignTx": 69,
+        "MessageType_NEMSignedTx": 70,
+        "MessageType_NEMDecryptMessage": 75,
+        "MessageType_NEMDecryptedMessage": 76,
+        "MessageType_TezosGetAddress": 150,
+        "MessageType_TezosAddress": 151,
+        "MessageType_TezosSignTx": 152,
+        "MessageType_TezosSignedTx": 153,
+        "MessageType_TezosGetPublicKey": 154,
+        "MessageType_TezosPublicKey": 155,
+        "MessageType_StellarSignTx": 202,
+        "MessageType_StellarTxOpRequest": 203,
+        "MessageType_StellarGetAddress": 207,
+        "MessageType_StellarAddress": 208,
+        "MessageType_StellarCreateAccountOp": 210,
+        "MessageType_StellarPaymentOp": 211,
+        "MessageType_StellarPathPaymentStrictReceiveOp": 212,
+        "MessageType_StellarManageSellOfferOp": 213,
+        "MessageType_StellarCreatePassiveSellOfferOp": 214,
+        "MessageType_StellarSetOptionsOp": 215,
+        "MessageType_StellarChangeTrustOp": 216,
+        "MessageType_StellarAllowTrustOp": 217,
+        "MessageType_StellarAccountMergeOp": 218,
+        "MessageType_StellarManageDataOp": 220,
+        "MessageType_StellarBumpSequenceOp": 221,
+        "MessageType_StellarManageBuyOfferOp": 222,
+        "MessageType_StellarPathPaymentStrictSendOp": 223,
+        "MessageType_StellarSignedTx": 230,
+        "MessageType_CardanoGetPublicKey": 305,
+        "MessageType_CardanoPublicKey": 306,
+        "MessageType_CardanoGetAddress": 307,
+        "MessageType_CardanoAddress": 308,
+        "MessageType_CardanoTxItemAck": 313,
+        "MessageType_CardanoTxAuxiliaryDataSupplement": 314,
+        "MessageType_CardanoTxWitnessRequest": 315,
+        "MessageType_CardanoTxWitnessResponse": 316,
+        "MessageType_CardanoTxHostAck": 317,
+        "MessageType_CardanoTxBodyHash": 318,
+        "MessageType_CardanoSignTxFinished": 319,
+        "MessageType_CardanoSignTxInit": 320,
+        "MessageType_CardanoTxInput": 321,
+        "MessageType_CardanoTxOutput": 322,
+        "MessageType_CardanoAssetGroup": 323,
+        "MessageType_CardanoToken": 324,
+        "MessageType_CardanoTxCertificate": 325,
+        "MessageType_CardanoTxWithdrawal": 326,
+        "MessageType_CardanoTxAuxiliaryData": 327,
+        "MessageType_CardanoPoolOwner": 328,
+        "MessageType_CardanoPoolRelayParameters": 329,
+        "MessageType_CardanoGetNativeScriptHash": 330,
+        "MessageType_CardanoNativeScriptHash": 331,
+        "MessageType_CardanoTxMint": 332,
+        "MessageType_CardanoTxCollateralInput": 333,
+        "MessageType_CardanoTxRequiredSigner": 334,
+        "MessageType_CardanoTxInlineDatumChunk": 335,
+        "MessageType_CardanoTxReferenceScriptChunk": 336,
+        "MessageType_CardanoTxReferenceInput": 337,
+        "MessageType_CardanoSignMessage": 350,
+        "MessageType_CardanoMessageSignature": 351,
+        "MessageType_RippleGetAddress": 400,
+        "MessageType_RippleAddress": 401,
+        "MessageType_RippleSignTx": 402,
+        "MessageType_RippleSignedTx": 403,
+        "MessageType_MoneroTransactionInitRequest": 501,
+        "MessageType_MoneroTransactionInitAck": 502,
+        "MessageType_MoneroTransactionSetInputRequest": 503,
+        "MessageType_MoneroTransactionSetInputAck": 504,
+        "MessageType_MoneroTransactionInputViniRequest": 507,
+        "MessageType_MoneroTransactionInputViniAck": 508,
+        "MessageType_MoneroTransactionAllInputsSetRequest": 509,
+        "MessageType_MoneroTransactionAllInputsSetAck": 510,
+        "MessageType_MoneroTransactionSetOutputRequest": 511,
+        "MessageType_MoneroTransactionSetOutputAck": 512,
+        "MessageType_MoneroTransactionAllOutSetRequest": 513,
+        "MessageType_MoneroTransactionAllOutSetAck": 514,
+        "MessageType_MoneroTransactionSignInputRequest": 515,
+        "MessageType_MoneroTransactionSignInputAck": 516,
+        "MessageType_MoneroTransactionFinalRequest": 517,
+        "MessageType_MoneroTransactionFinalAck": 518,
+        "MessageType_MoneroKeyImageExportInitRequest": 530,
+        "MessageType_MoneroKeyImageExportInitAck": 531,
+        "MessageType_MoneroKeyImageSyncStepRequest": 532,
+        "MessageType_MoneroKeyImageSyncStepAck": 533,
+        "MessageType_MoneroKeyImageSyncFinalRequest": 534,
+        "MessageType_MoneroKeyImageSyncFinalAck": 535,
+        "MessageType_MoneroGetAddress": 540,
+        "MessageType_MoneroAddress": 541,
+        "MessageType_MoneroGetWatchKey": 542,
+        "MessageType_MoneroWatchKey": 543,
+        "MessageType_DebugMoneroDiagRequest": 546,
+        "MessageType_DebugMoneroDiagAck": 547,
+        "MessageType_MoneroGetTxKeyRequest": 550,
+        "MessageType_MoneroGetTxKeyAck": 551,
+        "MessageType_MoneroLiveRefreshStartRequest": 552,
+        "MessageType_MoneroLiveRefreshStartAck": 553,
+        "MessageType_MoneroLiveRefreshStepRequest": 554,
+        "MessageType_MoneroLiveRefreshStepAck": 555,
+        "MessageType_MoneroLiveRefreshFinalRequest": 556,
+        "MessageType_MoneroLiveRefreshFinalAck": 557,
+        "MessageType_EosGetPublicKey": 600,
+        "MessageType_EosPublicKey": 601,
+        "MessageType_EosSignTx": 602,
+        "MessageType_EosTxActionRequest": 603,
+        "MessageType_EosTxActionAck": 604,
+        "MessageType_EosSignedTx": 605,
+        "MessageType_BinanceGetAddress": 700,
+        "MessageType_BinanceAddress": 701,
+        "MessageType_BinanceGetPublicKey": 702,
+        "MessageType_BinancePublicKey": 703,
+        "MessageType_BinanceSignTx": 704,
+        "MessageType_BinanceTxRequest": 705,
+        "MessageType_BinanceTransferMsg": 706,
+        "MessageType_BinanceOrderMsg": 707,
+        "MessageType_BinanceCancelMsg": 708,
+        "MessageType_BinanceSignedTx": 709,
+        "MessageType_StarcoinGetAddress": 10300,
+        "MessageType_StarcoinAddress": 10301,
+        "MessageType_StarcoinGetPublicKey": 10302,
+        "MessageType_StarcoinPublicKey": 10303,
+        "MessageType_StarcoinSignTx": 10304,
+        "MessageType_StarcoinSignedTx": 10305,
+        "MessageType_StarcoinSignMessage": 10306,
+        "MessageType_StarcoinMessageSignature": 10307,
+        "MessageType_StarcoinVerifyMessage": 10308,
+        "MessageType_ConfluxGetAddress": 10112,
+        "MessageType_ConfluxAddress": 10113,
+        "MessageType_ConfluxSignTx": 10114,
+        "MessageType_ConfluxTxRequest": 10115,
+        "MessageType_ConfluxTxAck": 10116,
+        "MessageType_ConfluxSignMessage": 10117,
+        "MessageType_ConfluxSignMessageCIP23": 10118,
+        "MessageType_ConfluxMessageSignature": 10119,
+        "MessageType_TronGetAddress": 10501,
+        "MessageType_TronAddress": 10502,
+        "MessageType_TronSignTx": 10503,
+        "MessageType_TronSignedTx": 10504,
+        "MessageType_TronSignMessage": 10505,
+        "MessageType_TronMessageSignature": 10506,
+        "MessageType_NearGetAddress": 10701,
+        "MessageType_NearAddress": 10702,
+        "MessageType_NearSignTx": 10703,
+        "MessageType_NearSignedTx": 10704,
+        "MessageType_AptosGetAddress": 10600,
+        "MessageType_AptosAddress": 10601,
+        "MessageType_AptosSignTx": 10602,
+        "MessageType_AptosSignedTx": 10603,
+        "MessageType_AptosSignMessage": 10604,
+        "MessageType_AptosMessageSignature": 10605,
+        "MessageType_AptosSignSIWAMessage": 10606,
+        "MessageType_WebAuthnListResidentCredentials": 800,
+        "MessageType_WebAuthnCredentials": 801,
+        "MessageType_WebAuthnAddResidentCredential": 802,
+        "MessageType_WebAuthnRemoveResidentCredential": 803,
+        "MessageType_SolanaGetAddress": 10100,
+        "MessageType_SolanaAddress": 10101,
+        "MessageType_SolanaSignTx": 10102,
+        "MessageType_SolanaSignedTx": 10103,
+        "MessageType_SolanaSignOffChainMessage": 10104,
+        "MessageType_SolanaMessageSignature": 10105,
+        "MessageType_SolanaSignUnsafeMessage": 10106,
+        "MessageType_CosmosGetAddress": 10800,
+        "MessageType_CosmosAddress": 10801,
+        "MessageType_CosmosSignTx": 10802,
+        "MessageType_CosmosSignedTx": 10803,
+        "MessageType_AlgorandGetAddress": 10900,
+        "MessageType_AlgorandAddress": 10901,
+        "MessageType_AlgorandSignTx": 10902,
+        "MessageType_AlgorandSignedTx": 10903,
+        "MessageType_PolkadotGetAddress": 11000,
+        "MessageType_PolkadotAddress": 11001,
+        "MessageType_PolkadotSignTx": 11002,
+        "MessageType_PolkadotSignedTx": 11003,
+        "MessageType_SuiGetAddress": 11100,
+        "MessageType_SuiAddress": 11101,
+        "MessageType_SuiSignTx": 11102,
+        "MessageType_SuiSignedTx": 11103,
+        "MessageType_SuiSignMessage": 11104,
+        "MessageType_SuiMessageSignature": 11105,
+        "MessageType_SuiTxRequest": 11106,
+        "MessageType_SuiTxAck": 11107,
+        "MessageType_FilecoinGetAddress": 11200,
+        "MessageType_FilecoinAddress": 11201,
+        "MessageType_FilecoinSignTx": 11202,
+        "MessageType_FilecoinSignedTx": 11203,
+        "MessageType_KaspaGetAddress": 11300,
+        "MessageType_KaspaAddress": 11301,
+        "MessageType_KaspaSignTx": 11302,
+        "MessageType_KaspaSignedTx": 11303,
+        "MessageType_KaspaTxInputRequest": 11304,
+        "MessageType_KaspaTxInputAck": 11305,
+        "MessageType_NexaGetAddress": 11400,
+        "MessageType_NexaAddress": 11401,
+        "MessageType_NexaSignTx": 11402,
+        "MessageType_NexaSignedTx": 11403,
+        "MessageType_NexaTxInputRequest": 11404,
+        "MessageType_NexaTxInputAck": 11405,
+        "MessageType_NostrGetPublicKey": 11500,
+        "MessageType_NostrPublicKey": 11501,
+        "MessageType_NostrSignEvent": 11502,
+        "MessageType_NostrSignedEvent": 11503,
+        "MessageType_NostrEncryptMessage": 11504,
+        "MessageType_NostrEncryptedMessage": 11505,
+        "MessageType_NostrDecryptMessage": 11506,
+        "MessageType_NostrDecryptedMessage": 11507,
+        "MessageType_NostrSignSchnorr": 11508,
+        "MessageType_NostrSignedSchnorr": 11509,
+        "MessageType_LnurlAuth": 11600,
+        "MessageType_LnurlAuthResp": 11601,
+        "MessageType_NervosGetAddress": 11701,
+        "MessageType_NervosAddress": 11702,
+        "MessageType_NervosSignTx": 11703,
+        "MessageType_NervosSignedTx": 11704,
+        "MessageType_NervosTxRequest": 11705,
+        "MessageType_NervosTxAck": 11706,
+        "MessageType_TonGetAddress": 11901,
+        "MessageType_TonAddress": 11902,
+        "MessageType_TonSignMessage": 11903,
+        "MessageType_TonSignedMessage": 11904,
+        "MessageType_TonSignProof": 11905,
+        "MessageType_TonSignedProof": 11906,
+        "MessageType_TonTxAck": 11907,
+        "MessageType_AlephiumGetAddress": 12101,
+        "MessageType_AlephiumAddress": 12102,
+        "MessageType_AlephiumSignTx": 12103,
+        "MessageType_AlephiumSignedTx": 12104,
+        "MessageType_AlephiumTxRequest": 12105,
+        "MessageType_AlephiumTxAck": 12106,
+        "MessageType_AlephiumBytecodeRequest": 12107,
+        "MessageType_AlephiumBytecodeAck": 12108,
+        "MessageType_AlephiumSignMessage": 12109,
+        "MessageType_AlephiumMessageSignature": 12110,
+        "MessageType_BenfenGetAddress": 12201,
+        "MessageType_BenfenAddress": 12202,
+        "MessageType_BenfenSignTx": 12203,
+        "MessageType_BenfenSignedTx": 12204,
+        "MessageType_BenfenSignMessage": 12205,
+        "MessageType_BenfenMessageSignature": 12206,
+        "MessageType_BenfenTxRequest": 12207,
+        "MessageType_BenfenTxAck": 12208,
+        "MessageType_NeoGetAddress": 12301,
+        "MessageType_NeoAddress": 12302,
+        "MessageType_NeoSignTx": 12303,
+        "MessageType_NeoSignedTx": 12304,
+        "MessageType_DeviceFactoryInfoSet": 60000,
+        "MessageType_DeviceFactoryInfoGet": 60001,
+        "MessageType_DeviceFactoryInfo": 60002,
+        "MessageType_DeviceFactoryPermanentLock": 60003,
+        "MessageType_DeviceFactoryTest": 60004,
+        "MessageType_ProtocolInfoRequest": 60200,
+        "MessageType_ProtocolInfo": 60201,
+        "MessageType_Ping": 60206,
+        "MessageType_Success": 60207,
+        "MessageType_Failure": 60208,
+        "MessageType_DeviceReboot": 60400,
+        "MessageType_DeviceSettings": 60410,
+        "MessageType_DeviceSettingsGet": 60411,
+        "MessageType_DeviceSettingsSet": 60412,
+        "MessageType_DeviceSettingsPageShow": 60413,
+        "MessageType_DeviceCertificate": 60420,
+        "MessageType_DeviceCertificateWrite": 60421,
+        "MessageType_DeviceCertificateRead": 60422,
+        "MessageType_DeviceCertificateSignature": 60423,
+        "MessageType_DeviceCertificateSign": 60424,
+        "MessageType_DeviceMiscUsbMscControl": 60440,
+        "MessageType_DeviceFindMyTokenState": 60450,
+        "MessageType_DeviceFindMyTokenUpdate": 60451,
+        "MessageType_DeviceFindMyTokenStateGet": 60452,
+        "MessageType_DeviceInfoGet": 60600,
+        "MessageType_DeviceInfo": 60601,
+        "MessageType_DeviceStatusGet": 60602,
+        "MessageType_DeviceStatus": 60603,
+        "MessageType_FilesystemPermissionFix": 60800,
+        "MessageType_FilesystemPathInfo": 60801,
+        "MessageType_FilesystemPathInfoQuery": 60802,
+        "MessageType_FilesystemFile": 60803,
+        "MessageType_FilesystemFileRead": 60804,
+        "MessageType_FilesystemFileWrite": 60805,
+        "MessageType_FilesystemFileDelete": 60806,
+        "MessageType_FilesystemDir": 60807,
+        "MessageType_FilesystemDirList": 60808,
+        "MessageType_FilesystemDirMake": 60809,
+        "MessageType_FilesystemDirRemove": 60810,
+        "MessageType_FilesystemFormat": 60811,
+        "MessageType_DeviceFirmwareUpdateStage": 61000,
+        "MessageType_DeviceFirmwareUpdateRequest": 61001,
+        "MessageType_DeviceFirmwareUpdateStatusGet": 61002,
+        "MessageType_DeviceFirmwareUpdateStatus": 61003,
+        "MessageType_DeviceSessionGet": 61200,
+        "MessageType_DeviceSession": 61201,
+        "MessageType_DeviceSessionAskPin": 61202,
+        "MessageType_DeviceSessionAskPassphrase": 61203,
+        "MessageType_PortfolioUpdate": 61400,
+        "MessageType_NftUpdate": 61500,
+        "MessageType_OnboardingStatusGet": 61600,
+        "MessageType_OnboardingStatus": 61601
+      },
+      "reserved": [
+        [90, 92],
+        [114, 122],
+        [300, 304],
+        [309, 312]
+      ]
+    },
     "ProtocolInfoRequest": {
       "fields": {
         "eventless_wallet_session": {
@@ -12322,11 +12322,6 @@
         "btc_test_address": {
           "type": "string",
           "id": 2
-        },
-        "seed_domains": {
-          "rule": "repeated",
-          "type": "DeviceSessionSeedDomain",
-          "id": 3
         }
       }
     },
@@ -12367,6 +12362,11 @@
           "rule": "required",
           "type": "bool",
           "id": 2
+        },
+        "seed_domains": {
+          "rule": "repeated",
+          "type": "DeviceSessionSeedDomain",
+          "id": 3
         }
       }
     },
@@ -12766,7 +12766,8 @@
           "type": "string",
           "id": 2
         }
-      }
+      },
+      "reserved": [[3, 3], "symbol"]
     },
     "ViewDetail": {
       "fields": {
@@ -12789,6 +12790,20 @@
           "rule": "required",
           "type": "bool",
           "id": 4
+        }
+      }
+    },
+    "ViewCustomField": {
+      "fields": {
+        "key": {
+          "rule": "required",
+          "type": "string",
+          "id": 1
+        },
+        "value": {
+          "rule": "required",
+          "type": "string",
+          "id": 2
         }
       }
     },
@@ -12822,17 +12837,67 @@
         }
       }
     },
-    "ViewRawData": {
+    "ViewActionCard": {
       "fields": {
         "initial_data": {
           "rule": "required",
           "type": "string",
           "id": 1
+        }
+      },
+      "reserved": [[2, 2], "placeholder"]
+    },
+    "ViewContentPreview": {
+      "fields": {
+        "content_key": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 1
         },
-        "placeholder": {
+        "preview": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 2
+        },
+        "total_bytes": {
+          "type": "uint32",
+          "id": 3
+        }
+      }
+    },
+    "ViewContentEntry": {
+      "fields": {
+        "entry_key": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 1
+        },
+        "value": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 2
+        }
+      }
+    },
+    "ViewContentPage": {
+      "fields": {
+        "page_index": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 1
+        },
+        "page_count": {
           "rule": "required",
           "type": "uint32",
           "id": 2
+        },
+        "chunk": {
+          "type": "bytes",
+          "id": 3
+        },
+        "entry": {
+          "type": "ViewContentEntry",
+          "id": 4
         }
       }
     },
@@ -12865,8 +12930,8 @@
           "type": "ViewTip",
           "id": 4
         },
-        "raw_data": {
-          "type": "ViewRawData",
+        "action_card": {
+          "type": "ViewActionCard",
           "id": 5
         },
         "slide_to_confirm": {
@@ -12890,6 +12955,36 @@
         "title_arg": {
           "type": "string",
           "id": 9
+        },
+        "content": {
+          "type": "ViewContentPreview",
+          "id": 10
+        },
+        "custom_field": {
+          "type": "ViewCustomField",
+          "id": 11
+        }
+      }
+    },
+    "ViewWarningPage": {
+      "fields": {
+        "title_id": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 1
+        },
+        "text_id": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 2
+        },
+        "text_arg": {
+          "type": "string",
+          "id": 3
+        },
+        "cancellable": {
+          "type": "bool",
+          "id": 4
         }
       }
     },
@@ -12928,6 +13023,10 @@
         "chain_id": {
           "type": "uint32",
           "id": 8
+        },
+        "content": {
+          "type": "ViewContentPreview",
+          "id": 9
         }
       }
     },

--- a/packages/core/src/data/messages/messages-protocol-v2.json
+++ b/packages/core/src/data/messages/messages-protocol-v2.json
@@ -12334,6 +12334,11 @@
         "btc_test_address": {
           "type": "string",
           "id": 2
+        },
+        "seed_domains": {
+          "rule": "repeated",
+          "type": "DeviceSessionSeedDomain",
+          "id": 3
         }
       }
     },

--- a/packages/core/src/protocols/protocol-v2/walletSession.ts
+++ b/packages/core/src/protocols/protocol-v2/walletSession.ts
@@ -571,6 +571,10 @@ export async function getProtocolV2WalletSession(
       clearCurrentWalletSession();
       throw ERRORS.TypedError(HardwareErrorCode.DeviceCheckPassphraseStateError);
     }
+    if (!deviceSessionHasCardano(message)) {
+      clearCurrentWalletSession();
+      throw ERRORS.TypedError(HardwareErrorCode.WalletSessionInvalid);
+    }
   }
 
   const internalStateArgs = [

--- a/packages/core/src/protocols/protocol-v2/walletSession.ts
+++ b/packages/core/src/protocols/protocol-v2/walletSession.ts
@@ -169,8 +169,20 @@ const selectDeviceSession = async (
       interaction: attachPinInteraction,
     });
     onStatusRefreshed?.();
-    // origin/dev AskPassphrase is SESSION_NEW and clears unlocked_by_attach_to_pin.
-    // Attach PIN Cardano cannot be requested here without destroying the wallet.
+    if (deriveCardano === true) {
+      await askDevicePassphrase(
+        device,
+        { passphrase: '', on_device: false },
+        true,
+        onStatusRefreshed
+      );
+      // Firmware AskPassphrase Success clears unlocked_by_attach_to_pin.
+      // Identity is still the Attach PIN wallet; keep the SDK flag so a later
+      // passphrase picker still locks instead of prompting.
+      if (device.features) {
+        device.features.unlockedAttachPin = true;
+      }
+    }
     const attachPinSession = await getDeviceSession(device, buildDeviceSessionGetRequest());
     return Object.assign(attachPinSession, { viaAttachPin: true as const });
   }
@@ -288,14 +300,24 @@ export async function getProtocolV2WalletSession(
       expectedPassphraseState: passphraseState,
     });
 
-  const askEmptyPassphraseAndGet = async (deriveCardano?: boolean) => {
+  const askEmptyPassphraseAndGet = async ({
+    deriveCardano,
+    keepAttachPin,
+  }: {
+    deriveCardano?: boolean;
+    keepAttachPin?: boolean;
+  } = {}) => {
     await askDevicePassphrase(
       device,
       { passphrase: '', on_device: false },
       deriveCardano,
       markWalletStatusRefreshed
     );
-    return getDeviceSession(device, buildDeviceSessionGetRequest());
+    if (keepAttachPin && device.features) {
+      device.features.unlockedAttachPin = true;
+    }
+    const session = await getDeviceSession(device, buildDeviceSessionGetRequest());
+    return keepAttachPin ? Object.assign(session, { viaAttachPin: true as const }) : session;
   };
 
   const rejectMismatchedAttachPinWallet = async () => {
@@ -319,8 +341,9 @@ export async function getProtocolV2WalletSession(
     throw ERRORS.TypedError(HardwareErrorCode.DeviceCheckUnlockTypeError);
   };
 
-  // AskPassphrase on an Attach PIN session starts SESSION_NEW and can fail
-  // the SE. Lock first; App retries after the user unlocks with Main PIN.
+  // The passphrase picker would prompt. Empty host AskPassphrase does not;
+  // that path is Attach PIN / standard Cardano. Switching to a different
+  // passphrase wallet still locks first.
   const lockAttachPinBeforePassphraseSelection = async () => {
     if (readCurrentAttachPinSession || options?.onlyMainPin) {
       return;
@@ -506,26 +529,23 @@ export async function getProtocolV2WalletSession(
     }
   }
 
-  // origin/dev generates Cardano on AskPassphrase, not Get. Attach PIN must
-  // not Ask: firmware SESSION_NEW clears attach-pin and can fail the SE.
-  // Hidden wallets re-Ask the real passphrase. Passphrase-off Get auto-requests
-  // Cardano.
-  if (
-    options?.deriveCardano === true &&
-    !deviceSessionHasCardano(message) &&
-    !sessionIsAttachPinWallet(response)
-  ) {
+  // origin/dev generates Cardano on AskPassphrase, not Get. Empty host
+  // passphrase is the Attach PIN / standard-wallet secret. Hidden wallets
+  // still need a real passphrase Ask. Passphrase-off Get auto-requests Cardano.
+  if (options?.deriveCardano === true && !deviceSessionHasCardano(message)) {
     if (options?.resumeOnly) {
       device.clearInternalState();
       throw ERRORS.TypedError(HardwareErrorCode.WalletSessionInvalid);
     }
     resumed = false;
     const previousAddress = message.btc_test_address;
-    if (device.features?.passphraseProtection === false) {
+    if (sessionIsAttachPinWallet(response)) {
+      response = await askEmptyPassphraseAndGet({ deriveCardano: true, keepAttachPin: true });
+    } else if (device.features?.passphraseProtection === false) {
       response = await getDeviceSession(device, buildDeviceSessionGetRequest());
     } else if (options?.onlyMainPin) {
       await selectMainPin();
-      response = await askEmptyPassphraseAndGet(true);
+      response = await askEmptyPassphraseAndGet({ deriveCardano: true });
     } else {
       await lockAttachPinBeforePassphraseSelection();
       response = await selectDeviceSession(
@@ -567,7 +587,7 @@ export async function getProtocolV2WalletSession(
   }
 
   let unlockedAttachPin: boolean | undefined;
-  if (readCurrentAttachPinSession) {
+  if (readCurrentAttachPinSession || sessionIsAttachPinWallet(response)) {
     unlockedAttachPin = true;
   } else if (mainPinAuthenticated) {
     unlockedAttachPin = false;

--- a/packages/core/src/protocols/protocol-v2/walletSession.ts
+++ b/packages/core/src/protocols/protocol-v2/walletSession.ts
@@ -76,18 +76,18 @@ const deviceSessionHasCardano = (message: { seed_domains?: DeviceSessionSeedDoma
   Array.isArray(message.seed_domains) &&
   message.seed_domains.includes(DeviceSessionSeedDomain.SeedDomain_Cardano);
 
-// AskPassphrase.seed_domains selects which seeds to generate. DeviceSessionGet
-// only resumes or reads the current session; firmware rejects unknown Get
-// fields, including leftover seed_domains.
 const buildDeviceSessionGetRequest = ({
   sessionId,
   expectedPassphraseState,
+  deriveCardano,
 }: {
   sessionId?: string;
   expectedPassphraseState?: string;
+  deriveCardano?: boolean;
 } = {}): DeviceSessionGet => ({
   ...(sessionId ? { session_id: sessionId } : {}),
   ...(expectedPassphraseState ? { btc_test_address: expectedPassphraseState } : {}),
+  seed_domains: buildDeviceSessionSeedDomains(deriveCardano),
 });
 
 const askDevicePassphrase = async (
@@ -171,7 +171,10 @@ const selectDeviceSession = async (
       interaction: attachPinInteraction,
     });
     onStatusRefreshed?.();
-    const attachPinSession = await getDeviceSession(device, buildDeviceSessionGetRequest());
+    const attachPinSession = await getDeviceSession(
+      device,
+      buildDeviceSessionGetRequest({ deriveCardano })
+    );
     return Object.assign(attachPinSession, { viaAttachPin: true as const });
   }
 
@@ -185,7 +188,7 @@ const selectDeviceSession = async (
       deriveCardano,
       onStatusRefreshed
     );
-    return getDeviceSession(device, buildDeviceSessionGetRequest());
+    return getDeviceSession(device, buildDeviceSessionGetRequest({ deriveCardano }));
   }
 
   const passphraseOnDeviceInteraction = device.createProtocolV2UiPhaseMetadata?.(
@@ -197,7 +200,7 @@ const selectDeviceSession = async (
     ...(passphraseOnDeviceInteraction ? { interaction: passphraseOnDeviceInteraction } : {}),
   });
   await askDevicePassphrase(device, { on_device: true }, deriveCardano, onStatusRefreshed);
-  return getDeviceSession(device, buildDeviceSessionGetRequest());
+  return getDeviceSession(device, buildDeviceSessionGetRequest({ deriveCardano }));
 };
 
 export async function getProtocolV2WalletSession(
@@ -276,6 +279,19 @@ export async function getProtocolV2WalletSession(
     }
   };
 
+  const sessionGetRequest = ({
+    sessionId,
+    expectedPassphraseState: passphraseState,
+  }: {
+    sessionId?: string;
+    expectedPassphraseState?: string;
+  } = {}) =>
+    buildDeviceSessionGetRequest({
+      sessionId,
+      expectedPassphraseState: passphraseState,
+      deriveCardano: options?.deriveCardano,
+    });
+
   const rejectMismatchedAttachPinWallet = async () => {
     const features = await refreshProtocolV2DeviceStatus(device);
     markWalletStatusRefreshed();
@@ -295,6 +311,18 @@ export async function getProtocolV2WalletSession(
       clearCurrentWalletSession();
     }
     throw ERRORS.TypedError(HardwareErrorCode.DeviceCheckUnlockTypeError);
+  };
+
+  // AskPassphrase on an Attach PIN session would prompt for a passphrase the
+  // hardware never uses. Lock first; App retries after the user unlocks.
+  const lockAttachPinBeforePassphraseSelection = async () => {
+    if (readCurrentAttachPinSession || options?.onlyMainPin) {
+      return;
+    }
+    if (device.features?.unlockedAttachPin !== true) {
+      return;
+    }
+    await rejectMismatchedAttachPinWallet();
   };
 
   if (options?.onlyMainPin && options.rejectAttachPinForMainWallet) {
@@ -347,7 +375,7 @@ export async function getProtocolV2WalletSession(
       device.clearInternalState();
       throw ERRORS.TypedError(HardwareErrorCode.DeviceCheckUnlockTypeError);
     }
-    response = await getDeviceSession(device, buildDeviceSessionGetRequest());
+    response = await getDeviceSession(device, sessionGetRequest());
   } else if (options?.onlyMainPin) {
     expectedPassphraseState = cachedStandardSession?.passphraseState;
     if (cachedStandardSession) {
@@ -357,7 +385,7 @@ export async function getProtocolV2WalletSession(
         }
         response = await getDeviceSession(
           device,
-          buildDeviceSessionGetRequest({
+          sessionGetRequest({
             sessionId: cachedStandardSession.sessionId,
             expectedPassphraseState,
           })
@@ -374,13 +402,13 @@ export async function getProtocolV2WalletSession(
 
     if (!response) {
       await selectStandardWallet();
-      response = await getDeviceSession(device, buildDeviceSessionGetRequest());
+      response = await getDeviceSession(device, sessionGetRequest());
     }
   } else if (cachedSessionId && expectedPassphraseState) {
     try {
       response = await getDeviceSession(
         device,
-        buildDeviceSessionGetRequest({
+        sessionGetRequest({
           sessionId: cachedSessionId,
           expectedPassphraseState,
         })
@@ -397,7 +425,7 @@ export async function getProtocolV2WalletSession(
     try {
       response = await getDeviceSession(
         device,
-        buildDeviceSessionGetRequest({
+        sessionGetRequest({
           expectedPassphraseState,
         })
       );
@@ -413,6 +441,7 @@ export async function getProtocolV2WalletSession(
       device.clearInternalState();
       throw ERRORS.TypedError(HardwareErrorCode.WalletSessionInvalid);
     }
+    await lockAttachPinBeforePassphraseSelection();
     response = await selectDeviceSession(
       device,
       expectedPassphraseState,
@@ -442,9 +471,10 @@ export async function getProtocolV2WalletSession(
     if (options?.onlyMainPin) {
       device.clearStandardInternalState?.();
       await selectStandardWallet();
-      response = await getDeviceSession(device, buildDeviceSessionGetRequest());
+      response = await getDeviceSession(device, sessionGetRequest());
     } else {
       device.clearInternalState();
+      await lockAttachPinBeforePassphraseSelection();
       response = await selectDeviceSession(
         device,
         expectedPassphraseState,
@@ -470,38 +500,44 @@ export async function getProtocolV2WalletSession(
     }
   }
 
-  // DeviceSession.seed_domains reports what the SE already generated. Get
-  // cannot add Cardano, so a passphrase wallet must Ask again. Attach PIN
-  // has no passphrase; never send DeviceSessionAskPassphrase for it.
+  // DeviceSession.seed_domains reports generated seeds. Attach PIN and
+  // passphrase-off can GEN Cardano on Get. Hidden passphrase still needs Ask.
   if (options?.deriveCardano === true && !deviceSessionHasCardano(message)) {
     if (options?.resumeOnly) {
       device.clearInternalState();
       throw ERRORS.TypedError(HardwareErrorCode.WalletSessionInvalid);
     }
-    if (!sessionIsAttachPinWallet(response)) {
-      resumed = false;
+    resumed = false;
+    if (sessionIsAttachPinWallet(response) || device.features?.passphraseProtection === false) {
+      response = await getDeviceSession(
+        device,
+        buildDeviceSessionGetRequest({ deriveCardano: true })
+      );
+    } else if (options?.onlyMainPin) {
+      await selectStandardWallet();
+      response = await getDeviceSession(
+        device,
+        buildDeviceSessionGetRequest({ deriveCardano: true })
+      );
+    } else {
+      await lockAttachPinBeforePassphraseSelection();
+      response = await selectDeviceSession(
+        device,
+        expectedPassphraseState,
+        true,
+        markWalletStatusRefreshed
+      );
+    }
+    message = response.message;
+    try {
+      assertCompleteDeviceSession(message);
+    } catch (error) {
       if (options?.onlyMainPin) {
-        await selectStandardWallet();
-        response = await getDeviceSession(device, buildDeviceSessionGetRequest());
+        device.clearStandardInternalState?.();
       } else {
-        response = await selectDeviceSession(
-          device,
-          expectedPassphraseState,
-          true,
-          markWalletStatusRefreshed
-        );
+        device.clearInternalState();
       }
-      message = response.message;
-      try {
-        assertCompleteDeviceSession(message);
-      } catch (error) {
-        if (options?.onlyMainPin) {
-          device.clearStandardInternalState?.();
-        } else {
-          device.clearInternalState();
-        }
-        throw error;
-      }
+      throw error;
     }
   }
 

--- a/packages/core/src/protocols/protocol-v2/walletSession.ts
+++ b/packages/core/src/protocols/protocol-v2/walletSession.ts
@@ -76,18 +76,16 @@ const deviceSessionHasCardano = (message: { seed_domains?: DeviceSessionSeedDoma
   Array.isArray(message.seed_domains) &&
   message.seed_domains.includes(DeviceSessionSeedDomain.SeedDomain_Cardano);
 
+// origin/dev Get is read/resume only. Seed generation lives on AskPassphrase.
 const buildDeviceSessionGetRequest = ({
   sessionId,
   expectedPassphraseState,
-  deriveCardano,
 }: {
   sessionId?: string;
   expectedPassphraseState?: string;
-  deriveCardano?: boolean;
 } = {}): DeviceSessionGet => ({
   ...(sessionId ? { session_id: sessionId } : {}),
   ...(expectedPassphraseState ? { btc_test_address: expectedPassphraseState } : {}),
-  seed_domains: buildDeviceSessionSeedDomains(deriveCardano),
 });
 
 const askDevicePassphrase = async (
@@ -171,10 +169,15 @@ const selectDeviceSession = async (
       interaction: attachPinInteraction,
     });
     onStatusRefreshed?.();
-    const attachPinSession = await getDeviceSession(
-      device,
-      buildDeviceSessionGetRequest({ deriveCardano })
-    );
+    if (deriveCardano === true) {
+      await askDevicePassphrase(
+        device,
+        { passphrase: '', on_device: false },
+        true,
+        onStatusRefreshed
+      );
+    }
+    const attachPinSession = await getDeviceSession(device, buildDeviceSessionGetRequest());
     return Object.assign(attachPinSession, { viaAttachPin: true as const });
   }
 
@@ -188,7 +191,7 @@ const selectDeviceSession = async (
       deriveCardano,
       onStatusRefreshed
     );
-    return getDeviceSession(device, buildDeviceSessionGetRequest({ deriveCardano }));
+    return getDeviceSession(device, buildDeviceSessionGetRequest());
   }
 
   const passphraseOnDeviceInteraction = device.createProtocolV2UiPhaseMetadata?.(
@@ -200,7 +203,7 @@ const selectDeviceSession = async (
     ...(passphraseOnDeviceInteraction ? { interaction: passphraseOnDeviceInteraction } : {}),
   });
   await askDevicePassphrase(device, { on_device: true }, deriveCardano, onStatusRefreshed);
-  return getDeviceSession(device, buildDeviceSessionGetRequest({ deriveCardano }));
+  return getDeviceSession(device, buildDeviceSessionGetRequest());
 };
 
 export async function getProtocolV2WalletSession(
@@ -289,8 +292,17 @@ export async function getProtocolV2WalletSession(
     buildDeviceSessionGetRequest({
       sessionId,
       expectedPassphraseState: passphraseState,
-      deriveCardano: options?.deriveCardano,
     });
+
+  const askEmptyPassphraseAndGet = async (deriveCardano?: boolean) => {
+    await askDevicePassphrase(
+      device,
+      { passphrase: '', on_device: false },
+      deriveCardano,
+      markWalletStatusRefreshed
+    );
+    return getDeviceSession(device, buildDeviceSessionGetRequest());
+  };
 
   const rejectMismatchedAttachPinWallet = async () => {
     const features = await refreshProtocolV2DeviceStatus(device);
@@ -313,8 +325,9 @@ export async function getProtocolV2WalletSession(
     throw ERRORS.TypedError(HardwareErrorCode.DeviceCheckUnlockTypeError);
   };
 
-  // AskPassphrase on an Attach PIN session would prompt for a passphrase the
-  // hardware never uses. Lock first; App retries after the user unlocks.
+  // The passphrase picker would prompt. Empty host AskPassphrase does not;
+  // that path is reserved for Attach PIN / standard Cardano. Switching to a
+  // different passphrase wallet still locks first.
   const lockAttachPinBeforePassphraseSelection = async () => {
     if (readCurrentAttachPinSession || options?.onlyMainPin) {
       return;
@@ -500,25 +513,23 @@ export async function getProtocolV2WalletSession(
     }
   }
 
-  // DeviceSession.seed_domains reports generated seeds. Attach PIN and
-  // passphrase-off can GEN Cardano on Get. Hidden passphrase still needs Ask.
+  // origin/dev generates Cardano on AskPassphrase, not Get. Empty host
+  // passphrase is the Attach PIN / standard-wallet secret. Hidden wallets
+  // still need a real passphrase Ask. Passphrase-off Get auto-requests Cardano.
   if (options?.deriveCardano === true && !deviceSessionHasCardano(message)) {
     if (options?.resumeOnly) {
       device.clearInternalState();
       throw ERRORS.TypedError(HardwareErrorCode.WalletSessionInvalid);
     }
     resumed = false;
-    if (sessionIsAttachPinWallet(response) || device.features?.passphraseProtection === false) {
-      response = await getDeviceSession(
-        device,
-        buildDeviceSessionGetRequest({ deriveCardano: true })
-      );
+    const previousAddress = message.btc_test_address;
+    if (sessionIsAttachPinWallet(response)) {
+      response = await askEmptyPassphraseAndGet(true);
+    } else if (device.features?.passphraseProtection === false) {
+      response = await getDeviceSession(device, buildDeviceSessionGetRequest());
     } else if (options?.onlyMainPin) {
-      await selectStandardWallet();
-      response = await getDeviceSession(
-        device,
-        buildDeviceSessionGetRequest({ deriveCardano: true })
-      );
+      await selectMainPin();
+      response = await askEmptyPassphraseAndGet(true);
     } else {
       await lockAttachPinBeforePassphraseSelection();
       response = await selectDeviceSession(
@@ -538,6 +549,11 @@ export async function getProtocolV2WalletSession(
         device.clearInternalState();
       }
       throw error;
+    }
+    if (previousAddress && previousAddress !== message.btc_test_address) {
+      await rejectMismatchedAttachPinWallet();
+      clearCurrentWalletSession();
+      throw ERRORS.TypedError(HardwareErrorCode.DeviceCheckPassphraseStateError);
     }
   }
 

--- a/packages/core/src/protocols/protocol-v2/walletSession.ts
+++ b/packages/core/src/protocols/protocol-v2/walletSession.ts
@@ -76,8 +76,9 @@ const deviceSessionHasCardano = (message: { seed_domains?: DeviceSessionSeedDoma
   Array.isArray(message.seed_domains) &&
   message.seed_domains.includes(DeviceSessionSeedDomain.SeedDomain_Cardano);
 
-// Seed domains are applied when creating a passphrase session, not when reading/resuming one.
-// Current firmware rejects unknown DeviceSessionGet fields, including leftover seed_domains.
+// AskPassphrase.seed_domains selects which seeds to generate. DeviceSessionGet
+// only resumes or reads the current session; firmware rejects unknown Get
+// fields, including leftover seed_domains.
 const buildDeviceSessionGetRequest = ({
   sessionId,
   expectedPassphraseState,
@@ -464,6 +465,8 @@ export async function getProtocolV2WalletSession(
     }
   }
 
+  // DeviceSession.seed_domains reports what the SE already generated. Get
+  // cannot add Cardano, so a Cardano call on a Standard-only session must Ask again.
   if (options?.deriveCardano === true && !deviceSessionHasCardano(message)) {
     if (options?.resumeOnly) {
       device.clearInternalState();

--- a/packages/core/src/protocols/protocol-v2/walletSession.ts
+++ b/packages/core/src/protocols/protocol-v2/walletSession.ts
@@ -474,32 +474,34 @@ export async function getProtocolV2WalletSession(
   // cannot add Cardano, so a passphrase wallet must Ask again. Attach PIN
   // has no passphrase; never send DeviceSessionAskPassphrase for it.
   if (options?.deriveCardano === true && !deviceSessionHasCardano(message)) {
-    if (options?.resumeOnly || sessionIsAttachPinWallet(response)) {
-      clearCurrentWalletSession();
+    if (options?.resumeOnly) {
+      device.clearInternalState();
       throw ERRORS.TypedError(HardwareErrorCode.WalletSessionInvalid);
     }
-    resumed = false;
-    if (options?.onlyMainPin) {
-      await selectStandardWallet();
-      response = await getDeviceSession(device, buildDeviceSessionGetRequest());
-    } else {
-      response = await selectDeviceSession(
-        device,
-        expectedPassphraseState,
-        true,
-        markWalletStatusRefreshed
-      );
-    }
-    message = response.message;
-    try {
-      assertCompleteDeviceSession(message);
-    } catch (error) {
+    if (!sessionIsAttachPinWallet(response)) {
+      resumed = false;
       if (options?.onlyMainPin) {
-        device.clearStandardInternalState?.();
+        await selectStandardWallet();
+        response = await getDeviceSession(device, buildDeviceSessionGetRequest());
       } else {
-        device.clearInternalState();
+        response = await selectDeviceSession(
+          device,
+          expectedPassphraseState,
+          true,
+          markWalletStatusRefreshed
+        );
       }
-      throw error;
+      message = response.message;
+      try {
+        assertCompleteDeviceSession(message);
+      } catch (error) {
+        if (options?.onlyMainPin) {
+          device.clearStandardInternalState?.();
+        } else {
+          device.clearInternalState();
+        }
+        throw error;
+      }
     }
   }
 

--- a/packages/core/src/protocols/protocol-v2/walletSession.ts
+++ b/packages/core/src/protocols/protocol-v2/walletSession.ts
@@ -171,7 +171,8 @@ const selectDeviceSession = async (
       interaction: attachPinInteraction,
     });
     onStatusRefreshed?.();
-    return getDeviceSession(device, buildDeviceSessionGetRequest());
+    const attachPinSession = await getDeviceSession(device, buildDeviceSessionGetRequest());
+    return Object.assign(attachPinSession, { viaAttachPin: true as const });
   }
 
   if (hasHostPassphrase) {
@@ -221,6 +222,10 @@ export async function getProtocolV2WalletSession(
   const forceWalletSelection =
     options?.forceWalletSelection === true || options?.initSession === true;
   const readCurrentAttachPinSession = options?.readCurrentAttachPinSession === true;
+  const sessionIsAttachPinWallet = (session?: { viaAttachPin?: boolean }) =>
+    readCurrentAttachPinSession ||
+    session?.viaAttachPin === true ||
+    device.features?.unlockedAttachPin === true;
 
   if (forceWalletSelection) {
     if (options.onlyMainPin) {
@@ -466,10 +471,11 @@ export async function getProtocolV2WalletSession(
   }
 
   // DeviceSession.seed_domains reports what the SE already generated. Get
-  // cannot add Cardano, so a Cardano call on a Standard-only session must Ask again.
+  // cannot add Cardano, so a passphrase wallet must Ask again. Attach PIN
+  // has no passphrase; never send DeviceSessionAskPassphrase for it.
   if (options?.deriveCardano === true && !deviceSessionHasCardano(message)) {
-    if (options?.resumeOnly) {
-      device.clearInternalState();
+    if (options?.resumeOnly || sessionIsAttachPinWallet(response)) {
+      clearCurrentWalletSession();
       throw ERRORS.TypedError(HardwareErrorCode.WalletSessionInvalid);
     }
     resumed = false;

--- a/packages/core/src/protocols/protocol-v2/walletSession.ts
+++ b/packages/core/src/protocols/protocol-v2/walletSession.ts
@@ -169,14 +169,8 @@ const selectDeviceSession = async (
       interaction: attachPinInteraction,
     });
     onStatusRefreshed?.();
-    if (deriveCardano === true) {
-      await askDevicePassphrase(
-        device,
-        { passphrase: '', on_device: false },
-        true,
-        onStatusRefreshed
-      );
-    }
+    // origin/dev AskPassphrase is SESSION_NEW and clears unlocked_by_attach_to_pin.
+    // Attach PIN Cardano cannot be requested here without destroying the wallet.
     const attachPinSession = await getDeviceSession(device, buildDeviceSessionGetRequest());
     return Object.assign(attachPinSession, { viaAttachPin: true as const });
   }
@@ -325,9 +319,8 @@ export async function getProtocolV2WalletSession(
     throw ERRORS.TypedError(HardwareErrorCode.DeviceCheckUnlockTypeError);
   };
 
-  // The passphrase picker would prompt. Empty host AskPassphrase does not;
-  // that path is reserved for Attach PIN / standard Cardano. Switching to a
-  // different passphrase wallet still locks first.
+  // AskPassphrase on an Attach PIN session starts SESSION_NEW and can fail
+  // the SE. Lock first; App retries after the user unlocks with Main PIN.
   const lockAttachPinBeforePassphraseSelection = async () => {
     if (readCurrentAttachPinSession || options?.onlyMainPin) {
       return;
@@ -513,19 +506,22 @@ export async function getProtocolV2WalletSession(
     }
   }
 
-  // origin/dev generates Cardano on AskPassphrase, not Get. Empty host
-  // passphrase is the Attach PIN / standard-wallet secret. Hidden wallets
-  // still need a real passphrase Ask. Passphrase-off Get auto-requests Cardano.
-  if (options?.deriveCardano === true && !deviceSessionHasCardano(message)) {
+  // origin/dev generates Cardano on AskPassphrase, not Get. Attach PIN must
+  // not Ask: firmware SESSION_NEW clears attach-pin and can fail the SE.
+  // Hidden wallets re-Ask the real passphrase. Passphrase-off Get auto-requests
+  // Cardano.
+  if (
+    options?.deriveCardano === true &&
+    !deviceSessionHasCardano(message) &&
+    !sessionIsAttachPinWallet(response)
+  ) {
     if (options?.resumeOnly) {
       device.clearInternalState();
       throw ERRORS.TypedError(HardwareErrorCode.WalletSessionInvalid);
     }
     resumed = false;
     const previousAddress = message.btc_test_address;
-    if (sessionIsAttachPinWallet(response)) {
-      response = await askEmptyPassphraseAndGet(true);
-    } else if (device.features?.passphraseProtection === false) {
+    if (device.features?.passphraseProtection === false) {
       response = await getDeviceSession(device, buildDeviceSessionGetRequest());
     } else if (options?.onlyMainPin) {
       await selectMainPin();

--- a/packages/core/src/protocols/protocol-v2/walletSession.ts
+++ b/packages/core/src/protocols/protocol-v2/walletSession.ts
@@ -63,18 +63,18 @@ const negotiateEventlessWalletSession = async (device: Device) => {
 const getDeviceSession = async (device: Device, request: DeviceSessionGet) =>
   device.commands.typedCall('DeviceSessionGet', 'DeviceSession', request);
 
-// V1 `deriveCardano` is a per-Initialize opt-in: false/omit skips Cardano this
-// round trip and a later Initialize can still add it. V2 seed domains are set
-// only on AskPassphrase and cannot be upgraded by Get, so false must not freeze
-// the session to Standard-only. true requests [Standard, Cardano]; anything
-// else leaves seed_domains empty and firmware keeps its default (all domains).
+const STANDARD_SEED_DOMAINS = [DeviceSessionSeedDomain.SeedDomain_Standard];
+const CARDANO_SEED_DOMAINS = [
+  DeviceSessionSeedDomain.SeedDomain_Standard,
+  DeviceSessionSeedDomain.SeedDomain_Cardano,
+];
+
 const buildDeviceSessionSeedDomains = (deriveCardano?: boolean): DeviceSessionSeedDomain[] =>
-  deriveCardano === true
-    ? [
-        DeviceSessionSeedDomain.SeedDomain_Standard,
-        DeviceSessionSeedDomain.SeedDomain_Cardano,
-      ]
-    : [];
+  deriveCardano === true ? CARDANO_SEED_DOMAINS : STANDARD_SEED_DOMAINS;
+
+const deviceSessionHasCardano = (message: { seed_domains?: DeviceSessionSeedDomain[] }) =>
+  Array.isArray(message.seed_domains) &&
+  message.seed_domains.includes(DeviceSessionSeedDomain.SeedDomain_Cardano);
 
 // Seed domains are applied when creating a passphrase session, not when reading/resuming one.
 // Current firmware rejects unknown DeviceSessionGet fields, including leftover seed_domains.
@@ -461,6 +461,36 @@ export async function getProtocolV2WalletSession(
       await rejectMismatchedAttachPinWallet();
       clearCurrentWalletSession();
       throw ERRORS.TypedError(HardwareErrorCode.DeviceCheckPassphraseStateError);
+    }
+  }
+
+  if (options?.deriveCardano === true && !deviceSessionHasCardano(message)) {
+    if (options?.resumeOnly) {
+      device.clearInternalState();
+      throw ERRORS.TypedError(HardwareErrorCode.WalletSessionInvalid);
+    }
+    resumed = false;
+    if (options?.onlyMainPin) {
+      await selectStandardWallet();
+      response = await getDeviceSession(device, buildDeviceSessionGetRequest());
+    } else {
+      response = await selectDeviceSession(
+        device,
+        expectedPassphraseState,
+        true,
+        markWalletStatusRefreshed
+      );
+    }
+    message = response.message;
+    try {
+      assertCompleteDeviceSession(message);
+    } catch (error) {
+      if (options?.onlyMainPin) {
+        device.clearStandardInternalState?.();
+      } else {
+        device.clearInternalState();
+      }
+      throw error;
     }
   }
 

--- a/packages/core/src/protocols/protocol-v2/walletSession.ts
+++ b/packages/core/src/protocols/protocol-v2/walletSession.ts
@@ -63,32 +63,37 @@ const negotiateEventlessWalletSession = async (device: Device) => {
 const getDeviceSession = async (device: Device, request: DeviceSessionGet) =>
   device.commands.typedCall('DeviceSessionGet', 'DeviceSession', request);
 
+const buildDeviceSessionSeedDomains = (deriveCardano?: boolean): DeviceSessionSeedDomain[] =>
+  deriveCardano === undefined
+    ? []
+    : [
+        DeviceSessionSeedDomain.SeedDomain_Standard,
+        ...(deriveCardano ? [DeviceSessionSeedDomain.SeedDomain_Cardano] : []),
+      ];
+
+// Seed domains are applied when creating a passphrase session, not when reading/resuming one.
+// Current firmware rejects unknown DeviceSessionGet fields, including leftover seed_domains.
 const buildDeviceSessionGetRequest = ({
   sessionId,
   expectedPassphraseState,
-  deriveCardano,
 }: {
   sessionId?: string;
   expectedPassphraseState?: string;
-  deriveCardano?: boolean;
 } = {}): DeviceSessionGet => ({
   ...(sessionId ? { session_id: sessionId } : {}),
   ...(expectedPassphraseState ? { btc_test_address: expectedPassphraseState } : {}),
-  seed_domains:
-    deriveCardano === undefined
-      ? []
-      : [
-          DeviceSessionSeedDomain.SeedDomain_Standard,
-          ...(deriveCardano ? [DeviceSessionSeedDomain.SeedDomain_Cardano] : []),
-        ],
 });
 
 const askDevicePassphrase = async (
   device: Device,
-  requestPayload: DeviceSessionAskPassphrase,
+  requestPayload: Omit<DeviceSessionAskPassphrase, 'seed_domains'>,
+  deriveCardano?: boolean,
   onStatusRefreshed?: () => void
 ) => {
-  await device.commands.typedCall('DeviceSessionAskPassphrase', 'Success', requestPayload);
+  await device.commands.typedCall('DeviceSessionAskPassphrase', 'Success', {
+    ...requestPayload,
+    seed_domains: buildDeviceSessionSeedDomains(deriveCardano),
+  });
   await refreshProtocolV2DeviceStatus(device);
   onStatusRefreshed?.();
 };
@@ -160,7 +165,7 @@ const selectDeviceSession = async (
       interaction: attachPinInteraction,
     });
     onStatusRefreshed?.();
-    return getDeviceSession(device, buildDeviceSessionGetRequest({ deriveCardano }));
+    return getDeviceSession(device, buildDeviceSessionGetRequest());
   }
 
   if (hasHostPassphrase) {
@@ -170,9 +175,10 @@ const selectDeviceSession = async (
         passphrase: hostPassphrase,
         on_device: false,
       },
+      deriveCardano,
       onStatusRefreshed
     );
-    return getDeviceSession(device, buildDeviceSessionGetRequest({ deriveCardano }));
+    return getDeviceSession(device, buildDeviceSessionGetRequest());
   }
 
   const passphraseOnDeviceInteraction = device.createProtocolV2UiPhaseMetadata?.(
@@ -183,8 +189,8 @@ const selectDeviceSession = async (
     ...metadata,
     ...(passphraseOnDeviceInteraction ? { interaction: passphraseOnDeviceInteraction } : {}),
   });
-  await askDevicePassphrase(device, { on_device: true }, onStatusRefreshed);
-  return getDeviceSession(device, buildDeviceSessionGetRequest({ deriveCardano }));
+  await askDevicePassphrase(device, { on_device: true }, deriveCardano, onStatusRefreshed);
+  return getDeviceSession(device, buildDeviceSessionGetRequest());
 };
 
 export async function getProtocolV2WalletSession(
@@ -307,6 +313,7 @@ export async function getProtocolV2WalletSession(
           passphrase: '',
           on_device: false,
         },
+        options?.deriveCardano,
         markWalletStatusRefreshed
       );
       standardWalletSelected = true;
@@ -329,10 +336,7 @@ export async function getProtocolV2WalletSession(
       device.clearInternalState();
       throw ERRORS.TypedError(HardwareErrorCode.DeviceCheckUnlockTypeError);
     }
-    response = await getDeviceSession(
-      device,
-      buildDeviceSessionGetRequest({ deriveCardano: options?.deriveCardano })
-    );
+    response = await getDeviceSession(device, buildDeviceSessionGetRequest());
   } else if (options?.onlyMainPin) {
     expectedPassphraseState = cachedStandardSession?.passphraseState;
     if (cachedStandardSession) {
@@ -345,7 +349,6 @@ export async function getProtocolV2WalletSession(
           buildDeviceSessionGetRequest({
             sessionId: cachedStandardSession.sessionId,
             expectedPassphraseState,
-            deriveCardano: options?.deriveCardano,
           })
         );
         resumed = true;
@@ -360,10 +363,7 @@ export async function getProtocolV2WalletSession(
 
     if (!response) {
       await selectStandardWallet();
-      response = await getDeviceSession(
-        device,
-        buildDeviceSessionGetRequest({ deriveCardano: options?.deriveCardano })
-      );
+      response = await getDeviceSession(device, buildDeviceSessionGetRequest());
     }
   } else if (cachedSessionId && expectedPassphraseState) {
     try {
@@ -372,7 +372,6 @@ export async function getProtocolV2WalletSession(
         buildDeviceSessionGetRequest({
           sessionId: cachedSessionId,
           expectedPassphraseState,
-          deriveCardano: options?.deriveCardano,
         })
       );
       resumed = true;
@@ -389,7 +388,6 @@ export async function getProtocolV2WalletSession(
         device,
         buildDeviceSessionGetRequest({
           expectedPassphraseState,
-          deriveCardano: options?.deriveCardano,
         })
       );
     } catch (error) {
@@ -433,10 +431,7 @@ export async function getProtocolV2WalletSession(
     if (options?.onlyMainPin) {
       device.clearStandardInternalState?.();
       await selectStandardWallet();
-      response = await getDeviceSession(
-        device,
-        buildDeviceSessionGetRequest({ deriveCardano: options?.deriveCardano })
-      );
+      response = await getDeviceSession(device, buildDeviceSessionGetRequest());
     } else {
       device.clearInternalState();
       response = await selectDeviceSession(

--- a/packages/core/src/protocols/protocol-v2/walletSession.ts
+++ b/packages/core/src/protocols/protocol-v2/walletSession.ts
@@ -63,13 +63,18 @@ const negotiateEventlessWalletSession = async (device: Device) => {
 const getDeviceSession = async (device: Device, request: DeviceSessionGet) =>
   device.commands.typedCall('DeviceSessionGet', 'DeviceSession', request);
 
+// V1 `deriveCardano` is a per-Initialize opt-in: false/omit skips Cardano this
+// round trip and a later Initialize can still add it. V2 seed domains are set
+// only on AskPassphrase and cannot be upgraded by Get, so false must not freeze
+// the session to Standard-only. true requests [Standard, Cardano]; anything
+// else leaves seed_domains empty and firmware keeps its default (all domains).
 const buildDeviceSessionSeedDomains = (deriveCardano?: boolean): DeviceSessionSeedDomain[] =>
-  deriveCardano === undefined
-    ? []
-    : [
+  deriveCardano === true
+    ? [
         DeviceSessionSeedDomain.SeedDomain_Standard,
-        ...(deriveCardano ? [DeviceSessionSeedDomain.SeedDomain_Cardano] : []),
-      ];
+        DeviceSessionSeedDomain.SeedDomain_Cardano,
+      ]
+    : [];
 
 // Seed domains are applied when creating a passphrase session, not when reading/resuming one.
 // Current firmware rejects unknown DeviceSessionGet fields, including leftover seed_domains.

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.5",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
-    "@onekeyfe/hd-transport-react-native": "1.2.2-alpha.5"
+    "@onekeyfe/hd-core": "1.2.2-alpha.6",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.6",
+    "@onekeyfe/hd-transport-react-native": "1.2.2-alpha.6"
   }
 }

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.4",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
-    "@onekeyfe/hd-transport-react-native": "1.2.2-alpha.4"
+    "@onekeyfe/hd-core": "1.2.2-alpha.5",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
+    "@onekeyfe/hd-transport-react-native": "1.2.2-alpha.5"
   }
 }

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.1",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.1",
-    "@onekeyfe/hd-transport-react-native": "1.2.2-alpha.1"
+    "@onekeyfe/hd-core": "1.2.2-alpha.2",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
+    "@onekeyfe/hd-transport-react-native": "1.2.2-alpha.2"
   }
 }

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.3",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
-    "@onekeyfe/hd-transport-react-native": "1.2.2-alpha.3"
+    "@onekeyfe/hd-core": "1.2.2-alpha.4",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
+    "@onekeyfe/hd-transport-react-native": "1.2.2-alpha.4"
   }
 }

--- a/packages/hd-ble-sdk/package.json
+++ b/packages/hd-ble-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-ble-sdk",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,8 +20,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.2",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
-    "@onekeyfe/hd-transport-react-native": "1.2.2-alpha.2"
+    "@onekeyfe/hd-core": "1.2.2-alpha.3",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
+    "@onekeyfe/hd-transport-react-native": "1.2.2-alpha.3"
   }
 }

--- a/packages/hd-cli/package.json
+++ b/packages/hd-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hardware-cli",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "description": "OneKey hardware wallet CLI for testing device communication",
   "author": "OneKey",
   "license": "Apache-2.0",
@@ -31,10 +31,10 @@
     "test": "jest"
   },
   "dependencies": {
-    "@onekeyfe/hd-common-connect-sdk": "1.2.2-alpha.5",
-    "@onekeyfe/hd-core": "1.2.2-alpha.5",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
-    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.5",
+    "@onekeyfe/hd-common-connect-sdk": "1.2.2-alpha.6",
+    "@onekeyfe/hd-core": "1.2.2-alpha.6",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.6",
+    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.6",
     "@stoprocent/noble": "2.3.16",
     "commander": "^12.0.0"
   }

--- a/packages/hd-cli/package.json
+++ b/packages/hd-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hardware-cli",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "description": "OneKey hardware wallet CLI for testing device communication",
   "author": "OneKey",
   "license": "Apache-2.0",
@@ -31,10 +31,10 @@
     "test": "jest"
   },
   "dependencies": {
-    "@onekeyfe/hd-common-connect-sdk": "1.2.2-alpha.4",
-    "@onekeyfe/hd-core": "1.2.2-alpha.4",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
-    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.4",
+    "@onekeyfe/hd-common-connect-sdk": "1.2.2-alpha.5",
+    "@onekeyfe/hd-core": "1.2.2-alpha.5",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
+    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.5",
     "@stoprocent/noble": "2.3.16",
     "commander": "^12.0.0"
   }

--- a/packages/hd-cli/package.json
+++ b/packages/hd-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hardware-cli",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "description": "OneKey hardware wallet CLI for testing device communication",
   "author": "OneKey",
   "license": "Apache-2.0",
@@ -31,10 +31,10 @@
     "test": "jest"
   },
   "dependencies": {
-    "@onekeyfe/hd-common-connect-sdk": "1.2.2-alpha.3",
-    "@onekeyfe/hd-core": "1.2.2-alpha.3",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
-    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.3",
+    "@onekeyfe/hd-common-connect-sdk": "1.2.2-alpha.4",
+    "@onekeyfe/hd-core": "1.2.2-alpha.4",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
+    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.4",
     "@stoprocent/noble": "2.3.16",
     "commander": "^12.0.0"
   }

--- a/packages/hd-cli/package.json
+++ b/packages/hd-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hardware-cli",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "description": "OneKey hardware wallet CLI for testing device communication",
   "author": "OneKey",
   "license": "Apache-2.0",
@@ -31,10 +31,10 @@
     "test": "jest"
   },
   "dependencies": {
-    "@onekeyfe/hd-common-connect-sdk": "1.2.2-alpha.1",
-    "@onekeyfe/hd-core": "1.2.2-alpha.1",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.1",
-    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.1",
+    "@onekeyfe/hd-common-connect-sdk": "1.2.2-alpha.2",
+    "@onekeyfe/hd-core": "1.2.2-alpha.2",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
+    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.2",
     "@stoprocent/noble": "2.3.16",
     "commander": "^12.0.0"
   }

--- a/packages/hd-cli/package.json
+++ b/packages/hd-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hardware-cli",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "description": "OneKey hardware wallet CLI for testing device communication",
   "author": "OneKey",
   "license": "Apache-2.0",
@@ -31,10 +31,10 @@
     "test": "jest"
   },
   "dependencies": {
-    "@onekeyfe/hd-common-connect-sdk": "1.2.2-alpha.2",
-    "@onekeyfe/hd-core": "1.2.2-alpha.2",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
-    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.2",
+    "@onekeyfe/hd-common-connect-sdk": "1.2.2-alpha.3",
+    "@onekeyfe/hd-core": "1.2.2-alpha.3",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
+    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.3",
     "@stoprocent/noble": "2.3.16",
     "commander": "^12.0.0"
   }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,12 +20,12 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.5",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
-    "@onekeyfe/hd-transport-emulator": "1.2.2-alpha.5",
-    "@onekeyfe/hd-transport-http": "1.2.2-alpha.5",
-    "@onekeyfe/hd-transport-lowlevel": "1.2.2-alpha.5",
-    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.5",
-    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.5"
+    "@onekeyfe/hd-core": "1.2.2-alpha.6",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.6",
+    "@onekeyfe/hd-transport-emulator": "1.2.2-alpha.6",
+    "@onekeyfe/hd-transport-http": "1.2.2-alpha.6",
+    "@onekeyfe/hd-transport-lowlevel": "1.2.2-alpha.6",
+    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.6",
+    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.6"
   }
 }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,12 +20,12 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.4",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
-    "@onekeyfe/hd-transport-emulator": "1.2.2-alpha.4",
-    "@onekeyfe/hd-transport-http": "1.2.2-alpha.4",
-    "@onekeyfe/hd-transport-lowlevel": "1.2.2-alpha.4",
-    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.4",
-    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.4"
+    "@onekeyfe/hd-core": "1.2.2-alpha.5",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
+    "@onekeyfe/hd-transport-emulator": "1.2.2-alpha.5",
+    "@onekeyfe/hd-transport-http": "1.2.2-alpha.5",
+    "@onekeyfe/hd-transport-lowlevel": "1.2.2-alpha.5",
+    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.5",
+    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.5"
   }
 }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,12 +20,12 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.3",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
-    "@onekeyfe/hd-transport-emulator": "1.2.2-alpha.3",
-    "@onekeyfe/hd-transport-http": "1.2.2-alpha.3",
-    "@onekeyfe/hd-transport-lowlevel": "1.2.2-alpha.3",
-    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.3",
-    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.3"
+    "@onekeyfe/hd-core": "1.2.2-alpha.4",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
+    "@onekeyfe/hd-transport-emulator": "1.2.2-alpha.4",
+    "@onekeyfe/hd-transport-http": "1.2.2-alpha.4",
+    "@onekeyfe/hd-transport-lowlevel": "1.2.2-alpha.4",
+    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.4",
+    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.4"
   }
 }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,12 +20,12 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.1",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.1",
-    "@onekeyfe/hd-transport-emulator": "1.2.2-alpha.1",
-    "@onekeyfe/hd-transport-http": "1.2.2-alpha.1",
-    "@onekeyfe/hd-transport-lowlevel": "1.2.2-alpha.1",
-    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.1",
-    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.1"
+    "@onekeyfe/hd-core": "1.2.2-alpha.2",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
+    "@onekeyfe/hd-transport-emulator": "1.2.2-alpha.2",
+    "@onekeyfe/hd-transport-http": "1.2.2-alpha.2",
+    "@onekeyfe/hd-transport-lowlevel": "1.2.2-alpha.2",
+    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.2",
+    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.2"
   }
 }

--- a/packages/hd-common-connect-sdk/package.json
+++ b/packages/hd-common-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-common-connect-sdk",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -20,12 +20,12 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.2",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
-    "@onekeyfe/hd-transport-emulator": "1.2.2-alpha.2",
-    "@onekeyfe/hd-transport-http": "1.2.2-alpha.2",
-    "@onekeyfe/hd-transport-lowlevel": "1.2.2-alpha.2",
-    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.2",
-    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.2"
+    "@onekeyfe/hd-core": "1.2.2-alpha.3",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
+    "@onekeyfe/hd-transport-emulator": "1.2.2-alpha.3",
+    "@onekeyfe/hd-transport-http": "1.2.2-alpha.3",
+    "@onekeyfe/hd-transport-lowlevel": "1.2.2-alpha.3",
+    "@onekeyfe/hd-transport-usb": "1.2.2-alpha.3",
+    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.3"
   }
 }

--- a/packages/hd-transport-electron/package.json
+++ b/packages/hd-transport-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-electron",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -25,9 +25,9 @@
     "electron-log": ">=4.0.0"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.4",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.4",
+    "@onekeyfe/hd-core": "1.2.2-alpha.5",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.5",
     "@stoprocent/noble": "2.3.16",
     "p-retry": "^4.6.2"
   },

--- a/packages/hd-transport-electron/package.json
+++ b/packages/hd-transport-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-electron",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -25,9 +25,9 @@
     "electron-log": ">=4.0.0"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.5",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.5",
+    "@onekeyfe/hd-core": "1.2.2-alpha.6",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.6",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.6",
     "@stoprocent/noble": "2.3.16",
     "p-retry": "^4.6.2"
   },

--- a/packages/hd-transport-electron/package.json
+++ b/packages/hd-transport-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-electron",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -25,9 +25,9 @@
     "electron-log": ">=4.0.0"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.2",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.2",
+    "@onekeyfe/hd-core": "1.2.2-alpha.3",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.3",
     "@stoprocent/noble": "2.3.16",
     "p-retry": "^4.6.2"
   },

--- a/packages/hd-transport-electron/package.json
+++ b/packages/hd-transport-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-electron",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -25,9 +25,9 @@
     "electron-log": ">=4.0.0"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.1",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.1",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.1",
+    "@onekeyfe/hd-core": "1.2.2-alpha.2",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.2",
     "@stoprocent/noble": "2.3.16",
     "p-retry": "^4.6.2"
   },

--- a/packages/hd-transport-electron/package.json
+++ b/packages/hd-transport-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-electron",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -25,9 +25,9 @@
     "electron-log": ">=4.0.0"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.3",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.3",
+    "@onekeyfe/hd-core": "1.2.2-alpha.4",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.4",
     "@stoprocent/noble": "2.3.16",
     "p-retry": "^4.6.2"
   },

--- a/packages/hd-transport-emulator/package.json
+++ b/packages/hd-transport-emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-emulator",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "description": "hardware emulator transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.5",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.6",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.6",
     "axios": "1.15.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-emulator/package.json
+++ b/packages/hd-transport-emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-emulator",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "description": "hardware emulator transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.4",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.5",
     "axios": "1.15.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-emulator/package.json
+++ b/packages/hd-transport-emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-emulator",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "description": "hardware emulator transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.3",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.4",
     "axios": "1.15.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-emulator/package.json
+++ b/packages/hd-transport-emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-emulator",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "description": "hardware emulator transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.2",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.3",
     "axios": "1.15.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-emulator/package.json
+++ b/packages/hd-transport-emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-emulator",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "description": "hardware emulator transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.1",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.1",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.2",
     "axios": "1.15.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.4",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.5",
     "axios": "1.15.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.5",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.6",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.6",
     "axios": "1.15.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.3",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.4",
     "axios": "1.15.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.2",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.3",
     "axios": "1.15.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-http/package.json
+++ b/packages/hd-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-http",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "description": "hardware http transport",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
@@ -24,8 +24,8 @@
     "url": "https://github.com/OneKeyHQ/hardware-js-sdk/issues"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.1",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.1",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.2",
     "axios": "1.15.2",
     "secure-json-parse": "^4.0.0"
   }

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.5"
+    "@onekeyfe/hd-shared": "1.2.2-alpha.6",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.6"
   }
 }

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.4"
+    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.5"
   }
 }

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.2"
+    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.3"
   }
 }

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.3"
+    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.4"
   }
 }

--- a/packages/hd-transport-lowlevel/package.json
+++ b/packages/hd-transport-lowlevel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-lowlevel",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.1",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.1"
+    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.2"
   }
 }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -20,9 +20,9 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.4",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.4",
+    "@onekeyfe/hd-core": "1.2.2-alpha.5",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.5",
     "@onekeyfe/react-native-ble-utils": "^0.1.6",
     "react-native-ble-plx": "3.5.1"
   }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -20,9 +20,9 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.5",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.5",
+    "@onekeyfe/hd-core": "1.2.2-alpha.6",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.6",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.6",
     "@onekeyfe/react-native-ble-utils": "^0.1.6",
     "react-native-ble-plx": "3.5.1"
   }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -20,9 +20,9 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.1",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.1",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.1",
+    "@onekeyfe/hd-core": "1.2.2-alpha.2",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.2",
     "@onekeyfe/react-native-ble-utils": "^0.1.6",
     "react-native-ble-plx": "3.5.1"
   }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -20,9 +20,9 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.3",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.3",
+    "@onekeyfe/hd-core": "1.2.2-alpha.4",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.4",
     "@onekeyfe/react-native-ble-utils": "^0.1.6",
     "react-native-ble-plx": "3.5.1"
   }

--- a/packages/hd-transport-react-native/package.json
+++ b/packages/hd-transport-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-react-native",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
   "main": "dist/index.js",
@@ -20,9 +20,9 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-core": "1.2.2-alpha.2",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.2",
+    "@onekeyfe/hd-core": "1.2.2-alpha.3",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.3",
     "@onekeyfe/react-native-ble-utils": "^0.1.6",
     "react-native-ble-plx": "3.5.1"
   }

--- a/packages/hd-transport-usb/package.json
+++ b/packages/hd-transport-usb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-usb",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "description": "OneKey hardware wallet direct USB transport plugin (libusb)",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -21,8 +21,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.5",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.6",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.6",
     "bytebuffer": "^5.0.1",
     "usb": "^2.14.0"
   }

--- a/packages/hd-transport-usb/package.json
+++ b/packages/hd-transport-usb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-usb",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "description": "OneKey hardware wallet direct USB transport plugin (libusb)",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -21,8 +21,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.4",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.5",
     "bytebuffer": "^5.0.1",
     "usb": "^2.14.0"
   }

--- a/packages/hd-transport-usb/package.json
+++ b/packages/hd-transport-usb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-usb",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "description": "OneKey hardware wallet direct USB transport plugin (libusb)",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -21,8 +21,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.1",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.1",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.2",
     "bytebuffer": "^5.0.1",
     "usb": "^2.14.0"
   }

--- a/packages/hd-transport-usb/package.json
+++ b/packages/hd-transport-usb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-usb",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "description": "OneKey hardware wallet direct USB transport plugin (libusb)",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -21,8 +21,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.3",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.4",
     "bytebuffer": "^5.0.1",
     "usb": "^2.14.0"
   }

--- a/packages/hd-transport-usb/package.json
+++ b/packages/hd-transport-usb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-usb",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "description": "OneKey hardware wallet direct USB transport plugin (libusb)",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -21,8 +21,8 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.2",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.3",
     "bytebuffer": "^5.0.1",
     "usb": "^2.14.0"
   }

--- a/packages/hd-transport-web-device/package.json
+++ b/packages/hd-transport-web-device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-web-device",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -21,11 +21,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.4"
+    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.5"
   },
   "devDependencies": {
-    "@onekeyfe/hd-transport-electron": "1.2.2-alpha.4",
+    "@onekeyfe/hd-transport-electron": "1.2.2-alpha.5",
     "@types/w3c-web-usb": "^1.0.6",
     "@types/web-bluetooth": "^0.0.17"
   }

--- a/packages/hd-transport-web-device/package.json
+++ b/packages/hd-transport-web-device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-web-device",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -21,11 +21,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.5"
+    "@onekeyfe/hd-shared": "1.2.2-alpha.6",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.6"
   },
   "devDependencies": {
-    "@onekeyfe/hd-transport-electron": "1.2.2-alpha.5",
+    "@onekeyfe/hd-transport-electron": "1.2.2-alpha.6",
     "@types/w3c-web-usb": "^1.0.6",
     "@types/web-bluetooth": "^0.0.17"
   }

--- a/packages/hd-transport-web-device/package.json
+++ b/packages/hd-transport-web-device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-web-device",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -21,11 +21,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.1",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.1"
+    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.2"
   },
   "devDependencies": {
-    "@onekeyfe/hd-transport-electron": "1.2.2-alpha.1",
+    "@onekeyfe/hd-transport-electron": "1.2.2-alpha.2",
     "@types/w3c-web-usb": "^1.0.6",
     "@types/web-bluetooth": "^0.0.17"
   }

--- a/packages/hd-transport-web-device/package.json
+++ b/packages/hd-transport-web-device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-web-device",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -21,11 +21,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.3"
+    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.4"
   },
   "devDependencies": {
-    "@onekeyfe/hd-transport-electron": "1.2.2-alpha.3",
+    "@onekeyfe/hd-transport-electron": "1.2.2-alpha.4",
     "@types/w3c-web-usb": "^1.0.6",
     "@types/web-bluetooth": "^0.0.17"
   }

--- a/packages/hd-transport-web-device/package.json
+++ b/packages/hd-transport-web-device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport-web-device",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "MIT",
@@ -21,11 +21,11 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
-    "@onekeyfe/hd-transport": "1.2.2-alpha.2"
+    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
+    "@onekeyfe/hd-transport": "1.2.2-alpha.3"
   },
   "devDependencies": {
-    "@onekeyfe/hd-transport-electron": "1.2.2-alpha.2",
+    "@onekeyfe/hd-transport-electron": "1.2.2-alpha.3",
     "@types/w3c-web-usb": "^1.0.6",
     "@types/web-bluetooth": "^0.0.17"
   }

--- a/packages/hd-transport/__tests__/messages.test.js
+++ b/packages/hd-transport/__tests__/messages.test.js
@@ -171,9 +171,14 @@ describe('messages', () => {
     expect(v2Messages.nested).not.toHaveProperty('DeviceWalletSelect');
     expect(v2Messages.nested).not.toHaveProperty('DeviceWalletType');
     expect(v2Messages.nested).not.toHaveProperty('DeviceHiddenWalletSelect');
-    expect(v2Messages.nested.DeviceSession.fields).toMatchObject({
+    expect(v2Messages.nested.DeviceSession.fields).toEqual({
       session_id: { id: 1, type: 'bytes' },
       btc_test_address: { id: 2, type: 'string' },
+      seed_domains: {
+        rule: 'repeated',
+        type: 'DeviceSessionSeedDomain',
+        id: 3,
+      },
     });
     expect(v2Messages.nested.DeviceSessionAskPin.fields.type).toMatchObject({
       id: 1,
@@ -263,6 +268,30 @@ describe('messages', () => {
     expect(payload.toString('hex')).toBe('120a7462317177616c6c6574');
     expect(Message.decode(payload.toBuffer())).toMatchObject({
       btc_test_address: 'tb1qwallet',
+    });
+    expect(Message.decode(payload.toBuffer())).not.toHaveProperty('seed_domains');
+  });
+
+  test('Protocol V2 DeviceSession reports generated seed domains on wire', () => {
+    const messages = parseConfigure(v2Messages);
+    const { Message } = createMessageFromName(messages, 'DeviceSession');
+    const encoded = Message.encode(
+      Message.create({
+        btc_test_address: 'tb1qwallet',
+        seed_domains: [
+          generatedTypes.DeviceSessionSeedDomain.SeedDomain_Standard,
+          generatedTypes.DeviceSessionSeedDomain.SeedDomain_Cardano,
+        ],
+      })
+    ).finish();
+
+    expect(Buffer.from(encoded).toString('hex')).toBe('120a7462317177616c6c65741a020102');
+    expect(Message.decode(encoded)).toMatchObject({
+      btc_test_address: 'tb1qwallet',
+      seed_domains: [
+        generatedTypes.DeviceSessionSeedDomain.SeedDomain_Standard,
+        generatedTypes.DeviceSessionSeedDomain.SeedDomain_Cardano,
+      ],
     });
   });
 

--- a/packages/hd-transport/__tests__/messages.test.js
+++ b/packages/hd-transport/__tests__/messages.test.js
@@ -150,6 +150,11 @@ describe('messages', () => {
     expect(v2Messages.nested.DeviceSessionGet.fields).toEqual({
       session_id: { id: 1, type: 'bytes' },
       btc_test_address: { id: 2, type: 'string' },
+      seed_domains: {
+        rule: 'repeated',
+        type: 'DeviceSessionSeedDomain',
+        id: 3,
+      },
     });
     expect(v2Messages.nested.DeviceSessionSeedDomain.values).toEqual({
       SeedDomain_Standard: 1,
@@ -264,12 +269,27 @@ describe('messages', () => {
     const payload = encode(Message, {
       btc_test_address: 'tb1qwallet',
     });
+    const withCardano = encode(Message, {
+      btc_test_address: 'tb1qwallet',
+      seed_domains: [
+        generatedTypes.DeviceSessionSeedDomain.SeedDomain_Standard,
+        generatedTypes.DeviceSessionSeedDomain.SeedDomain_Cardano,
+      ],
+    });
 
     expect(payload.toString('hex')).toBe('120a7462317177616c6c6574');
     expect(Message.decode(payload.toBuffer())).toMatchObject({
       btc_test_address: 'tb1qwallet',
+      seed_domains: [],
     });
-    expect(Message.decode(payload.toBuffer())).not.toHaveProperty('seed_domains');
+    expect(withCardano.toString('hex')).toBe('120a7462317177616c6c65741a020102');
+    expect(Message.decode(withCardano.toBuffer())).toMatchObject({
+      btc_test_address: 'tb1qwallet',
+      seed_domains: [
+        generatedTypes.DeviceSessionSeedDomain.SeedDomain_Standard,
+        generatedTypes.DeviceSessionSeedDomain.SeedDomain_Cardano,
+      ],
+    });
   });
 
   test('Protocol V2 DeviceSession reports generated seed domains on wire', () => {

--- a/packages/hd-transport/__tests__/messages.test.js
+++ b/packages/hd-transport/__tests__/messages.test.js
@@ -150,11 +150,6 @@ describe('messages', () => {
     expect(v2Messages.nested.DeviceSessionGet.fields).toEqual({
       session_id: { id: 1, type: 'bytes' },
       btc_test_address: { id: 2, type: 'string' },
-      seed_domains: {
-        rule: 'repeated',
-        type: 'DeviceSessionSeedDomain',
-        id: 3,
-      },
     });
     expect(v2Messages.nested.DeviceSessionSeedDomain.values).toEqual({
       SeedDomain_Standard: 1,
@@ -269,27 +264,12 @@ describe('messages', () => {
     const payload = encode(Message, {
       btc_test_address: 'tb1qwallet',
     });
-    const withCardano = encode(Message, {
-      btc_test_address: 'tb1qwallet',
-      seed_domains: [
-        generatedTypes.DeviceSessionSeedDomain.SeedDomain_Standard,
-        generatedTypes.DeviceSessionSeedDomain.SeedDomain_Cardano,
-      ],
-    });
 
     expect(payload.toString('hex')).toBe('120a7462317177616c6c6574');
     expect(Message.decode(payload.toBuffer())).toMatchObject({
       btc_test_address: 'tb1qwallet',
-      seed_domains: [],
     });
-    expect(withCardano.toString('hex')).toBe('120a7462317177616c6c65741a020102');
-    expect(Message.decode(withCardano.toBuffer())).toMatchObject({
-      btc_test_address: 'tb1qwallet',
-      seed_domains: [
-        generatedTypes.DeviceSessionSeedDomain.SeedDomain_Standard,
-        generatedTypes.DeviceSessionSeedDomain.SeedDomain_Cardano,
-      ],
-    });
+    expect(Message.decode(payload.toBuffer())).not.toHaveProperty('seed_domains');
   });
 
   test('Protocol V2 DeviceSession reports generated seed domains on wire', () => {

--- a/packages/hd-transport/__tests__/messages.test.js
+++ b/packages/hd-transport/__tests__/messages.test.js
@@ -150,11 +150,6 @@ describe('messages', () => {
     expect(v2Messages.nested.DeviceSessionGet.fields).toEqual({
       session_id: { id: 1, type: 'bytes' },
       btc_test_address: { id: 2, type: 'string' },
-      seed_domains: {
-        id: 3,
-        rule: 'repeated',
-        type: 'DeviceSessionSeedDomain',
-      },
     });
     expect(v2Messages.nested.DeviceSessionSeedDomain.values).toEqual({
       SeedDomain_Standard: 1,
@@ -195,6 +190,11 @@ describe('messages', () => {
           type: 'bool',
           id: 2,
         },
+        seed_domains: {
+          rule: 'repeated',
+          type: 'DeviceSessionSeedDomain',
+          id: 3,
+        },
       },
     });
     expect(v2Messages.nested.DeviceSessionAskPin_FailureSubCodes.values).toEqual({
@@ -212,42 +212,57 @@ describe('messages', () => {
     const messages = parseConfigure(v2Messages);
     const { Message } = createMessageFromName(messages, 'DeviceSessionAskPassphrase');
 
-    const standardWallet = encode(Message, { passphrase: '', on_device: false });
+    const standardWallet = encode(Message, {
+      passphrase: '',
+      on_device: false,
+      seed_domains: [],
+    });
     const onHost = Message.encode(
-      Message.create({ passphrase: 'host hidden wallet', on_device: false })
+      Message.create({
+        passphrase: 'host hidden wallet',
+        on_device: false,
+        seed_domains: [
+          generatedTypes.DeviceSessionSeedDomain.SeedDomain_Standard,
+          generatedTypes.DeviceSessionSeedDomain.SeedDomain_Cardano,
+        ],
+      })
     ).finish();
-    const onDevice = Message.encode(Message.create({ on_device: true })).finish();
+    const onDevice = Message.encode(
+      Message.create({
+        on_device: true,
+        seed_domains: [generatedTypes.DeviceSessionSeedDomain.SeedDomain_Standard],
+      })
+    ).finish();
 
     expect(standardWallet.toString('hex')).toBe('0a001000');
     expect(Buffer.from(onHost).toString('hex')).toBe(
-      '0a12686f73742068696464656e2077616c6c65741000'
+      '0a12686f73742068696464656e2077616c6c657410001a020102'
     );
-    expect(Buffer.from(onDevice).toString('hex')).toBe('1001');
+    expect(Buffer.from(onDevice).toString('hex')).toBe('10011a0101');
     expect(Message.decode(onHost)).toMatchObject({
       passphrase: 'host hidden wallet',
       on_device: false,
+      seed_domains: [
+        generatedTypes.DeviceSessionSeedDomain.SeedDomain_Standard,
+        generatedTypes.DeviceSessionSeedDomain.SeedDomain_Cardano,
+      ],
     });
-    expect(Message.decode(onDevice)).toMatchObject({ on_device: true });
+    expect(Message.decode(onDevice)).toMatchObject({
+      on_device: true,
+      seed_domains: [generatedTypes.DeviceSessionSeedDomain.SeedDomain_Standard],
+    });
   });
 
-  test('Protocol V2 wallet recovery carries the expected wallet and seed domains on wire', () => {
+  test('Protocol V2 wallet recovery carries the expected wallet on wire', () => {
     const messages = parseConfigure(v2Messages);
     const { Message } = createMessageFromName(messages, 'DeviceSessionGet');
     const payload = encode(Message, {
       btc_test_address: 'tb1qwallet',
-      seed_domains: [
-        generatedTypes.DeviceSessionSeedDomain.SeedDomain_Standard,
-        generatedTypes.DeviceSessionSeedDomain.SeedDomain_Cardano,
-      ],
     });
 
-    expect(payload.toString('hex')).toBe('120a7462317177616c6c65741a020102');
+    expect(payload.toString('hex')).toBe('120a7462317177616c6c6574');
     expect(Message.decode(payload.toBuffer())).toMatchObject({
       btc_test_address: 'tb1qwallet',
-      seed_domains: [
-        generatedTypes.DeviceSessionSeedDomain.SeedDomain_Standard,
-        generatedTypes.DeviceSessionSeedDomain.SeedDomain_Cardano,
-      ],
     });
   });
 

--- a/packages/hd-transport/messages-protocol-v2.json
+++ b/packages/hd-transport/messages-protocol-v2.json
@@ -12322,6 +12322,11 @@
         "btc_test_address": {
           "type": "string",
           "id": 2
+        },
+        "seed_domains": {
+          "rule": "repeated",
+          "type": "DeviceSessionSeedDomain",
+          "id": 3
         }
       }
     },
@@ -12852,57 +12857,36 @@
       },
       "reserved": [[2, 2], "placeholder"]
     },
-    "ViewContentPreview": {
+    "ViewData": {
       "fields": {
-        "content_key": {
-          "rule": "required",
-          "type": "uint32",
-          "id": 1
-        },
         "preview": {
           "rule": "required",
           "type": "bytes",
-          "id": 2
-        },
-        "total_bytes": {
-          "type": "uint32",
-          "id": 3
-        }
-      }
-    },
-    "ViewContentEntry": {
-      "fields": {
-        "entry_key": {
-          "rule": "required",
-          "type": "uint32",
           "id": 1
         },
-        "value": {
+        "total_bytes": {
           "rule": "required",
-          "type": "bytes",
+          "type": "uint32",
           "id": 2
         }
       }
     },
-    "ViewContentPage": {
+    "ViewDataPage": {
       "fields": {
+        "chunk": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 1
+        },
         "page_index": {
           "rule": "required",
           "type": "uint32",
-          "id": 1
+          "id": 2
         },
         "page_count": {
           "rule": "required",
           "type": "uint32",
-          "id": 2
-        },
-        "chunk": {
-          "type": "bytes",
           "id": 3
-        },
-        "entry": {
-          "type": "ViewContentEntry",
-          "id": 4
         }
       }
     },
@@ -12961,8 +12945,8 @@
           "type": "string",
           "id": 9
         },
-        "content": {
-          "type": "ViewContentPreview",
+        "data": {
+          "type": "ViewData",
           "id": 10
         },
         "custom_field": {
@@ -12986,10 +12970,6 @@
         "text_arg": {
           "type": "string",
           "id": 3
-        },
-        "cancellable": {
-          "type": "bool",
-          "id": 4
         }
       }
     },
@@ -13028,10 +13008,6 @@
         "chain_id": {
           "type": "uint32",
           "id": 8
-        },
-        "content": {
-          "type": "ViewContentPreview",
-          "id": 9
         }
       }
     },

--- a/packages/hd-transport/messages-protocol-v2.json
+++ b/packages/hd-transport/messages-protocol-v2.json
@@ -12852,57 +12852,36 @@
       },
       "reserved": [[2, 2], "placeholder"]
     },
-    "ViewContentPreview": {
+    "ViewData": {
       "fields": {
-        "content_key": {
-          "rule": "required",
-          "type": "uint32",
-          "id": 1
-        },
         "preview": {
           "rule": "required",
           "type": "bytes",
-          "id": 2
-        },
-        "total_bytes": {
-          "type": "uint32",
-          "id": 3
-        }
-      }
-    },
-    "ViewContentEntry": {
-      "fields": {
-        "entry_key": {
-          "rule": "required",
-          "type": "uint32",
           "id": 1
         },
-        "value": {
+        "total_bytes": {
           "rule": "required",
-          "type": "bytes",
+          "type": "uint32",
           "id": 2
         }
       }
     },
-    "ViewContentPage": {
+    "ViewDataPage": {
       "fields": {
+        "chunk": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 1
+        },
         "page_index": {
           "rule": "required",
           "type": "uint32",
-          "id": 1
+          "id": 2
         },
         "page_count": {
           "rule": "required",
           "type": "uint32",
-          "id": 2
-        },
-        "chunk": {
-          "type": "bytes",
           "id": 3
-        },
-        "entry": {
-          "type": "ViewContentEntry",
-          "id": 4
         }
       }
     },
@@ -12961,8 +12940,8 @@
           "type": "string",
           "id": 9
         },
-        "content": {
-          "type": "ViewContentPreview",
+        "data": {
+          "type": "ViewData",
           "id": 10
         },
         "custom_field": {
@@ -12986,10 +12965,6 @@
         "text_arg": {
           "type": "string",
           "id": 3
-        },
-        "cancellable": {
-          "type": "bool",
-          "id": 4
         }
       }
     },
@@ -13028,10 +13003,6 @@
         "chain_id": {
           "type": "uint32",
           "id": 8
-        },
-        "content": {
-          "type": "ViewContentPreview",
-          "id": 9
         }
       }
     },

--- a/packages/hd-transport/messages-protocol-v2.json
+++ b/packages/hd-transport/messages-protocol-v2.json
@@ -12852,36 +12852,57 @@
       },
       "reserved": [[2, 2], "placeholder"]
     },
-    "ViewData": {
+    "ViewContentPreview": {
       "fields": {
+        "content_key": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 1
+        },
         "preview": {
           "rule": "required",
           "type": "bytes",
-          "id": 1
+          "id": 2
         },
         "total_bytes": {
+          "type": "uint32",
+          "id": 3
+        }
+      }
+    },
+    "ViewContentEntry": {
+      "fields": {
+        "entry_key": {
           "rule": "required",
           "type": "uint32",
+          "id": 1
+        },
+        "value": {
+          "rule": "required",
+          "type": "bytes",
           "id": 2
         }
       }
     },
-    "ViewDataPage": {
+    "ViewContentPage": {
       "fields": {
-        "chunk": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 1
-        },
         "page_index": {
           "rule": "required",
           "type": "uint32",
-          "id": 2
+          "id": 1
         },
         "page_count": {
           "rule": "required",
           "type": "uint32",
+          "id": 2
+        },
+        "chunk": {
+          "type": "bytes",
           "id": 3
+        },
+        "entry": {
+          "type": "ViewContentEntry",
+          "id": 4
         }
       }
     },
@@ -12940,8 +12961,8 @@
           "type": "string",
           "id": 9
         },
-        "data": {
-          "type": "ViewData",
+        "content": {
+          "type": "ViewContentPreview",
           "id": 10
         },
         "custom_field": {
@@ -12965,6 +12986,10 @@
         "text_arg": {
           "type": "string",
           "id": 3
+        },
+        "cancellable": {
+          "type": "bool",
+          "id": 4
         }
       }
     },
@@ -13003,6 +13028,10 @@
         "chain_id": {
           "type": "uint32",
           "id": 8
+        },
+        "content": {
+          "type": "ViewContentPreview",
+          "id": 9
         }
       }
     },

--- a/packages/hd-transport/messages-protocol-v2.json
+++ b/packages/hd-transport/messages-protocol-v2.json
@@ -12322,11 +12322,6 @@
         "btc_test_address": {
           "type": "string",
           "id": 2
-        },
-        "seed_domains": {
-          "rule": "repeated",
-          "type": "DeviceSessionSeedDomain",
-          "id": 3
         }
       }
     },
@@ -12857,36 +12852,57 @@
       },
       "reserved": [[2, 2], "placeholder"]
     },
-    "ViewData": {
+    "ViewContentPreview": {
       "fields": {
+        "content_key": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 1
+        },
         "preview": {
           "rule": "required",
           "type": "bytes",
-          "id": 1
+          "id": 2
         },
         "total_bytes": {
+          "type": "uint32",
+          "id": 3
+        }
+      }
+    },
+    "ViewContentEntry": {
+      "fields": {
+        "entry_key": {
           "rule": "required",
           "type": "uint32",
+          "id": 1
+        },
+        "value": {
+          "rule": "required",
+          "type": "bytes",
           "id": 2
         }
       }
     },
-    "ViewDataPage": {
+    "ViewContentPage": {
       "fields": {
-        "chunk": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 1
-        },
         "page_index": {
           "rule": "required",
           "type": "uint32",
-          "id": 2
+          "id": 1
         },
         "page_count": {
           "rule": "required",
           "type": "uint32",
+          "id": 2
+        },
+        "chunk": {
+          "type": "bytes",
           "id": 3
+        },
+        "entry": {
+          "type": "ViewContentEntry",
+          "id": 4
         }
       }
     },
@@ -12945,8 +12961,8 @@
           "type": "string",
           "id": 9
         },
-        "data": {
-          "type": "ViewData",
+        "content": {
+          "type": "ViewContentPreview",
           "id": 10
         },
         "custom_field": {
@@ -12970,6 +12986,10 @@
         "text_arg": {
           "type": "string",
           "id": 3
+        },
+        "cancellable": {
+          "type": "bool",
+          "id": 4
         }
       }
     },
@@ -13008,6 +13028,10 @@
         "chain_id": {
           "type": "uint32",
           "id": 8
+        },
+        "content": {
+          "type": "ViewContentPreview",
+          "id": 9
         }
       }
     },

--- a/packages/hd-transport/messages-protocol-v2.json
+++ b/packages/hd-transport/messages-protocol-v2.json
@@ -1,490 +1,5 @@
 {
   "nested": {
-    "wire_in": {
-      "type": "bool",
-      "id": 50002,
-      "extend": "google.protobuf.EnumValueOptions"
-    },
-    "wire_out": {
-      "type": "bool",
-      "id": 50003,
-      "extend": "google.protobuf.EnumValueOptions"
-    },
-    "wire_debug_in": {
-      "type": "bool",
-      "id": 50004,
-      "extend": "google.protobuf.EnumValueOptions"
-    },
-    "wire_debug_out": {
-      "type": "bool",
-      "id": 50005,
-      "extend": "google.protobuf.EnumValueOptions"
-    },
-    "wire_tiny": {
-      "type": "bool",
-      "id": 50006,
-      "extend": "google.protobuf.EnumValueOptions"
-    },
-    "wire_bootloader": {
-      "type": "bool",
-      "id": 50007,
-      "extend": "google.protobuf.EnumValueOptions"
-    },
-    "wire_no_fsm": {
-      "type": "bool",
-      "id": 50008,
-      "extend": "google.protobuf.EnumValueOptions"
-    },
-    "bitcoin_only": {
-      "type": "bool",
-      "id": 60000,
-      "extend": "google.protobuf.EnumValueOptions"
-    },
-    "has_bitcoin_only_values": {
-      "type": "bool",
-      "id": 51001,
-      "extend": "google.protobuf.EnumOptions"
-    },
-    "experimental_message": {
-      "type": "bool",
-      "id": 52001,
-      "extend": "google.protobuf.MessageOptions"
-    },
-    "wire_type": {
-      "type": "uint32",
-      "id": 52002,
-      "extend": "google.protobuf.MessageOptions"
-    },
-    "experimental_field": {
-      "type": "bool",
-      "id": 53001,
-      "extend": "google.protobuf.FieldOptions"
-    },
-    "include_in_bitcoin_only": {
-      "type": "bool",
-      "id": 60000,
-      "extend": "google.protobuf.FileOptions"
-    },
-    "MessageType": {
-      "options": {
-        "(has_bitcoin_only_values)": true
-      },
-      "values": {
-        "MessageType_Initialize": 0,
-        "MessageType_ChangePin": 4,
-        "MessageType_WipeDevice": 5,
-        "MessageType_GetEntropy": 9,
-        "MessageType_Entropy": 10,
-        "MessageType_LoadDevice": 13,
-        "MessageType_ResetDevice": 14,
-        "MessageType_SetBusy": 16,
-        "MessageType_Features": 17,
-        "MessageType_Cancel": 20,
-        "MessageType_LockDevice": 24,
-        "MessageType_ApplySettings": 25,
-        "MessageType_ButtonRequest": 26,
-        "MessageType_ButtonAck": 27,
-        "MessageType_ApplyFlags": 28,
-        "MessageType_GetNonce": 31,
-        "MessageType_Nonce": 33,
-        "MessageType_BackupDevice": 34,
-        "MessageType_EntropyRequest": 35,
-        "MessageType_EntropyAck": 36,
-        "MessageType_PassphraseRequest": 41,
-        "MessageType_PassphraseAck": 42,
-        "MessageType_RecoveryDevice": 45,
-        "MessageType_WordRequest": 46,
-        "MessageType_WordAck": 47,
-        "MessageType_GetFeatures": 55,
-        "MessageType_SdProtect": 79,
-        "MessageType_ChangeWipeCode": 82,
-        "MessageType_DoPreauthorized": 84,
-        "MessageType_PreauthorizedRequest": 85,
-        "MessageType_CancelAuthorization": 86,
-        "MessageType_GetFirmwareHash": 88,
-        "MessageType_FirmwareHash": 89,
-        "MessageType_UnlockPath": 93,
-        "MessageType_UnlockedPathRequest": 94,
-        "MessageType_SetU2FCounter": 63,
-        "MessageType_GetNextU2FCounter": 80,
-        "MessageType_NextU2FCounter": 81,
-        "MessageType_Deprecated_PassphraseStateRequest": 77,
-        "MessageType_Deprecated_PassphraseStateAck": 78,
-        "MessageType_GetPublicKey": 11,
-        "MessageType_PublicKey": 12,
-        "MessageType_SignTx": 15,
-        "MessageType_TxRequest": 21,
-        "MessageType_TxAck": 22,
-        "MessageType_GetAddress": 29,
-        "MessageType_Address": 30,
-        "MessageType_TxAckPaymentRequest": 37,
-        "MessageType_SignMessage": 38,
-        "MessageType_VerifyMessage": 39,
-        "MessageType_MessageSignature": 40,
-        "MessageType_GetOwnershipId": 43,
-        "MessageType_OwnershipId": 44,
-        "MessageType_GetOwnershipProof": 49,
-        "MessageType_OwnershipProof": 50,
-        "MessageType_AuthorizeCoinJoin": 51,
-        "MessageType_SignPsbt": 10052,
-        "MessageType_SignedPsbt": 10053,
-        "MessageType_CipherKeyValue": 23,
-        "MessageType_CipheredKeyValue": 48,
-        "MessageType_SignIdentity": 53,
-        "MessageType_SignedIdentity": 54,
-        "MessageType_GetECDHSessionKey": 61,
-        "MessageType_ECDHSessionKey": 62,
-        "MessageType_CosiCommit": 71,
-        "MessageType_CosiCommitment": 72,
-        "MessageType_CosiSign": 73,
-        "MessageType_CosiSignature": 74,
-        "MessageType_BatchGetPublickeys": 10016,
-        "MessageType_EcdsaPublicKeys": 10017,
-        "MessageType_EthereumGetPublicKey": 450,
-        "MessageType_EthereumPublicKey": 451,
-        "MessageType_EthereumGetAddress": 56,
-        "MessageType_EthereumAddress": 57,
-        "MessageType_EthereumSignTx": 58,
-        "MessageType_EthereumSignTxEIP1559": 452,
-        "MessageType_EthereumTxRequest": 59,
-        "MessageType_EthereumTxAck": 60,
-        "MessageType_EthereumSignMessage": 64,
-        "MessageType_EthereumVerifyMessage": 65,
-        "MessageType_EthereumMessageSignature": 66,
-        "MessageType_EthereumSignTypedData": 464,
-        "MessageType_EthereumTypedDataStructRequest": 465,
-        "MessageType_EthereumTypedDataStructAck": 466,
-        "MessageType_EthereumTypedDataValueRequest": 467,
-        "MessageType_EthereumTypedDataValueAck": 468,
-        "MessageType_EthereumTypedDataSignature": 469,
-        "MessageType_EthereumSignTypedHash": 470,
-        "MessageType_EthereumGetPublicKeyOneKey": 20100,
-        "MessageType_EthereumPublicKeyOneKey": 20101,
-        "MessageType_EthereumGetAddressOneKey": 20102,
-        "MessageType_EthereumAddressOneKey": 20103,
-        "MessageType_EthereumSignTxOneKey": 20104,
-        "MessageType_EthereumSignTxEIP1559OneKey": 20105,
-        "MessageType_EthereumTxRequestOneKey": 20106,
-        "MessageType_EthereumTxAckOneKey": 20107,
-        "MessageType_EthereumSignMessageOneKey": 20108,
-        "MessageType_EthereumVerifyMessageOneKey": 20109,
-        "MessageType_EthereumMessageSignatureOneKey": 20110,
-        "MessageType_EthereumSignTypedDataOneKey": 20111,
-        "MessageType_EthereumTypedDataStructRequestOneKey": 20112,
-        "MessageType_EthereumTypedDataStructAckOneKey": 20113,
-        "MessageType_EthereumTypedDataValueRequestOneKey": 20114,
-        "MessageType_EthereumTypedDataValueAckOneKey": 20115,
-        "MessageType_EthereumTypedDataSignatureOneKey": 20116,
-        "MessageType_EthereumSignTypedHashOneKey": 20117,
-        "MessageType_EthereumGnosisSafeTxAck": 20118,
-        "MessageType_EthereumGnosisSafeTxRequest": 20119,
-        "MessageType_EthereumSignTxEIP7702OneKey": 20120,
-        "MessageType_EthereumSignTypedDataQR": 20121,
-        "MessageType_NEMGetAddress": 67,
-        "MessageType_NEMAddress": 68,
-        "MessageType_NEMSignTx": 69,
-        "MessageType_NEMSignedTx": 70,
-        "MessageType_NEMDecryptMessage": 75,
-        "MessageType_NEMDecryptedMessage": 76,
-        "MessageType_TezosGetAddress": 150,
-        "MessageType_TezosAddress": 151,
-        "MessageType_TezosSignTx": 152,
-        "MessageType_TezosSignedTx": 153,
-        "MessageType_TezosGetPublicKey": 154,
-        "MessageType_TezosPublicKey": 155,
-        "MessageType_StellarSignTx": 202,
-        "MessageType_StellarTxOpRequest": 203,
-        "MessageType_StellarGetAddress": 207,
-        "MessageType_StellarAddress": 208,
-        "MessageType_StellarCreateAccountOp": 210,
-        "MessageType_StellarPaymentOp": 211,
-        "MessageType_StellarPathPaymentStrictReceiveOp": 212,
-        "MessageType_StellarManageSellOfferOp": 213,
-        "MessageType_StellarCreatePassiveSellOfferOp": 214,
-        "MessageType_StellarSetOptionsOp": 215,
-        "MessageType_StellarChangeTrustOp": 216,
-        "MessageType_StellarAllowTrustOp": 217,
-        "MessageType_StellarAccountMergeOp": 218,
-        "MessageType_StellarManageDataOp": 220,
-        "MessageType_StellarBumpSequenceOp": 221,
-        "MessageType_StellarManageBuyOfferOp": 222,
-        "MessageType_StellarPathPaymentStrictSendOp": 223,
-        "MessageType_StellarSignedTx": 230,
-        "MessageType_CardanoGetPublicKey": 305,
-        "MessageType_CardanoPublicKey": 306,
-        "MessageType_CardanoGetAddress": 307,
-        "MessageType_CardanoAddress": 308,
-        "MessageType_CardanoTxItemAck": 313,
-        "MessageType_CardanoTxAuxiliaryDataSupplement": 314,
-        "MessageType_CardanoTxWitnessRequest": 315,
-        "MessageType_CardanoTxWitnessResponse": 316,
-        "MessageType_CardanoTxHostAck": 317,
-        "MessageType_CardanoTxBodyHash": 318,
-        "MessageType_CardanoSignTxFinished": 319,
-        "MessageType_CardanoSignTxInit": 320,
-        "MessageType_CardanoTxInput": 321,
-        "MessageType_CardanoTxOutput": 322,
-        "MessageType_CardanoAssetGroup": 323,
-        "MessageType_CardanoToken": 324,
-        "MessageType_CardanoTxCertificate": 325,
-        "MessageType_CardanoTxWithdrawal": 326,
-        "MessageType_CardanoTxAuxiliaryData": 327,
-        "MessageType_CardanoPoolOwner": 328,
-        "MessageType_CardanoPoolRelayParameters": 329,
-        "MessageType_CardanoGetNativeScriptHash": 330,
-        "MessageType_CardanoNativeScriptHash": 331,
-        "MessageType_CardanoTxMint": 332,
-        "MessageType_CardanoTxCollateralInput": 333,
-        "MessageType_CardanoTxRequiredSigner": 334,
-        "MessageType_CardanoTxInlineDatumChunk": 335,
-        "MessageType_CardanoTxReferenceScriptChunk": 336,
-        "MessageType_CardanoTxReferenceInput": 337,
-        "MessageType_CardanoSignMessage": 350,
-        "MessageType_CardanoMessageSignature": 351,
-        "MessageType_RippleGetAddress": 400,
-        "MessageType_RippleAddress": 401,
-        "MessageType_RippleSignTx": 402,
-        "MessageType_RippleSignedTx": 403,
-        "MessageType_MoneroTransactionInitRequest": 501,
-        "MessageType_MoneroTransactionInitAck": 502,
-        "MessageType_MoneroTransactionSetInputRequest": 503,
-        "MessageType_MoneroTransactionSetInputAck": 504,
-        "MessageType_MoneroTransactionInputViniRequest": 507,
-        "MessageType_MoneroTransactionInputViniAck": 508,
-        "MessageType_MoneroTransactionAllInputsSetRequest": 509,
-        "MessageType_MoneroTransactionAllInputsSetAck": 510,
-        "MessageType_MoneroTransactionSetOutputRequest": 511,
-        "MessageType_MoneroTransactionSetOutputAck": 512,
-        "MessageType_MoneroTransactionAllOutSetRequest": 513,
-        "MessageType_MoneroTransactionAllOutSetAck": 514,
-        "MessageType_MoneroTransactionSignInputRequest": 515,
-        "MessageType_MoneroTransactionSignInputAck": 516,
-        "MessageType_MoneroTransactionFinalRequest": 517,
-        "MessageType_MoneroTransactionFinalAck": 518,
-        "MessageType_MoneroKeyImageExportInitRequest": 530,
-        "MessageType_MoneroKeyImageExportInitAck": 531,
-        "MessageType_MoneroKeyImageSyncStepRequest": 532,
-        "MessageType_MoneroKeyImageSyncStepAck": 533,
-        "MessageType_MoneroKeyImageSyncFinalRequest": 534,
-        "MessageType_MoneroKeyImageSyncFinalAck": 535,
-        "MessageType_MoneroGetAddress": 540,
-        "MessageType_MoneroAddress": 541,
-        "MessageType_MoneroGetWatchKey": 542,
-        "MessageType_MoneroWatchKey": 543,
-        "MessageType_DebugMoneroDiagRequest": 546,
-        "MessageType_DebugMoneroDiagAck": 547,
-        "MessageType_MoneroGetTxKeyRequest": 550,
-        "MessageType_MoneroGetTxKeyAck": 551,
-        "MessageType_MoneroLiveRefreshStartRequest": 552,
-        "MessageType_MoneroLiveRefreshStartAck": 553,
-        "MessageType_MoneroLiveRefreshStepRequest": 554,
-        "MessageType_MoneroLiveRefreshStepAck": 555,
-        "MessageType_MoneroLiveRefreshFinalRequest": 556,
-        "MessageType_MoneroLiveRefreshFinalAck": 557,
-        "MessageType_EosGetPublicKey": 600,
-        "MessageType_EosPublicKey": 601,
-        "MessageType_EosSignTx": 602,
-        "MessageType_EosTxActionRequest": 603,
-        "MessageType_EosTxActionAck": 604,
-        "MessageType_EosSignedTx": 605,
-        "MessageType_BinanceGetAddress": 700,
-        "MessageType_BinanceAddress": 701,
-        "MessageType_BinanceGetPublicKey": 702,
-        "MessageType_BinancePublicKey": 703,
-        "MessageType_BinanceSignTx": 704,
-        "MessageType_BinanceTxRequest": 705,
-        "MessageType_BinanceTransferMsg": 706,
-        "MessageType_BinanceOrderMsg": 707,
-        "MessageType_BinanceCancelMsg": 708,
-        "MessageType_BinanceSignedTx": 709,
-        "MessageType_StarcoinGetAddress": 10300,
-        "MessageType_StarcoinAddress": 10301,
-        "MessageType_StarcoinGetPublicKey": 10302,
-        "MessageType_StarcoinPublicKey": 10303,
-        "MessageType_StarcoinSignTx": 10304,
-        "MessageType_StarcoinSignedTx": 10305,
-        "MessageType_StarcoinSignMessage": 10306,
-        "MessageType_StarcoinMessageSignature": 10307,
-        "MessageType_StarcoinVerifyMessage": 10308,
-        "MessageType_ConfluxGetAddress": 10112,
-        "MessageType_ConfluxAddress": 10113,
-        "MessageType_ConfluxSignTx": 10114,
-        "MessageType_ConfluxTxRequest": 10115,
-        "MessageType_ConfluxTxAck": 10116,
-        "MessageType_ConfluxSignMessage": 10117,
-        "MessageType_ConfluxSignMessageCIP23": 10118,
-        "MessageType_ConfluxMessageSignature": 10119,
-        "MessageType_TronGetAddress": 10501,
-        "MessageType_TronAddress": 10502,
-        "MessageType_TronSignTx": 10503,
-        "MessageType_TronSignedTx": 10504,
-        "MessageType_TronSignMessage": 10505,
-        "MessageType_TronMessageSignature": 10506,
-        "MessageType_NearGetAddress": 10701,
-        "MessageType_NearAddress": 10702,
-        "MessageType_NearSignTx": 10703,
-        "MessageType_NearSignedTx": 10704,
-        "MessageType_AptosGetAddress": 10600,
-        "MessageType_AptosAddress": 10601,
-        "MessageType_AptosSignTx": 10602,
-        "MessageType_AptosSignedTx": 10603,
-        "MessageType_AptosSignMessage": 10604,
-        "MessageType_AptosMessageSignature": 10605,
-        "MessageType_AptosSignSIWAMessage": 10606,
-        "MessageType_WebAuthnListResidentCredentials": 800,
-        "MessageType_WebAuthnCredentials": 801,
-        "MessageType_WebAuthnAddResidentCredential": 802,
-        "MessageType_WebAuthnRemoveResidentCredential": 803,
-        "MessageType_SolanaGetAddress": 10100,
-        "MessageType_SolanaAddress": 10101,
-        "MessageType_SolanaSignTx": 10102,
-        "MessageType_SolanaSignedTx": 10103,
-        "MessageType_SolanaSignOffChainMessage": 10104,
-        "MessageType_SolanaMessageSignature": 10105,
-        "MessageType_SolanaSignUnsafeMessage": 10106,
-        "MessageType_CosmosGetAddress": 10800,
-        "MessageType_CosmosAddress": 10801,
-        "MessageType_CosmosSignTx": 10802,
-        "MessageType_CosmosSignedTx": 10803,
-        "MessageType_AlgorandGetAddress": 10900,
-        "MessageType_AlgorandAddress": 10901,
-        "MessageType_AlgorandSignTx": 10902,
-        "MessageType_AlgorandSignedTx": 10903,
-        "MessageType_PolkadotGetAddress": 11000,
-        "MessageType_PolkadotAddress": 11001,
-        "MessageType_PolkadotSignTx": 11002,
-        "MessageType_PolkadotSignedTx": 11003,
-        "MessageType_SuiGetAddress": 11100,
-        "MessageType_SuiAddress": 11101,
-        "MessageType_SuiSignTx": 11102,
-        "MessageType_SuiSignedTx": 11103,
-        "MessageType_SuiSignMessage": 11104,
-        "MessageType_SuiMessageSignature": 11105,
-        "MessageType_SuiTxRequest": 11106,
-        "MessageType_SuiTxAck": 11107,
-        "MessageType_FilecoinGetAddress": 11200,
-        "MessageType_FilecoinAddress": 11201,
-        "MessageType_FilecoinSignTx": 11202,
-        "MessageType_FilecoinSignedTx": 11203,
-        "MessageType_KaspaGetAddress": 11300,
-        "MessageType_KaspaAddress": 11301,
-        "MessageType_KaspaSignTx": 11302,
-        "MessageType_KaspaSignedTx": 11303,
-        "MessageType_KaspaTxInputRequest": 11304,
-        "MessageType_KaspaTxInputAck": 11305,
-        "MessageType_NexaGetAddress": 11400,
-        "MessageType_NexaAddress": 11401,
-        "MessageType_NexaSignTx": 11402,
-        "MessageType_NexaSignedTx": 11403,
-        "MessageType_NexaTxInputRequest": 11404,
-        "MessageType_NexaTxInputAck": 11405,
-        "MessageType_NostrGetPublicKey": 11500,
-        "MessageType_NostrPublicKey": 11501,
-        "MessageType_NostrSignEvent": 11502,
-        "MessageType_NostrSignedEvent": 11503,
-        "MessageType_NostrEncryptMessage": 11504,
-        "MessageType_NostrEncryptedMessage": 11505,
-        "MessageType_NostrDecryptMessage": 11506,
-        "MessageType_NostrDecryptedMessage": 11507,
-        "MessageType_NostrSignSchnorr": 11508,
-        "MessageType_NostrSignedSchnorr": 11509,
-        "MessageType_LnurlAuth": 11600,
-        "MessageType_LnurlAuthResp": 11601,
-        "MessageType_NervosGetAddress": 11701,
-        "MessageType_NervosAddress": 11702,
-        "MessageType_NervosSignTx": 11703,
-        "MessageType_NervosSignedTx": 11704,
-        "MessageType_NervosTxRequest": 11705,
-        "MessageType_NervosTxAck": 11706,
-        "MessageType_TonGetAddress": 11901,
-        "MessageType_TonAddress": 11902,
-        "MessageType_TonSignMessage": 11903,
-        "MessageType_TonSignedMessage": 11904,
-        "MessageType_TonSignProof": 11905,
-        "MessageType_TonSignedProof": 11906,
-        "MessageType_TonTxAck": 11907,
-        "MessageType_AlephiumGetAddress": 12101,
-        "MessageType_AlephiumAddress": 12102,
-        "MessageType_AlephiumSignTx": 12103,
-        "MessageType_AlephiumSignedTx": 12104,
-        "MessageType_AlephiumTxRequest": 12105,
-        "MessageType_AlephiumTxAck": 12106,
-        "MessageType_AlephiumBytecodeRequest": 12107,
-        "MessageType_AlephiumBytecodeAck": 12108,
-        "MessageType_AlephiumSignMessage": 12109,
-        "MessageType_AlephiumMessageSignature": 12110,
-        "MessageType_BenfenGetAddress": 12201,
-        "MessageType_BenfenAddress": 12202,
-        "MessageType_BenfenSignTx": 12203,
-        "MessageType_BenfenSignedTx": 12204,
-        "MessageType_BenfenSignMessage": 12205,
-        "MessageType_BenfenMessageSignature": 12206,
-        "MessageType_BenfenTxRequest": 12207,
-        "MessageType_BenfenTxAck": 12208,
-        "MessageType_NeoGetAddress": 12301,
-        "MessageType_NeoAddress": 12302,
-        "MessageType_NeoSignTx": 12303,
-        "MessageType_NeoSignedTx": 12304,
-        "MessageType_DeviceFactoryInfoSet": 60000,
-        "MessageType_DeviceFactoryInfoGet": 60001,
-        "MessageType_DeviceFactoryInfo": 60002,
-        "MessageType_DeviceFactoryPermanentLock": 60003,
-        "MessageType_DeviceFactoryTest": 60004,
-        "MessageType_ProtocolInfoRequest": 60200,
-        "MessageType_ProtocolInfo": 60201,
-        "MessageType_Ping": 60206,
-        "MessageType_Success": 60207,
-        "MessageType_Failure": 60208,
-        "MessageType_DeviceReboot": 60400,
-        "MessageType_DeviceSettings": 60410,
-        "MessageType_DeviceSettingsGet": 60411,
-        "MessageType_DeviceSettingsSet": 60412,
-        "MessageType_DeviceSettingsPageShow": 60413,
-        "MessageType_DeviceCertificate": 60420,
-        "MessageType_DeviceCertificateWrite": 60421,
-        "MessageType_DeviceCertificateRead": 60422,
-        "MessageType_DeviceCertificateSignature": 60423,
-        "MessageType_DeviceCertificateSign": 60424,
-        "MessageType_DeviceMiscUsbMscControl": 60440,
-        "MessageType_DeviceFindMyTokenState": 60450,
-        "MessageType_DeviceFindMyTokenUpdate": 60451,
-        "MessageType_DeviceFindMyTokenStateGet": 60452,
-        "MessageType_DeviceInfoGet": 60600,
-        "MessageType_DeviceInfo": 60601,
-        "MessageType_DeviceStatusGet": 60602,
-        "MessageType_DeviceStatus": 60603,
-        "MessageType_FilesystemPermissionFix": 60800,
-        "MessageType_FilesystemPathInfo": 60801,
-        "MessageType_FilesystemPathInfoQuery": 60802,
-        "MessageType_FilesystemFile": 60803,
-        "MessageType_FilesystemFileRead": 60804,
-        "MessageType_FilesystemFileWrite": 60805,
-        "MessageType_FilesystemFileDelete": 60806,
-        "MessageType_FilesystemDir": 60807,
-        "MessageType_FilesystemDirList": 60808,
-        "MessageType_FilesystemDirMake": 60809,
-        "MessageType_FilesystemDirRemove": 60810,
-        "MessageType_FilesystemFormat": 60811,
-        "MessageType_DeviceFirmwareUpdateStage": 61000,
-        "MessageType_DeviceFirmwareUpdateRequest": 61001,
-        "MessageType_DeviceFirmwareUpdateStatusGet": 61002,
-        "MessageType_DeviceFirmwareUpdateStatus": 61003,
-        "MessageType_DeviceSessionGet": 61200,
-        "MessageType_DeviceSession": 61201,
-        "MessageType_DeviceSessionAskPin": 61202,
-        "MessageType_DeviceSessionAskPassphrase": 61203,
-        "MessageType_PortfolioUpdate": 61400,
-        "MessageType_NftUpdate": 61500,
-        "MessageType_OnboardingStatusGet": 61600,
-        "MessageType_OnboardingStatus": 61601
-      },
-      "reserved": [
-        [90, 92],
-        [114, 122],
-        [300, 304],
-        [309, 312]
-      ]
-    },
     "AlephiumGetAddress": {
       "fields": {
         "address_n": {
@@ -4653,349 +4168,6 @@
         }
       }
     },
-    "EthereumGetPublicKey": {
-      "fields": {
-        "address_n": {
-          "rule": "repeated",
-          "type": "uint32",
-          "id": 1,
-          "options": {
-            "packed": false
-          }
-        },
-        "show_display": {
-          "type": "bool",
-          "id": 2
-        }
-      }
-    },
-    "EthereumPublicKey": {
-      "fields": {
-        "node": {
-          "rule": "required",
-          "type": "HDNodeType",
-          "id": 1
-        },
-        "xpub": {
-          "rule": "required",
-          "type": "string",
-          "id": 2
-        }
-      }
-    },
-    "EthereumGetAddress": {
-      "fields": {
-        "address_n": {
-          "rule": "repeated",
-          "type": "uint32",
-          "id": 1,
-          "options": {
-            "packed": false
-          }
-        },
-        "show_display": {
-          "type": "bool",
-          "id": 2
-        },
-        "encoded_network": {
-          "type": "bytes",
-          "id": 3
-        }
-      }
-    },
-    "EthereumAddress": {
-      "fields": {
-        "_old_address": {
-          "type": "bytes",
-          "id": 1,
-          "options": {
-            "deprecated": true
-          }
-        },
-        "address": {
-          "type": "string",
-          "id": 2
-        }
-      }
-    },
-    "EthereumSignTx": {
-      "fields": {
-        "address_n": {
-          "rule": "repeated",
-          "type": "uint32",
-          "id": 1,
-          "options": {
-            "packed": false
-          }
-        },
-        "nonce": {
-          "type": "bytes",
-          "id": 2,
-          "options": {
-            "default": ""
-          }
-        },
-        "gas_price": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 3
-        },
-        "gas_limit": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 4
-        },
-        "to": {
-          "type": "string",
-          "id": 11,
-          "options": {
-            "default": ""
-          }
-        },
-        "value": {
-          "type": "bytes",
-          "id": 6,
-          "options": {
-            "default": ""
-          }
-        },
-        "data_initial_chunk": {
-          "type": "bytes",
-          "id": 7,
-          "options": {
-            "default": ""
-          }
-        },
-        "data_length": {
-          "type": "uint32",
-          "id": 8,
-          "options": {
-            "default": 0
-          }
-        },
-        "chain_id": {
-          "rule": "required",
-          "type": "uint64",
-          "id": 9
-        },
-        "tx_type": {
-          "type": "uint32",
-          "id": 10
-        },
-        "definitions": {
-          "type": "EthereumDefinitions",
-          "id": 12
-        }
-      }
-    },
-    "EthereumSignTxEIP1559": {
-      "fields": {
-        "address_n": {
-          "rule": "repeated",
-          "type": "uint32",
-          "id": 1,
-          "options": {
-            "packed": false
-          }
-        },
-        "nonce": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 2
-        },
-        "max_gas_fee": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 3
-        },
-        "max_priority_fee": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 4
-        },
-        "gas_limit": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 5
-        },
-        "to": {
-          "type": "string",
-          "id": 6,
-          "options": {
-            "default": ""
-          }
-        },
-        "value": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 7
-        },
-        "data_initial_chunk": {
-          "type": "bytes",
-          "id": 8,
-          "options": {
-            "default": ""
-          }
-        },
-        "data_length": {
-          "rule": "required",
-          "type": "uint32",
-          "id": 9
-        },
-        "chain_id": {
-          "rule": "required",
-          "type": "uint64",
-          "id": 10
-        },
-        "access_list": {
-          "rule": "repeated",
-          "type": "EthereumAccessList",
-          "id": 11
-        },
-        "definitions": {
-          "type": "EthereumDefinitions",
-          "id": 12
-        }
-      },
-      "nested": {
-        "EthereumAccessList": {
-          "fields": {
-            "address": {
-              "rule": "required",
-              "type": "string",
-              "id": 1
-            },
-            "storage_keys": {
-              "rule": "repeated",
-              "type": "bytes",
-              "id": 2
-            }
-          }
-        }
-      }
-    },
-    "EthereumTxRequest": {
-      "fields": {
-        "data_length": {
-          "type": "uint32",
-          "id": 1
-        },
-        "signature_v": {
-          "type": "uint32",
-          "id": 2
-        },
-        "signature_r": {
-          "type": "bytes",
-          "id": 3
-        },
-        "signature_s": {
-          "type": "bytes",
-          "id": 4
-        }
-      }
-    },
-    "EthereumTxAck": {
-      "fields": {
-        "data_chunk": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 1
-        }
-      }
-    },
-    "EthereumSignMessage": {
-      "fields": {
-        "address_n": {
-          "rule": "repeated",
-          "type": "uint32",
-          "id": 1,
-          "options": {
-            "packed": false
-          }
-        },
-        "message": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 2
-        },
-        "encoded_network": {
-          "type": "bytes",
-          "id": 3
-        }
-      }
-    },
-    "EthereumMessageSignature": {
-      "fields": {
-        "signature": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 2
-        },
-        "address": {
-          "rule": "required",
-          "type": "string",
-          "id": 3
-        }
-      }
-    },
-    "EthereumVerifyMessage": {
-      "fields": {
-        "signature": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 2
-        },
-        "message": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 3
-        },
-        "address": {
-          "rule": "required",
-          "type": "string",
-          "id": 4
-        }
-      }
-    },
-    "EthereumSignTypedHash": {
-      "fields": {
-        "address_n": {
-          "rule": "repeated",
-          "type": "uint32",
-          "id": 1,
-          "options": {
-            "packed": false
-          }
-        },
-        "domain_separator_hash": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 2
-        },
-        "message_hash": {
-          "type": "bytes",
-          "id": 3
-        },
-        "encoded_network": {
-          "type": "bytes",
-          "id": 4
-        }
-      }
-    },
-    "EthereumTypedDataSignature": {
-      "fields": {
-        "signature": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 1
-        },
-        "address": {
-          "rule": "required",
-          "type": "string",
-          "id": 2
-        }
-      }
-    },
     "EthereumDefinitionType": {
       "values": {
         "NETWORK": 0,
@@ -5072,122 +4244,6 @@
         "encoded_token": {
           "type": "bytes",
           "id": 2
-        }
-      }
-    },
-    "EthereumSignTypedData": {
-      "fields": {
-        "address_n": {
-          "rule": "repeated",
-          "type": "uint32",
-          "id": 1,
-          "options": {
-            "packed": false
-          }
-        },
-        "primary_type": {
-          "rule": "required",
-          "type": "string",
-          "id": 2
-        },
-        "metamask_v4_compat": {
-          "type": "bool",
-          "id": 3,
-          "options": {
-            "default": true
-          }
-        },
-        "definitions": {
-          "type": "EthereumDefinitions",
-          "id": 4
-        }
-      }
-    },
-    "EthereumTypedDataStructRequest": {
-      "fields": {
-        "name": {
-          "rule": "required",
-          "type": "string",
-          "id": 1
-        }
-      }
-    },
-    "EthereumTypedDataStructAck": {
-      "fields": {
-        "members": {
-          "rule": "repeated",
-          "type": "EthereumStructMember",
-          "id": 1
-        }
-      },
-      "nested": {
-        "EthereumStructMember": {
-          "fields": {
-            "type": {
-              "rule": "required",
-              "type": "EthereumFieldType",
-              "id": 1
-            },
-            "name": {
-              "rule": "required",
-              "type": "string",
-              "id": 2
-            }
-          }
-        },
-        "EthereumFieldType": {
-          "fields": {
-            "data_type": {
-              "rule": "required",
-              "type": "EthereumDataType",
-              "id": 1
-            },
-            "size": {
-              "type": "uint32",
-              "id": 2
-            },
-            "entry_type": {
-              "type": "EthereumFieldType",
-              "id": 3
-            },
-            "struct_name": {
-              "type": "string",
-              "id": 4
-            }
-          }
-        },
-        "EthereumDataType": {
-          "values": {
-            "UINT": 1,
-            "INT": 2,
-            "BYTES": 3,
-            "STRING": 4,
-            "BOOL": 5,
-            "ADDRESS": 6,
-            "ARRAY": 7,
-            "STRUCT": 8
-          }
-        }
-      }
-    },
-    "EthereumTypedDataValueRequest": {
-      "fields": {
-        "member_path": {
-          "rule": "repeated",
-          "type": "uint32",
-          "id": 1,
-          "options": {
-            "packed": false
-          }
-        }
-      }
-    },
-    "EthereumTypedDataValueAck": {
-      "fields": {
-        "value": {
-          "rule": "required",
-          "type": "bytes",
-          "id": 1
         }
       }
     },
@@ -5411,6 +4467,122 @@
         "source_fingerprint": {
           "type": "uint32",
           "id": 6
+        }
+      }
+    },
+    "EthereumSignTypedData": {
+      "fields": {
+        "address_n": {
+          "rule": "repeated",
+          "type": "uint32",
+          "id": 1,
+          "options": {
+            "packed": false
+          }
+        },
+        "primary_type": {
+          "rule": "required",
+          "type": "string",
+          "id": 2
+        },
+        "metamask_v4_compat": {
+          "type": "bool",
+          "id": 3,
+          "options": {
+            "default": true
+          }
+        },
+        "definitions": {
+          "type": "EthereumDefinitions",
+          "id": 4
+        }
+      }
+    },
+    "EthereumTypedDataStructRequest": {
+      "fields": {
+        "name": {
+          "rule": "required",
+          "type": "string",
+          "id": 1
+        }
+      }
+    },
+    "EthereumTypedDataStructAck": {
+      "fields": {
+        "members": {
+          "rule": "repeated",
+          "type": "EthereumStructMember",
+          "id": 1
+        }
+      },
+      "nested": {
+        "EthereumStructMember": {
+          "fields": {
+            "type": {
+              "rule": "required",
+              "type": "EthereumFieldType",
+              "id": 1
+            },
+            "name": {
+              "rule": "required",
+              "type": "string",
+              "id": 2
+            }
+          }
+        },
+        "EthereumFieldType": {
+          "fields": {
+            "data_type": {
+              "rule": "required",
+              "type": "EthereumDataType",
+              "id": 1
+            },
+            "size": {
+              "type": "uint32",
+              "id": 2
+            },
+            "entry_type": {
+              "type": "EthereumFieldType",
+              "id": 3
+            },
+            "struct_name": {
+              "type": "string",
+              "id": 4
+            }
+          }
+        },
+        "EthereumDataType": {
+          "values": {
+            "UINT": 1,
+            "INT": 2,
+            "BYTES": 3,
+            "STRING": 4,
+            "BOOL": 5,
+            "ADDRESS": 6,
+            "ARRAY": 7,
+            "STRUCT": 8
+          }
+        }
+      }
+    },
+    "EthereumTypedDataValueRequest": {
+      "fields": {
+        "member_path": {
+          "rule": "repeated",
+          "type": "uint32",
+          "id": 1,
+          "options": {
+            "packed": false
+          }
+        }
+      }
+    },
+    "EthereumTypedDataValueAck": {
+      "fields": {
+        "value": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 1
         }
       }
     },
@@ -5888,6 +5060,349 @@
       }
     },
     "EthereumTypedDataSignatureOneKey": {
+      "fields": {
+        "signature": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 1
+        },
+        "address": {
+          "rule": "required",
+          "type": "string",
+          "id": 2
+        }
+      }
+    },
+    "EthereumGetPublicKey": {
+      "fields": {
+        "address_n": {
+          "rule": "repeated",
+          "type": "uint32",
+          "id": 1,
+          "options": {
+            "packed": false
+          }
+        },
+        "show_display": {
+          "type": "bool",
+          "id": 2
+        }
+      }
+    },
+    "EthereumPublicKey": {
+      "fields": {
+        "node": {
+          "rule": "required",
+          "type": "HDNodeType",
+          "id": 1
+        },
+        "xpub": {
+          "rule": "required",
+          "type": "string",
+          "id": 2
+        }
+      }
+    },
+    "EthereumGetAddress": {
+      "fields": {
+        "address_n": {
+          "rule": "repeated",
+          "type": "uint32",
+          "id": 1,
+          "options": {
+            "packed": false
+          }
+        },
+        "show_display": {
+          "type": "bool",
+          "id": 2
+        },
+        "encoded_network": {
+          "type": "bytes",
+          "id": 3
+        }
+      }
+    },
+    "EthereumAddress": {
+      "fields": {
+        "_old_address": {
+          "type": "bytes",
+          "id": 1,
+          "options": {
+            "deprecated": true
+          }
+        },
+        "address": {
+          "type": "string",
+          "id": 2
+        }
+      }
+    },
+    "EthereumSignTx": {
+      "fields": {
+        "address_n": {
+          "rule": "repeated",
+          "type": "uint32",
+          "id": 1,
+          "options": {
+            "packed": false
+          }
+        },
+        "nonce": {
+          "type": "bytes",
+          "id": 2,
+          "options": {
+            "default": ""
+          }
+        },
+        "gas_price": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 3
+        },
+        "gas_limit": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 4
+        },
+        "to": {
+          "type": "string",
+          "id": 11,
+          "options": {
+            "default": ""
+          }
+        },
+        "value": {
+          "type": "bytes",
+          "id": 6,
+          "options": {
+            "default": ""
+          }
+        },
+        "data_initial_chunk": {
+          "type": "bytes",
+          "id": 7,
+          "options": {
+            "default": ""
+          }
+        },
+        "data_length": {
+          "type": "uint32",
+          "id": 8,
+          "options": {
+            "default": 0
+          }
+        },
+        "chain_id": {
+          "rule": "required",
+          "type": "uint64",
+          "id": 9
+        },
+        "tx_type": {
+          "type": "uint32",
+          "id": 10
+        },
+        "definitions": {
+          "type": "EthereumDefinitions",
+          "id": 12
+        }
+      }
+    },
+    "EthereumSignTxEIP1559": {
+      "fields": {
+        "address_n": {
+          "rule": "repeated",
+          "type": "uint32",
+          "id": 1,
+          "options": {
+            "packed": false
+          }
+        },
+        "nonce": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 2
+        },
+        "max_gas_fee": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 3
+        },
+        "max_priority_fee": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 4
+        },
+        "gas_limit": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 5
+        },
+        "to": {
+          "type": "string",
+          "id": 6,
+          "options": {
+            "default": ""
+          }
+        },
+        "value": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 7
+        },
+        "data_initial_chunk": {
+          "type": "bytes",
+          "id": 8,
+          "options": {
+            "default": ""
+          }
+        },
+        "data_length": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 9
+        },
+        "chain_id": {
+          "rule": "required",
+          "type": "uint64",
+          "id": 10
+        },
+        "access_list": {
+          "rule": "repeated",
+          "type": "EthereumAccessList",
+          "id": 11
+        },
+        "definitions": {
+          "type": "EthereumDefinitions",
+          "id": 12
+        }
+      },
+      "nested": {
+        "EthereumAccessList": {
+          "fields": {
+            "address": {
+              "rule": "required",
+              "type": "string",
+              "id": 1
+            },
+            "storage_keys": {
+              "rule": "repeated",
+              "type": "bytes",
+              "id": 2
+            }
+          }
+        }
+      }
+    },
+    "EthereumTxRequest": {
+      "fields": {
+        "data_length": {
+          "type": "uint32",
+          "id": 1
+        },
+        "signature_v": {
+          "type": "uint32",
+          "id": 2
+        },
+        "signature_r": {
+          "type": "bytes",
+          "id": 3
+        },
+        "signature_s": {
+          "type": "bytes",
+          "id": 4
+        }
+      }
+    },
+    "EthereumTxAck": {
+      "fields": {
+        "data_chunk": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 1
+        }
+      }
+    },
+    "EthereumSignMessage": {
+      "fields": {
+        "address_n": {
+          "rule": "repeated",
+          "type": "uint32",
+          "id": 1,
+          "options": {
+            "packed": false
+          }
+        },
+        "message": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 2
+        },
+        "encoded_network": {
+          "type": "bytes",
+          "id": 3
+        }
+      }
+    },
+    "EthereumMessageSignature": {
+      "fields": {
+        "signature": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 2
+        },
+        "address": {
+          "rule": "required",
+          "type": "string",
+          "id": 3
+        }
+      }
+    },
+    "EthereumVerifyMessage": {
+      "fields": {
+        "signature": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 2
+        },
+        "message": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 3
+        },
+        "address": {
+          "rule": "required",
+          "type": "string",
+          "id": 4
+        }
+      }
+    },
+    "EthereumSignTypedHash": {
+      "fields": {
+        "address_n": {
+          "rule": "repeated",
+          "type": "uint32",
+          "id": 1,
+          "options": {
+            "packed": false
+          }
+        },
+        "domain_separator_hash": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 2
+        },
+        "message_hash": {
+          "type": "bytes",
+          "id": 3
+        },
+        "encoded_network": {
+          "type": "bytes",
+          "id": 4
+        }
+      }
+    },
+    "EthereumTypedDataSignature": {
       "fields": {
         "signature": {
           "rule": "required",
@@ -11537,6 +11052,491 @@
         }
       }
     },
+    "wire_in": {
+      "type": "bool",
+      "id": 50002,
+      "extend": "google.protobuf.EnumValueOptions"
+    },
+    "wire_out": {
+      "type": "bool",
+      "id": 50003,
+      "extend": "google.protobuf.EnumValueOptions"
+    },
+    "wire_debug_in": {
+      "type": "bool",
+      "id": 50004,
+      "extend": "google.protobuf.EnumValueOptions"
+    },
+    "wire_debug_out": {
+      "type": "bool",
+      "id": 50005,
+      "extend": "google.protobuf.EnumValueOptions"
+    },
+    "wire_tiny": {
+      "type": "bool",
+      "id": 50006,
+      "extend": "google.protobuf.EnumValueOptions"
+    },
+    "wire_bootloader": {
+      "type": "bool",
+      "id": 50007,
+      "extend": "google.protobuf.EnumValueOptions"
+    },
+    "wire_no_fsm": {
+      "type": "bool",
+      "id": 50008,
+      "extend": "google.protobuf.EnumValueOptions"
+    },
+    "bitcoin_only": {
+      "type": "bool",
+      "id": 60000,
+      "extend": "google.protobuf.EnumValueOptions"
+    },
+    "has_bitcoin_only_values": {
+      "type": "bool",
+      "id": 51001,
+      "extend": "google.protobuf.EnumOptions"
+    },
+    "experimental_message": {
+      "type": "bool",
+      "id": 52001,
+      "extend": "google.protobuf.MessageOptions"
+    },
+    "wire_type": {
+      "type": "uint32",
+      "id": 52002,
+      "extend": "google.protobuf.MessageOptions"
+    },
+    "experimental_field": {
+      "type": "bool",
+      "id": 53001,
+      "extend": "google.protobuf.FieldOptions"
+    },
+    "include_in_bitcoin_only": {
+      "type": "bool",
+      "id": 60000,
+      "extend": "google.protobuf.FileOptions"
+    },
+    "MessageType": {
+      "options": {
+        "(has_bitcoin_only_values)": true
+      },
+      "values": {
+        "MessageType_Initialize": 0,
+        "MessageType_ChangePin": 4,
+        "MessageType_WipeDevice": 5,
+        "MessageType_GetEntropy": 9,
+        "MessageType_Entropy": 10,
+        "MessageType_LoadDevice": 13,
+        "MessageType_ResetDevice": 14,
+        "MessageType_SetBusy": 16,
+        "MessageType_Features": 17,
+        "MessageType_Cancel": 20,
+        "MessageType_LockDevice": 24,
+        "MessageType_ApplySettings": 25,
+        "MessageType_ButtonRequest": 26,
+        "MessageType_ButtonAck": 27,
+        "MessageType_ApplyFlags": 28,
+        "MessageType_GetNonce": 31,
+        "MessageType_Nonce": 33,
+        "MessageType_BackupDevice": 34,
+        "MessageType_EntropyRequest": 35,
+        "MessageType_EntropyAck": 36,
+        "MessageType_PassphraseRequest": 41,
+        "MessageType_PassphraseAck": 42,
+        "MessageType_RecoveryDevice": 45,
+        "MessageType_WordRequest": 46,
+        "MessageType_WordAck": 47,
+        "MessageType_GetFeatures": 55,
+        "MessageType_SdProtect": 79,
+        "MessageType_ChangeWipeCode": 82,
+        "MessageType_DoPreauthorized": 84,
+        "MessageType_PreauthorizedRequest": 85,
+        "MessageType_CancelAuthorization": 86,
+        "MessageType_GetFirmwareHash": 88,
+        "MessageType_FirmwareHash": 89,
+        "MessageType_UnlockPath": 93,
+        "MessageType_UnlockedPathRequest": 94,
+        "MessageType_SetU2FCounter": 63,
+        "MessageType_GetNextU2FCounter": 80,
+        "MessageType_NextU2FCounter": 81,
+        "MessageType_Deprecated_PassphraseStateRequest": 77,
+        "MessageType_Deprecated_PassphraseStateAck": 78,
+        "MessageType_GetPublicKey": 11,
+        "MessageType_PublicKey": 12,
+        "MessageType_SignTx": 15,
+        "MessageType_TxRequest": 21,
+        "MessageType_TxAck": 22,
+        "MessageType_GetAddress": 29,
+        "MessageType_Address": 30,
+        "MessageType_TxAckPaymentRequest": 37,
+        "MessageType_SignMessage": 38,
+        "MessageType_VerifyMessage": 39,
+        "MessageType_MessageSignature": 40,
+        "MessageType_GetOwnershipId": 43,
+        "MessageType_OwnershipId": 44,
+        "MessageType_GetOwnershipProof": 49,
+        "MessageType_OwnershipProof": 50,
+        "MessageType_AuthorizeCoinJoin": 51,
+        "MessageType_SignPsbt": 10052,
+        "MessageType_SignedPsbt": 10053,
+        "MessageType_CipherKeyValue": 23,
+        "MessageType_CipheredKeyValue": 48,
+        "MessageType_SignIdentity": 53,
+        "MessageType_SignedIdentity": 54,
+        "MessageType_GetECDHSessionKey": 61,
+        "MessageType_ECDHSessionKey": 62,
+        "MessageType_CosiCommit": 71,
+        "MessageType_CosiCommitment": 72,
+        "MessageType_CosiSign": 73,
+        "MessageType_CosiSignature": 74,
+        "MessageType_BatchGetPublickeys": 10016,
+        "MessageType_EcdsaPublicKeys": 10017,
+        "MessageType_EthereumGetPublicKey": 450,
+        "MessageType_EthereumPublicKey": 451,
+        "MessageType_EthereumGetAddress": 56,
+        "MessageType_EthereumAddress": 57,
+        "MessageType_EthereumSignTx": 58,
+        "MessageType_EthereumSignTxEIP1559": 452,
+        "MessageType_EthereumTxRequest": 59,
+        "MessageType_EthereumTxAck": 60,
+        "MessageType_EthereumSignMessage": 64,
+        "MessageType_EthereumVerifyMessage": 65,
+        "MessageType_EthereumMessageSignature": 66,
+        "MessageType_EthereumSignTypedData": 464,
+        "MessageType_EthereumTypedDataStructRequest": 465,
+        "MessageType_EthereumTypedDataStructAck": 466,
+        "MessageType_EthereumTypedDataValueRequest": 467,
+        "MessageType_EthereumTypedDataValueAck": 468,
+        "MessageType_EthereumTypedDataSignature": 469,
+        "MessageType_EthereumSignTypedHash": 470,
+        "MessageType_EthereumGetPublicKeyOneKey": 20100,
+        "MessageType_EthereumPublicKeyOneKey": 20101,
+        "MessageType_EthereumGetAddressOneKey": 20102,
+        "MessageType_EthereumAddressOneKey": 20103,
+        "MessageType_EthereumSignTxOneKey": 20104,
+        "MessageType_EthereumSignTxEIP1559OneKey": 20105,
+        "MessageType_EthereumTxRequestOneKey": 20106,
+        "MessageType_EthereumTxAckOneKey": 20107,
+        "MessageType_EthereumSignMessageOneKey": 20108,
+        "MessageType_EthereumVerifyMessageOneKey": 20109,
+        "MessageType_EthereumMessageSignatureOneKey": 20110,
+        "MessageType_EthereumSignTypedDataOneKey": 20111,
+        "MessageType_EthereumTypedDataStructRequestOneKey": 20112,
+        "MessageType_EthereumTypedDataStructAckOneKey": 20113,
+        "MessageType_EthereumTypedDataValueRequestOneKey": 20114,
+        "MessageType_EthereumTypedDataValueAckOneKey": 20115,
+        "MessageType_EthereumTypedDataSignatureOneKey": 20116,
+        "MessageType_EthereumSignTypedHashOneKey": 20117,
+        "MessageType_EthereumGnosisSafeTxAck": 20118,
+        "MessageType_EthereumGnosisSafeTxRequest": 20119,
+        "MessageType_EthereumSignTxEIP7702OneKey": 20120,
+        "MessageType_EthereumSignTypedDataQR": 20121,
+        "MessageType_NEMGetAddress": 67,
+        "MessageType_NEMAddress": 68,
+        "MessageType_NEMSignTx": 69,
+        "MessageType_NEMSignedTx": 70,
+        "MessageType_NEMDecryptMessage": 75,
+        "MessageType_NEMDecryptedMessage": 76,
+        "MessageType_TezosGetAddress": 150,
+        "MessageType_TezosAddress": 151,
+        "MessageType_TezosSignTx": 152,
+        "MessageType_TezosSignedTx": 153,
+        "MessageType_TezosGetPublicKey": 154,
+        "MessageType_TezosPublicKey": 155,
+        "MessageType_StellarSignTx": 202,
+        "MessageType_StellarTxOpRequest": 203,
+        "MessageType_StellarGetAddress": 207,
+        "MessageType_StellarAddress": 208,
+        "MessageType_StellarCreateAccountOp": 210,
+        "MessageType_StellarPaymentOp": 211,
+        "MessageType_StellarPathPaymentStrictReceiveOp": 212,
+        "MessageType_StellarManageSellOfferOp": 213,
+        "MessageType_StellarCreatePassiveSellOfferOp": 214,
+        "MessageType_StellarSetOptionsOp": 215,
+        "MessageType_StellarChangeTrustOp": 216,
+        "MessageType_StellarAllowTrustOp": 217,
+        "MessageType_StellarAccountMergeOp": 218,
+        "MessageType_StellarManageDataOp": 220,
+        "MessageType_StellarBumpSequenceOp": 221,
+        "MessageType_StellarManageBuyOfferOp": 222,
+        "MessageType_StellarPathPaymentStrictSendOp": 223,
+        "MessageType_StellarSignedTx": 230,
+        "MessageType_CardanoGetPublicKey": 305,
+        "MessageType_CardanoPublicKey": 306,
+        "MessageType_CardanoGetAddress": 307,
+        "MessageType_CardanoAddress": 308,
+        "MessageType_CardanoTxItemAck": 313,
+        "MessageType_CardanoTxAuxiliaryDataSupplement": 314,
+        "MessageType_CardanoTxWitnessRequest": 315,
+        "MessageType_CardanoTxWitnessResponse": 316,
+        "MessageType_CardanoTxHostAck": 317,
+        "MessageType_CardanoTxBodyHash": 318,
+        "MessageType_CardanoSignTxFinished": 319,
+        "MessageType_CardanoSignTxInit": 320,
+        "MessageType_CardanoTxInput": 321,
+        "MessageType_CardanoTxOutput": 322,
+        "MessageType_CardanoAssetGroup": 323,
+        "MessageType_CardanoToken": 324,
+        "MessageType_CardanoTxCertificate": 325,
+        "MessageType_CardanoTxWithdrawal": 326,
+        "MessageType_CardanoTxAuxiliaryData": 327,
+        "MessageType_CardanoPoolOwner": 328,
+        "MessageType_CardanoPoolRelayParameters": 329,
+        "MessageType_CardanoGetNativeScriptHash": 330,
+        "MessageType_CardanoNativeScriptHash": 331,
+        "MessageType_CardanoTxMint": 332,
+        "MessageType_CardanoTxCollateralInput": 333,
+        "MessageType_CardanoTxRequiredSigner": 334,
+        "MessageType_CardanoTxInlineDatumChunk": 335,
+        "MessageType_CardanoTxReferenceScriptChunk": 336,
+        "MessageType_CardanoTxReferenceInput": 337,
+        "MessageType_CardanoSignMessage": 350,
+        "MessageType_CardanoMessageSignature": 351,
+        "MessageType_RippleGetAddress": 400,
+        "MessageType_RippleAddress": 401,
+        "MessageType_RippleSignTx": 402,
+        "MessageType_RippleSignedTx": 403,
+        "MessageType_MoneroTransactionInitRequest": 501,
+        "MessageType_MoneroTransactionInitAck": 502,
+        "MessageType_MoneroTransactionSetInputRequest": 503,
+        "MessageType_MoneroTransactionSetInputAck": 504,
+        "MessageType_MoneroTransactionInputViniRequest": 507,
+        "MessageType_MoneroTransactionInputViniAck": 508,
+        "MessageType_MoneroTransactionAllInputsSetRequest": 509,
+        "MessageType_MoneroTransactionAllInputsSetAck": 510,
+        "MessageType_MoneroTransactionSetOutputRequest": 511,
+        "MessageType_MoneroTransactionSetOutputAck": 512,
+        "MessageType_MoneroTransactionAllOutSetRequest": 513,
+        "MessageType_MoneroTransactionAllOutSetAck": 514,
+        "MessageType_MoneroTransactionSignInputRequest": 515,
+        "MessageType_MoneroTransactionSignInputAck": 516,
+        "MessageType_MoneroTransactionFinalRequest": 517,
+        "MessageType_MoneroTransactionFinalAck": 518,
+        "MessageType_MoneroKeyImageExportInitRequest": 530,
+        "MessageType_MoneroKeyImageExportInitAck": 531,
+        "MessageType_MoneroKeyImageSyncStepRequest": 532,
+        "MessageType_MoneroKeyImageSyncStepAck": 533,
+        "MessageType_MoneroKeyImageSyncFinalRequest": 534,
+        "MessageType_MoneroKeyImageSyncFinalAck": 535,
+        "MessageType_MoneroGetAddress": 540,
+        "MessageType_MoneroAddress": 541,
+        "MessageType_MoneroGetWatchKey": 542,
+        "MessageType_MoneroWatchKey": 543,
+        "MessageType_DebugMoneroDiagRequest": 546,
+        "MessageType_DebugMoneroDiagAck": 547,
+        "MessageType_MoneroGetTxKeyRequest": 550,
+        "MessageType_MoneroGetTxKeyAck": 551,
+        "MessageType_MoneroLiveRefreshStartRequest": 552,
+        "MessageType_MoneroLiveRefreshStartAck": 553,
+        "MessageType_MoneroLiveRefreshStepRequest": 554,
+        "MessageType_MoneroLiveRefreshStepAck": 555,
+        "MessageType_MoneroLiveRefreshFinalRequest": 556,
+        "MessageType_MoneroLiveRefreshFinalAck": 557,
+        "MessageType_EosGetPublicKey": 600,
+        "MessageType_EosPublicKey": 601,
+        "MessageType_EosSignTx": 602,
+        "MessageType_EosTxActionRequest": 603,
+        "MessageType_EosTxActionAck": 604,
+        "MessageType_EosSignedTx": 605,
+        "MessageType_BinanceGetAddress": 700,
+        "MessageType_BinanceAddress": 701,
+        "MessageType_BinanceGetPublicKey": 702,
+        "MessageType_BinancePublicKey": 703,
+        "MessageType_BinanceSignTx": 704,
+        "MessageType_BinanceTxRequest": 705,
+        "MessageType_BinanceTransferMsg": 706,
+        "MessageType_BinanceOrderMsg": 707,
+        "MessageType_BinanceCancelMsg": 708,
+        "MessageType_BinanceSignedTx": 709,
+        "MessageType_StarcoinGetAddress": 10300,
+        "MessageType_StarcoinAddress": 10301,
+        "MessageType_StarcoinGetPublicKey": 10302,
+        "MessageType_StarcoinPublicKey": 10303,
+        "MessageType_StarcoinSignTx": 10304,
+        "MessageType_StarcoinSignedTx": 10305,
+        "MessageType_StarcoinSignMessage": 10306,
+        "MessageType_StarcoinMessageSignature": 10307,
+        "MessageType_StarcoinVerifyMessage": 10308,
+        "MessageType_ConfluxGetAddress": 10112,
+        "MessageType_ConfluxAddress": 10113,
+        "MessageType_ConfluxSignTx": 10114,
+        "MessageType_ConfluxTxRequest": 10115,
+        "MessageType_ConfluxTxAck": 10116,
+        "MessageType_ConfluxSignMessage": 10117,
+        "MessageType_ConfluxSignMessageCIP23": 10118,
+        "MessageType_ConfluxMessageSignature": 10119,
+        "MessageType_TronGetAddress": 10501,
+        "MessageType_TronAddress": 10502,
+        "MessageType_TronSignTx": 10503,
+        "MessageType_TronSignedTx": 10504,
+        "MessageType_TronSignMessage": 10505,
+        "MessageType_TronMessageSignature": 10506,
+        "MessageType_NearGetAddress": 10701,
+        "MessageType_NearAddress": 10702,
+        "MessageType_NearSignTx": 10703,
+        "MessageType_NearSignedTx": 10704,
+        "MessageType_AptosGetAddress": 10600,
+        "MessageType_AptosAddress": 10601,
+        "MessageType_AptosSignTx": 10602,
+        "MessageType_AptosSignedTx": 10603,
+        "MessageType_AptosSignMessage": 10604,
+        "MessageType_AptosMessageSignature": 10605,
+        "MessageType_AptosSignSIWAMessage": 10606,
+        "MessageType_WebAuthnListResidentCredentials": 800,
+        "MessageType_WebAuthnCredentials": 801,
+        "MessageType_WebAuthnAddResidentCredential": 802,
+        "MessageType_WebAuthnRemoveResidentCredential": 803,
+        "MessageType_SolanaGetAddress": 10100,
+        "MessageType_SolanaAddress": 10101,
+        "MessageType_SolanaSignTx": 10102,
+        "MessageType_SolanaSignedTx": 10103,
+        "MessageType_SolanaSignOffChainMessage": 10104,
+        "MessageType_SolanaMessageSignature": 10105,
+        "MessageType_SolanaSignUnsafeMessage": 10106,
+        "MessageType_CosmosGetAddress": 10800,
+        "MessageType_CosmosAddress": 10801,
+        "MessageType_CosmosSignTx": 10802,
+        "MessageType_CosmosSignedTx": 10803,
+        "MessageType_AlgorandGetAddress": 10900,
+        "MessageType_AlgorandAddress": 10901,
+        "MessageType_AlgorandSignTx": 10902,
+        "MessageType_AlgorandSignedTx": 10903,
+        "MessageType_PolkadotGetAddress": 11000,
+        "MessageType_PolkadotAddress": 11001,
+        "MessageType_PolkadotSignTx": 11002,
+        "MessageType_PolkadotSignedTx": 11003,
+        "MessageType_SuiGetAddress": 11100,
+        "MessageType_SuiAddress": 11101,
+        "MessageType_SuiSignTx": 11102,
+        "MessageType_SuiSignedTx": 11103,
+        "MessageType_SuiSignMessage": 11104,
+        "MessageType_SuiMessageSignature": 11105,
+        "MessageType_SuiTxRequest": 11106,
+        "MessageType_SuiTxAck": 11107,
+        "MessageType_FilecoinGetAddress": 11200,
+        "MessageType_FilecoinAddress": 11201,
+        "MessageType_FilecoinSignTx": 11202,
+        "MessageType_FilecoinSignedTx": 11203,
+        "MessageType_KaspaGetAddress": 11300,
+        "MessageType_KaspaAddress": 11301,
+        "MessageType_KaspaSignTx": 11302,
+        "MessageType_KaspaSignedTx": 11303,
+        "MessageType_KaspaTxInputRequest": 11304,
+        "MessageType_KaspaTxInputAck": 11305,
+        "MessageType_NexaGetAddress": 11400,
+        "MessageType_NexaAddress": 11401,
+        "MessageType_NexaSignTx": 11402,
+        "MessageType_NexaSignedTx": 11403,
+        "MessageType_NexaTxInputRequest": 11404,
+        "MessageType_NexaTxInputAck": 11405,
+        "MessageType_NostrGetPublicKey": 11500,
+        "MessageType_NostrPublicKey": 11501,
+        "MessageType_NostrSignEvent": 11502,
+        "MessageType_NostrSignedEvent": 11503,
+        "MessageType_NostrEncryptMessage": 11504,
+        "MessageType_NostrEncryptedMessage": 11505,
+        "MessageType_NostrDecryptMessage": 11506,
+        "MessageType_NostrDecryptedMessage": 11507,
+        "MessageType_NostrSignSchnorr": 11508,
+        "MessageType_NostrSignedSchnorr": 11509,
+        "MessageType_LnurlAuth": 11600,
+        "MessageType_LnurlAuthResp": 11601,
+        "MessageType_NervosGetAddress": 11701,
+        "MessageType_NervosAddress": 11702,
+        "MessageType_NervosSignTx": 11703,
+        "MessageType_NervosSignedTx": 11704,
+        "MessageType_NervosTxRequest": 11705,
+        "MessageType_NervosTxAck": 11706,
+        "MessageType_TonGetAddress": 11901,
+        "MessageType_TonAddress": 11902,
+        "MessageType_TonSignMessage": 11903,
+        "MessageType_TonSignedMessage": 11904,
+        "MessageType_TonSignProof": 11905,
+        "MessageType_TonSignedProof": 11906,
+        "MessageType_TonTxAck": 11907,
+        "MessageType_AlephiumGetAddress": 12101,
+        "MessageType_AlephiumAddress": 12102,
+        "MessageType_AlephiumSignTx": 12103,
+        "MessageType_AlephiumSignedTx": 12104,
+        "MessageType_AlephiumTxRequest": 12105,
+        "MessageType_AlephiumTxAck": 12106,
+        "MessageType_AlephiumBytecodeRequest": 12107,
+        "MessageType_AlephiumBytecodeAck": 12108,
+        "MessageType_AlephiumSignMessage": 12109,
+        "MessageType_AlephiumMessageSignature": 12110,
+        "MessageType_BenfenGetAddress": 12201,
+        "MessageType_BenfenAddress": 12202,
+        "MessageType_BenfenSignTx": 12203,
+        "MessageType_BenfenSignedTx": 12204,
+        "MessageType_BenfenSignMessage": 12205,
+        "MessageType_BenfenMessageSignature": 12206,
+        "MessageType_BenfenTxRequest": 12207,
+        "MessageType_BenfenTxAck": 12208,
+        "MessageType_NeoGetAddress": 12301,
+        "MessageType_NeoAddress": 12302,
+        "MessageType_NeoSignTx": 12303,
+        "MessageType_NeoSignedTx": 12304,
+        "MessageType_DeviceFactoryInfoSet": 60000,
+        "MessageType_DeviceFactoryInfoGet": 60001,
+        "MessageType_DeviceFactoryInfo": 60002,
+        "MessageType_DeviceFactoryPermanentLock": 60003,
+        "MessageType_DeviceFactoryTest": 60004,
+        "MessageType_ProtocolInfoRequest": 60200,
+        "MessageType_ProtocolInfo": 60201,
+        "MessageType_Ping": 60206,
+        "MessageType_Success": 60207,
+        "MessageType_Failure": 60208,
+        "MessageType_DeviceReboot": 60400,
+        "MessageType_DeviceSettings": 60410,
+        "MessageType_DeviceSettingsGet": 60411,
+        "MessageType_DeviceSettingsSet": 60412,
+        "MessageType_DeviceSettingsPageShow": 60413,
+        "MessageType_DeviceCertificate": 60420,
+        "MessageType_DeviceCertificateWrite": 60421,
+        "MessageType_DeviceCertificateRead": 60422,
+        "MessageType_DeviceCertificateSignature": 60423,
+        "MessageType_DeviceCertificateSign": 60424,
+        "MessageType_DeviceMiscUsbMscControl": 60440,
+        "MessageType_DeviceFindMyTokenState": 60450,
+        "MessageType_DeviceFindMyTokenUpdate": 60451,
+        "MessageType_DeviceFindMyTokenStateGet": 60452,
+        "MessageType_DeviceInfoGet": 60600,
+        "MessageType_DeviceInfo": 60601,
+        "MessageType_DeviceStatusGet": 60602,
+        "MessageType_DeviceStatus": 60603,
+        "MessageType_FilesystemPermissionFix": 60800,
+        "MessageType_FilesystemPathInfo": 60801,
+        "MessageType_FilesystemPathInfoQuery": 60802,
+        "MessageType_FilesystemFile": 60803,
+        "MessageType_FilesystemFileRead": 60804,
+        "MessageType_FilesystemFileWrite": 60805,
+        "MessageType_FilesystemFileDelete": 60806,
+        "MessageType_FilesystemDir": 60807,
+        "MessageType_FilesystemDirList": 60808,
+        "MessageType_FilesystemDirMake": 60809,
+        "MessageType_FilesystemDirRemove": 60810,
+        "MessageType_FilesystemFormat": 60811,
+        "MessageType_DeviceFirmwareUpdateStage": 61000,
+        "MessageType_DeviceFirmwareUpdateRequest": 61001,
+        "MessageType_DeviceFirmwareUpdateStatusGet": 61002,
+        "MessageType_DeviceFirmwareUpdateStatus": 61003,
+        "MessageType_DeviceSessionGet": 61200,
+        "MessageType_DeviceSession": 61201,
+        "MessageType_DeviceSessionAskPin": 61202,
+        "MessageType_DeviceSessionAskPassphrase": 61203,
+        "MessageType_PortfolioUpdate": 61400,
+        "MessageType_NftUpdate": 61500,
+        "MessageType_OnboardingStatusGet": 61600,
+        "MessageType_OnboardingStatus": 61601
+      },
+      "reserved": [
+        [90, 92],
+        [114, 122],
+        [300, 304],
+        [309, 312]
+      ]
+    },
     "ProtocolInfoRequest": {
       "fields": {
         "eventless_wallet_session": {
@@ -12322,11 +12322,6 @@
         "btc_test_address": {
           "type": "string",
           "id": 2
-        },
-        "seed_domains": {
-          "rule": "repeated",
-          "type": "DeviceSessionSeedDomain",
-          "id": 3
         }
       }
     },
@@ -12367,6 +12362,11 @@
           "rule": "required",
           "type": "bool",
           "id": 2
+        },
+        "seed_domains": {
+          "rule": "repeated",
+          "type": "DeviceSessionSeedDomain",
+          "id": 3
         }
       }
     },
@@ -12766,7 +12766,8 @@
           "type": "string",
           "id": 2
         }
-      }
+      },
+      "reserved": [[3, 3], "symbol"]
     },
     "ViewDetail": {
       "fields": {
@@ -12789,6 +12790,20 @@
           "rule": "required",
           "type": "bool",
           "id": 4
+        }
+      }
+    },
+    "ViewCustomField": {
+      "fields": {
+        "key": {
+          "rule": "required",
+          "type": "string",
+          "id": 1
+        },
+        "value": {
+          "rule": "required",
+          "type": "string",
+          "id": 2
         }
       }
     },
@@ -12822,17 +12837,67 @@
         }
       }
     },
-    "ViewRawData": {
+    "ViewActionCard": {
       "fields": {
         "initial_data": {
           "rule": "required",
           "type": "string",
           "id": 1
+        }
+      },
+      "reserved": [[2, 2], "placeholder"]
+    },
+    "ViewContentPreview": {
+      "fields": {
+        "content_key": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 1
         },
-        "placeholder": {
+        "preview": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 2
+        },
+        "total_bytes": {
+          "type": "uint32",
+          "id": 3
+        }
+      }
+    },
+    "ViewContentEntry": {
+      "fields": {
+        "entry_key": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 1
+        },
+        "value": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 2
+        }
+      }
+    },
+    "ViewContentPage": {
+      "fields": {
+        "page_index": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 1
+        },
+        "page_count": {
           "rule": "required",
           "type": "uint32",
           "id": 2
+        },
+        "chunk": {
+          "type": "bytes",
+          "id": 3
+        },
+        "entry": {
+          "type": "ViewContentEntry",
+          "id": 4
         }
       }
     },
@@ -12865,8 +12930,8 @@
           "type": "ViewTip",
           "id": 4
         },
-        "raw_data": {
-          "type": "ViewRawData",
+        "action_card": {
+          "type": "ViewActionCard",
           "id": 5
         },
         "slide_to_confirm": {
@@ -12890,6 +12955,36 @@
         "title_arg": {
           "type": "string",
           "id": 9
+        },
+        "content": {
+          "type": "ViewContentPreview",
+          "id": 10
+        },
+        "custom_field": {
+          "type": "ViewCustomField",
+          "id": 11
+        }
+      }
+    },
+    "ViewWarningPage": {
+      "fields": {
+        "title_id": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 1
+        },
+        "text_id": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 2
+        },
+        "text_arg": {
+          "type": "string",
+          "id": 3
+        },
+        "cancellable": {
+          "type": "bool",
+          "id": 4
         }
       }
     },
@@ -12928,6 +13023,10 @@
         "chain_id": {
           "type": "uint32",
           "id": 8
+        },
+        "content": {
+          "type": "ViewContentPreview",
+          "id": 9
         }
       }
     },

--- a/packages/hd-transport/messages-protocol-v2.json
+++ b/packages/hd-transport/messages-protocol-v2.json
@@ -12334,6 +12334,11 @@
         "btc_test_address": {
           "type": "string",
           "id": 2
+        },
+        "seed_domains": {
+          "rule": "repeated",
+          "type": "DeviceSessionSeedDomain",
+          "id": 3
         }
       }
     },

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "description": "Transport layer abstractions and utilities for OneKey hardware SDK.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "description": "Transport layer abstractions and utilities for OneKey hardware SDK.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "description": "Transport layer abstractions and utilities for OneKey hardware SDK.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "description": "Transport layer abstractions and utilities for OneKey hardware SDK.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-transport/package.json
+++ b/packages/hd-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-transport",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "description": "Transport layer abstractions and utilities for OneKey hardware SDK.",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",

--- a/packages/hd-transport/src/types/messages.ts
+++ b/packages/hd-transport/src/types/messages.ts
@@ -5275,17 +5275,25 @@ export type ViewActionCard = {
   initial_data: string;
 };
 
-// ViewData
-export type ViewData = {
+// ViewContentPreview
+export type ViewContentPreview = {
+  content_key: number;
   preview: string;
-  total_bytes: number;
+  total_bytes?: number;
 };
 
-// ViewDataPage
-export type ViewDataPage = {
-  chunk: string;
+// ViewContentEntry
+export type ViewContentEntry = {
+  entry_key: number;
+  value: string;
+};
+
+// ViewContentPage
+export type ViewContentPage = {
   page_index: number;
   page_count: number;
+  chunk?: string;
+  entry?: ViewContentEntry;
 };
 
 export enum ViewSignLayout {
@@ -5308,7 +5316,7 @@ export type ViewSignPage = {
   layout?: ViewSignLayout;
   title_id?: number;
   title_arg?: string;
-  data?: ViewData;
+  content?: ViewContentPreview;
   custom_field?: ViewCustomField;
 };
 
@@ -5317,6 +5325,7 @@ export type ViewWarningPage = {
   title_id: number;
   text_id: number;
   text_arg?: string;
+  cancellable?: boolean;
 };
 
 // ViewVerifyPage
@@ -5329,6 +5338,7 @@ export type ViewVerifyPage = {
   value_key?: number;
   title_id?: number;
   chain_id?: number;
+  content?: ViewContentPreview;
 };
 
 export enum ProtocolV2FailureType {
@@ -6012,8 +6022,9 @@ export type MessageType = {
   ViewCustomField: ViewCustomField;
   ViewTip: ViewTip;
   ViewActionCard: ViewActionCard;
-  ViewData: ViewData;
-  ViewDataPage: ViewDataPage;
+  ViewContentPreview: ViewContentPreview;
+  ViewContentEntry: ViewContentEntry;
+  ViewContentPage: ViewContentPage;
   ViewSignPage: ViewSignPage;
   ViewWarningPage: ViewWarningPage;
   ViewVerifyPage: ViewVerifyPage;

--- a/packages/hd-transport/src/types/messages.ts
+++ b/packages/hd-transport/src/types/messages.ts
@@ -5275,25 +5275,17 @@ export type ViewActionCard = {
   initial_data: string;
 };
 
-// ViewContentPreview
-export type ViewContentPreview = {
-  content_key: number;
+// ViewData
+export type ViewData = {
   preview: string;
-  total_bytes?: number;
+  total_bytes: number;
 };
 
-// ViewContentEntry
-export type ViewContentEntry = {
-  entry_key: number;
-  value: string;
-};
-
-// ViewContentPage
-export type ViewContentPage = {
+// ViewDataPage
+export type ViewDataPage = {
+  chunk: string;
   page_index: number;
   page_count: number;
-  chunk?: string;
-  entry?: ViewContentEntry;
 };
 
 export enum ViewSignLayout {
@@ -5316,7 +5308,7 @@ export type ViewSignPage = {
   layout?: ViewSignLayout;
   title_id?: number;
   title_arg?: string;
-  content?: ViewContentPreview;
+  data?: ViewData;
   custom_field?: ViewCustomField;
 };
 
@@ -5325,7 +5317,6 @@ export type ViewWarningPage = {
   title_id: number;
   text_id: number;
   text_arg?: string;
-  cancellable?: boolean;
 };
 
 // ViewVerifyPage
@@ -5338,7 +5329,6 @@ export type ViewVerifyPage = {
   value_key?: number;
   title_id?: number;
   chain_id?: number;
-  content?: ViewContentPreview;
 };
 
 export enum ProtocolV2FailureType {
@@ -6022,9 +6012,8 @@ export type MessageType = {
   ViewCustomField: ViewCustomField;
   ViewTip: ViewTip;
   ViewActionCard: ViewActionCard;
-  ViewContentPreview: ViewContentPreview;
-  ViewContentEntry: ViewContentEntry;
-  ViewContentPage: ViewContentPage;
+  ViewData: ViewData;
+  ViewDataPage: ViewDataPage;
   ViewSignPage: ViewSignPage;
   ViewWarningPage: ViewWarningPage;
   ViewVerifyPage: ViewVerifyPage;

--- a/packages/hd-transport/src/types/messages.ts
+++ b/packages/hd-transport/src/types/messages.ts
@@ -5032,7 +5032,6 @@ export enum DeviceSessionSeedDomain {
 export type DeviceSessionGet = {
   session_id?: string;
   btc_test_address?: string;
-  seed_domains: DeviceSessionSeedDomain[];
 };
 
 // DeviceSession
@@ -5276,17 +5275,25 @@ export type ViewActionCard = {
   initial_data: string;
 };
 
-// ViewData
-export type ViewData = {
+// ViewContentPreview
+export type ViewContentPreview = {
+  content_key: number;
   preview: string;
-  total_bytes: number;
+  total_bytes?: number;
 };
 
-// ViewDataPage
-export type ViewDataPage = {
-  chunk: string;
+// ViewContentEntry
+export type ViewContentEntry = {
+  entry_key: number;
+  value: string;
+};
+
+// ViewContentPage
+export type ViewContentPage = {
   page_index: number;
   page_count: number;
+  chunk?: string;
+  entry?: ViewContentEntry;
 };
 
 export enum ViewSignLayout {
@@ -5309,7 +5316,7 @@ export type ViewSignPage = {
   layout?: ViewSignLayout;
   title_id?: number;
   title_arg?: string;
-  data?: ViewData;
+  content?: ViewContentPreview;
   custom_field?: ViewCustomField;
 };
 
@@ -5318,6 +5325,7 @@ export type ViewWarningPage = {
   title_id: number;
   text_id: number;
   text_arg?: string;
+  cancellable?: boolean;
 };
 
 // ViewVerifyPage
@@ -5330,6 +5338,7 @@ export type ViewVerifyPage = {
   value_key?: number;
   title_id?: number;
   chain_id?: number;
+  content?: ViewContentPreview;
 };
 
 export enum ProtocolV2FailureType {
@@ -6013,8 +6022,9 @@ export type MessageType = {
   ViewCustomField: ViewCustomField;
   ViewTip: ViewTip;
   ViewActionCard: ViewActionCard;
-  ViewData: ViewData;
-  ViewDataPage: ViewDataPage;
+  ViewContentPreview: ViewContentPreview;
+  ViewContentEntry: ViewContentEntry;
+  ViewContentPage: ViewContentPage;
   ViewSignPage: ViewSignPage;
   ViewWarningPage: ViewWarningPage;
   ViewVerifyPage: ViewVerifyPage;

--- a/packages/hd-transport/src/types/messages.ts
+++ b/packages/hd-transport/src/types/messages.ts
@@ -5032,6 +5032,7 @@ export enum DeviceSessionSeedDomain {
 export type DeviceSessionGet = {
   session_id?: string;
   btc_test_address?: string;
+  seed_domains: DeviceSessionSeedDomain[];
 };
 
 // DeviceSession
@@ -5275,25 +5276,17 @@ export type ViewActionCard = {
   initial_data: string;
 };
 
-// ViewContentPreview
-export type ViewContentPreview = {
-  content_key: number;
+// ViewData
+export type ViewData = {
   preview: string;
-  total_bytes?: number;
+  total_bytes: number;
 };
 
-// ViewContentEntry
-export type ViewContentEntry = {
-  entry_key: number;
-  value: string;
-};
-
-// ViewContentPage
-export type ViewContentPage = {
+// ViewDataPage
+export type ViewDataPage = {
+  chunk: string;
   page_index: number;
   page_count: number;
-  chunk?: string;
-  entry?: ViewContentEntry;
 };
 
 export enum ViewSignLayout {
@@ -5316,7 +5309,7 @@ export type ViewSignPage = {
   layout?: ViewSignLayout;
   title_id?: number;
   title_arg?: string;
-  content?: ViewContentPreview;
+  data?: ViewData;
   custom_field?: ViewCustomField;
 };
 
@@ -5325,7 +5318,6 @@ export type ViewWarningPage = {
   title_id: number;
   text_id: number;
   text_arg?: string;
-  cancellable?: boolean;
 };
 
 // ViewVerifyPage
@@ -5338,7 +5330,6 @@ export type ViewVerifyPage = {
   value_key?: number;
   title_id?: number;
   chain_id?: number;
-  content?: ViewContentPreview;
 };
 
 export enum ProtocolV2FailureType {
@@ -6022,9 +6013,8 @@ export type MessageType = {
   ViewCustomField: ViewCustomField;
   ViewTip: ViewTip;
   ViewActionCard: ViewActionCard;
-  ViewContentPreview: ViewContentPreview;
-  ViewContentEntry: ViewContentEntry;
-  ViewContentPage: ViewContentPage;
+  ViewData: ViewData;
+  ViewDataPage: ViewDataPage;
   ViewSignPage: ViewSignPage;
   ViewWarningPage: ViewWarningPage;
   ViewVerifyPage: ViewVerifyPage;

--- a/packages/hd-transport/src/types/messages.ts
+++ b/packages/hd-transport/src/types/messages.ts
@@ -5038,6 +5038,7 @@ export type DeviceSessionGet = {
 export type DeviceSession = {
   session_id?: string;
   btc_test_address?: string;
+  seed_domains: DeviceSessionSeedDomain[];
 };
 
 export enum DeviceSessionPinType {

--- a/packages/hd-transport/src/types/messages.ts
+++ b/packages/hd-transport/src/types/messages.ts
@@ -4558,12 +4558,6 @@ export enum CommandFlags {
   Factory_Only = 1,
 }
 
-// experimental_message
-export type experimental_message = {};
-
-// experimental_field
-export type experimental_field = {};
-
 export type TextMemo = {
   text: string;
 };
@@ -4668,6 +4662,12 @@ export type UiAnimationRequest = {
   command: UiAnimationCommand;
   type?: UiAnimationType;
 };
+
+// experimental_message
+export type experimental_message = {};
+
+// experimental_field
+export type experimental_field = {};
 
 // ProtocolInfoRequest
 export type ProtocolInfoRequest = {
@@ -5032,7 +5032,6 @@ export enum DeviceSessionSeedDomain {
 export type DeviceSessionGet = {
   session_id?: string;
   btc_test_address?: string;
-  seed_domains: DeviceSessionSeedDomain[];
 };
 
 // DeviceSession
@@ -5056,6 +5055,7 @@ export type DeviceSessionAskPin = {
 export type DeviceSessionAskPassphrase = {
   passphrase?: string;
   on_device: boolean;
+  seed_domains: DeviceSessionSeedDomain[];
 };
 
 export enum DeviceSessionAskPin_FailureSubCodes {
@@ -5247,6 +5247,12 @@ export type ViewDetail = {
   has_icon: boolean;
 };
 
+// ViewCustomField
+export type ViewCustomField = {
+  key: string;
+  value: string;
+};
+
 export enum ViewTipType {
   Default = 0,
   Highlight = 1,
@@ -5263,10 +5269,30 @@ export type ViewTip = {
   text_arg?: string;
 };
 
-// ViewRawData
-export type ViewRawData = {
+// ViewActionCard
+export type ViewActionCard = {
   initial_data: string;
-  placeholder: number;
+};
+
+// ViewContentPreview
+export type ViewContentPreview = {
+  content_key: number;
+  preview: string;
+  total_bytes?: number;
+};
+
+// ViewContentEntry
+export type ViewContentEntry = {
+  entry_key: number;
+  value: string;
+};
+
+// ViewContentPage
+export type ViewContentPage = {
+  page_index: number;
+  page_count: number;
+  chunk?: string;
+  entry?: ViewContentEntry;
 };
 
 export enum ViewSignLayout {
@@ -5284,11 +5310,21 @@ export type ViewSignPage = {
   amount?: UintType;
   general: ViewDetail[];
   tip?: ViewTip;
-  raw_data?: ViewRawData;
+  action_card?: ViewActionCard;
   slide_to_confirm?: boolean;
   layout?: ViewSignLayout;
   title_id?: number;
   title_arg?: string;
+  content?: ViewContentPreview;
+  custom_field?: ViewCustomField;
+};
+
+// ViewWarningPage
+export type ViewWarningPage = {
+  title_id: number;
+  text_id: number;
+  text_arg?: string;
+  cancellable?: boolean;
 };
 
 // ViewVerifyPage
@@ -5301,6 +5337,7 @@ export type ViewVerifyPage = {
   value_key?: number;
   title_id?: number;
   chain_id?: number;
+  content?: ViewContentPreview;
 };
 
 export enum ProtocolV2FailureType {
@@ -5900,8 +5937,6 @@ export type MessageType = {
   TronSignMessage: TronSignMessage;
   TronMessageSignature: TronMessageSignature;
   facotry: facotry;
-  experimental_message: experimental_message;
-  experimental_field: experimental_field;
   TextMemo: TextMemo;
   RefundMemo: RefundMemo;
   CoinPurchaseMemo: CoinPurchaseMemo;
@@ -5917,6 +5952,8 @@ export type MessageType = {
   UnlockPath: UnlockPath;
   UnlockedPathRequest: UnlockedPathRequest;
   UiAnimationRequest: UiAnimationRequest;
+  experimental_message: experimental_message;
+  experimental_field: experimental_field;
   ProtocolInfoRequest: ProtocolInfoRequest;
   ProtocolInfo: ProtocolInfo;
   DeviceReboot: DeviceReboot;
@@ -5981,9 +6018,14 @@ export type MessageType = {
   PortfolioUpdate: PortfolioUpdate;
   ViewAmount: ViewAmount;
   ViewDetail: ViewDetail;
+  ViewCustomField: ViewCustomField;
   ViewTip: ViewTip;
-  ViewRawData: ViewRawData;
+  ViewActionCard: ViewActionCard;
+  ViewContentPreview: ViewContentPreview;
+  ViewContentEntry: ViewContentEntry;
+  ViewContentPage: ViewContentPage;
   ViewSignPage: ViewSignPage;
+  ViewWarningPage: ViewWarningPage;
   ViewVerifyPage: ViewVerifyPage;
 };
 

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -23,10 +23,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "2.2.67",
-    "@onekeyfe/hd-core": "1.2.2-alpha.4",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
-    "@onekeyfe/hd-transport-http": "1.2.2-alpha.4",
-    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.4"
+    "@onekeyfe/hd-core": "1.2.2-alpha.5",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
+    "@onekeyfe/hd-transport-http": "1.2.2-alpha.5",
+    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.5"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -23,10 +23,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "2.2.67",
-    "@onekeyfe/hd-core": "1.2.2-alpha.5",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.5",
-    "@onekeyfe/hd-transport-http": "1.2.2-alpha.5",
-    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.5"
+    "@onekeyfe/hd-core": "1.2.2-alpha.6",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.6",
+    "@onekeyfe/hd-transport-http": "1.2.2-alpha.6",
+    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.6"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -23,10 +23,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "2.2.67",
-    "@onekeyfe/hd-core": "1.2.2-alpha.1",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.1",
-    "@onekeyfe/hd-transport-http": "1.2.2-alpha.1",
-    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.1"
+    "@onekeyfe/hd-core": "1.2.2-alpha.2",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
+    "@onekeyfe/hd-transport-http": "1.2.2-alpha.2",
+    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.2"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -23,10 +23,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "2.2.67",
-    "@onekeyfe/hd-core": "1.2.2-alpha.2",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.2",
-    "@onekeyfe/hd-transport-http": "1.2.2-alpha.2",
-    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.2"
+    "@onekeyfe/hd-core": "1.2.2-alpha.3",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
+    "@onekeyfe/hd-transport-http": "1.2.2-alpha.3",
+    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.3"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/hd-web-sdk/package.json
+++ b/packages/hd-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-web-sdk",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "author": "OneKey",
   "homepage": "https://github.com/OneKeyHQ/hardware-js-sdk#readme",
   "license": "ISC",
@@ -23,10 +23,10 @@
   },
   "dependencies": {
     "@onekeyfe/cross-inpage-provider-core": "2.2.67",
-    "@onekeyfe/hd-core": "1.2.2-alpha.3",
-    "@onekeyfe/hd-shared": "1.2.2-alpha.3",
-    "@onekeyfe/hd-transport-http": "1.2.2-alpha.3",
-    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.3"
+    "@onekeyfe/hd-core": "1.2.2-alpha.4",
+    "@onekeyfe/hd-shared": "1.2.2-alpha.4",
+    "@onekeyfe/hd-transport-http": "1.2.2-alpha.4",
+    "@onekeyfe/hd-transport-web-device": "1.2.2-alpha.4"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.17.12",

--- a/packages/hwk-adapter-core/package.json
+++ b/packages/hwk-adapter-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-adapter-core",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "description": "Shared types and utilities for OneKey hardware wallet kit",
   "author": "OneKey",
   "license": "MIT",

--- a/packages/hwk-adapter-core/package.json
+++ b/packages/hwk-adapter-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-adapter-core",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "description": "Shared types and utilities for OneKey hardware wallet kit",
   "author": "OneKey",
   "license": "MIT",

--- a/packages/hwk-adapter-core/package.json
+++ b/packages/hwk-adapter-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-adapter-core",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "description": "Shared types and utilities for OneKey hardware wallet kit",
   "author": "OneKey",
   "license": "MIT",

--- a/packages/hwk-adapter-core/package.json
+++ b/packages/hwk-adapter-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-adapter-core",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "description": "Shared types and utilities for OneKey hardware wallet kit",
   "author": "OneKey",
   "license": "MIT",

--- a/packages/hwk-adapter-core/package.json
+++ b/packages/hwk-adapter-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-adapter-core",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "description": "Shared types and utilities for OneKey hardware wallet kit",
   "author": "OneKey",
   "license": "MIT",

--- a/packages/hwk-ledger-adapter/package.json
+++ b/packages/hwk-ledger-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-adapter",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "description": "Ledger hardware wallet adapter for OneKey",
   "author": "OneKey",
   "license": "MIT",
@@ -50,7 +50,7 @@
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/hw-app-trx": "^6.34.1",
     "@ledgerhq/hw-transport": "^6.34.1",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.6",
     "bitcoinjs-lib": "npm:@onekeyfe/bitcoinjs-lib@7.0.1"
   },
   "devDependencies": {

--- a/packages/hwk-ledger-adapter/package.json
+++ b/packages/hwk-ledger-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-adapter",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "description": "Ledger hardware wallet adapter for OneKey",
   "author": "OneKey",
   "license": "MIT",
@@ -50,7 +50,7 @@
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/hw-app-trx": "^6.34.1",
     "@ledgerhq/hw-transport": "^6.34.1",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.5",
     "bitcoinjs-lib": "npm:@onekeyfe/bitcoinjs-lib@7.0.1"
   },
   "devDependencies": {

--- a/packages/hwk-ledger-adapter/package.json
+++ b/packages/hwk-ledger-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-adapter",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "description": "Ledger hardware wallet adapter for OneKey",
   "author": "OneKey",
   "license": "MIT",
@@ -50,7 +50,7 @@
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/hw-app-trx": "^6.34.1",
     "@ledgerhq/hw-transport": "^6.34.1",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.3",
     "bitcoinjs-lib": "npm:@onekeyfe/bitcoinjs-lib@7.0.1"
   },
   "devDependencies": {

--- a/packages/hwk-ledger-adapter/package.json
+++ b/packages/hwk-ledger-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-adapter",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "description": "Ledger hardware wallet adapter for OneKey",
   "author": "OneKey",
   "license": "MIT",
@@ -50,7 +50,7 @@
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/hw-app-trx": "^6.34.1",
     "@ledgerhq/hw-transport": "^6.34.1",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.1",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.2",
     "bitcoinjs-lib": "npm:@onekeyfe/bitcoinjs-lib@7.0.1"
   },
   "devDependencies": {

--- a/packages/hwk-ledger-adapter/package.json
+++ b/packages/hwk-ledger-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-adapter",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "description": "Ledger hardware wallet adapter for OneKey",
   "author": "OneKey",
   "license": "MIT",
@@ -50,7 +50,7 @@
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/hw-app-trx": "^6.34.1",
     "@ledgerhq/hw-transport": "^6.34.1",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.4",
     "bitcoinjs-lib": "npm:@onekeyfe/bitcoinjs-lib@7.0.1"
   },
   "devDependencies": {

--- a/packages/hwk-ledger-connector-ble/package.json
+++ b/packages/hwk-ledger-connector-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-connector-ble",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "description": "IConnector implementation for Ledger hardware wallets via React Native BLE",
   "author": "OneKey",
   "license": "MIT",
@@ -51,8 +51,8 @@
     "@ledgerhq/device-signer-kit-ethereum": "^1.9.0",
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/device-transport-kit-react-native-ble": "^1.0.0",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.5"
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.6"
   },
   "peerDependencies": {
     "react-native": "*"

--- a/packages/hwk-ledger-connector-ble/package.json
+++ b/packages/hwk-ledger-connector-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-connector-ble",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "description": "IConnector implementation for Ledger hardware wallets via React Native BLE",
   "author": "OneKey",
   "license": "MIT",
@@ -51,8 +51,8 @@
     "@ledgerhq/device-signer-kit-ethereum": "^1.9.0",
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/device-transport-kit-react-native-ble": "^1.0.0",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.4"
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.5"
   },
   "peerDependencies": {
     "react-native": "*"

--- a/packages/hwk-ledger-connector-ble/package.json
+++ b/packages/hwk-ledger-connector-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-connector-ble",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "description": "IConnector implementation for Ledger hardware wallets via React Native BLE",
   "author": "OneKey",
   "license": "MIT",
@@ -51,8 +51,8 @@
     "@ledgerhq/device-signer-kit-ethereum": "^1.9.0",
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/device-transport-kit-react-native-ble": "^1.0.0",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.2"
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.3"
   },
   "peerDependencies": {
     "react-native": "*"

--- a/packages/hwk-ledger-connector-ble/package.json
+++ b/packages/hwk-ledger-connector-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-connector-ble",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "description": "IConnector implementation for Ledger hardware wallets via React Native BLE",
   "author": "OneKey",
   "license": "MIT",
@@ -51,8 +51,8 @@
     "@ledgerhq/device-signer-kit-ethereum": "^1.9.0",
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/device-transport-kit-react-native-ble": "^1.0.0",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.3"
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.4"
   },
   "peerDependencies": {
     "react-native": "*"

--- a/packages/hwk-ledger-connector-ble/package.json
+++ b/packages/hwk-ledger-connector-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-connector-ble",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "description": "IConnector implementation for Ledger hardware wallets via React Native BLE",
   "author": "OneKey",
   "license": "MIT",
@@ -51,8 +51,8 @@
     "@ledgerhq/device-signer-kit-ethereum": "^1.9.0",
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/device-transport-kit-react-native-ble": "^1.0.0",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.1"
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.2"
   },
   "peerDependencies": {
     "react-native": "*"

--- a/packages/hwk-ledger-connector-webhid/package.json
+++ b/packages/hwk-ledger-connector-webhid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-connector-webhid",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "description": "IConnector implementation for Ledger hardware wallets via WebHID (DMK)",
   "author": "OneKey",
   "license": "MIT",
@@ -49,8 +49,8 @@
     "@ledgerhq/device-signer-kit-ethereum": "^1.9.0",
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/device-transport-kit-web-hid": "^1.0.0",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.4"
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.5"
   },
   "devDependencies": {
     "rimraf": "^5.0.0",

--- a/packages/hwk-ledger-connector-webhid/package.json
+++ b/packages/hwk-ledger-connector-webhid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-connector-webhid",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "description": "IConnector implementation for Ledger hardware wallets via WebHID (DMK)",
   "author": "OneKey",
   "license": "MIT",
@@ -49,8 +49,8 @@
     "@ledgerhq/device-signer-kit-ethereum": "^1.9.0",
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/device-transport-kit-web-hid": "^1.0.0",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.5"
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.6"
   },
   "devDependencies": {
     "rimraf": "^5.0.0",

--- a/packages/hwk-ledger-connector-webhid/package.json
+++ b/packages/hwk-ledger-connector-webhid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-connector-webhid",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "description": "IConnector implementation for Ledger hardware wallets via WebHID (DMK)",
   "author": "OneKey",
   "license": "MIT",
@@ -49,8 +49,8 @@
     "@ledgerhq/device-signer-kit-ethereum": "^1.9.0",
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/device-transport-kit-web-hid": "^1.0.0",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.2"
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.3"
   },
   "devDependencies": {
     "rimraf": "^5.0.0",

--- a/packages/hwk-ledger-connector-webhid/package.json
+++ b/packages/hwk-ledger-connector-webhid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-connector-webhid",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "description": "IConnector implementation for Ledger hardware wallets via WebHID (DMK)",
   "author": "OneKey",
   "license": "MIT",
@@ -49,8 +49,8 @@
     "@ledgerhq/device-signer-kit-ethereum": "^1.9.0",
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/device-transport-kit-web-hid": "^1.0.0",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.3"
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.4"
   },
   "devDependencies": {
     "rimraf": "^5.0.0",

--- a/packages/hwk-ledger-connector-webhid/package.json
+++ b/packages/hwk-ledger-connector-webhid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-ledger-connector-webhid",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "description": "IConnector implementation for Ledger hardware wallets via WebHID (DMK)",
   "author": "OneKey",
   "license": "MIT",
@@ -49,8 +49,8 @@
     "@ledgerhq/device-signer-kit-ethereum": "^1.9.0",
     "@ledgerhq/device-signer-kit-solana": "^1.7.0",
     "@ledgerhq/device-transport-kit-web-hid": "^1.0.0",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.1"
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-ledger-adapter": "1.2.2-alpha.2"
   },
   "devDependencies": {
     "rimraf": "^5.0.0",

--- a/packages/hwk-trezor-adapter/package.json
+++ b/packages/hwk-trezor-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-adapter",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "description": "Trezor hardware wallet adapter primitives for OneKey",
   "author": "OneKey",
   "license": "MIT",
@@ -45,8 +45,8 @@
   "dependencies": {
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "^1.3.3",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.5",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/packages/hwk-trezor-adapter/package.json
+++ b/packages/hwk-trezor-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-adapter",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "description": "Trezor hardware wallet adapter primitives for OneKey",
   "author": "OneKey",
   "license": "MIT",
@@ -45,8 +45,8 @@
   "dependencies": {
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "^1.3.3",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.6",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/packages/hwk-trezor-adapter/package.json
+++ b/packages/hwk-trezor-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-adapter",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "description": "Trezor hardware wallet adapter primitives for OneKey",
   "author": "OneKey",
   "license": "MIT",
@@ -45,8 +45,8 @@
   "dependencies": {
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "^1.3.3",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.1",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.2",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/packages/hwk-trezor-adapter/package.json
+++ b/packages/hwk-trezor-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-adapter",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "description": "Trezor hardware wallet adapter primitives for OneKey",
   "author": "OneKey",
   "license": "MIT",
@@ -45,8 +45,8 @@
   "dependencies": {
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "^1.3.3",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.4",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/packages/hwk-trezor-adapter/package.json
+++ b/packages/hwk-trezor-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-adapter",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "description": "Trezor hardware wallet adapter primitives for OneKey",
   "author": "OneKey",
   "license": "MIT",
@@ -45,8 +45,8 @@
   "dependencies": {
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "^1.3.3",
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.3",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/packages/hwk-trezor-connector-electron-ble/package.json
+++ b/packages/hwk-trezor-connector-electron-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector-electron-ble",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "description": "IConnector implementation for Trezor hardware wallets via Electron BLE (noble in main process)",
   "author": "OneKey",
   "license": "MIT",
@@ -68,9 +68,9 @@
     "connector"
   ],
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.5",
     "buffer": "^6.0.3"
   },
   "peerDependencies": {

--- a/packages/hwk-trezor-connector-electron-ble/package.json
+++ b/packages/hwk-trezor-connector-electron-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector-electron-ble",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "description": "IConnector implementation for Trezor hardware wallets via Electron BLE (noble in main process)",
   "author": "OneKey",
   "license": "MIT",
@@ -68,9 +68,9 @@
     "connector"
   ],
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.6",
     "buffer": "^6.0.3"
   },
   "peerDependencies": {

--- a/packages/hwk-trezor-connector-electron-ble/package.json
+++ b/packages/hwk-trezor-connector-electron-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector-electron-ble",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "description": "IConnector implementation for Trezor hardware wallets via Electron BLE (noble in main process)",
   "author": "OneKey",
   "license": "MIT",
@@ -68,9 +68,9 @@
     "connector"
   ],
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.4",
     "buffer": "^6.0.3"
   },
   "peerDependencies": {

--- a/packages/hwk-trezor-connector-electron-ble/package.json
+++ b/packages/hwk-trezor-connector-electron-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector-electron-ble",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "description": "IConnector implementation for Trezor hardware wallets via Electron BLE (noble in main process)",
   "author": "OneKey",
   "license": "MIT",
@@ -68,9 +68,9 @@
     "connector"
   ],
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.1",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.2",
     "buffer": "^6.0.3"
   },
   "peerDependencies": {

--- a/packages/hwk-trezor-connector-electron-ble/package.json
+++ b/packages/hwk-trezor-connector-electron-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector-electron-ble",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "description": "IConnector implementation for Trezor hardware wallets via Electron BLE (noble in main process)",
   "author": "OneKey",
   "license": "MIT",
@@ -68,9 +68,9 @@
     "connector"
   ],
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.3",
     "buffer": "^6.0.3"
   },
   "peerDependencies": {

--- a/packages/hwk-trezor-connector-rn-ble/package.json
+++ b/packages/hwk-trezor-connector-rn-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector-rn-ble",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "description": "IConnector implementation for Trezor hardware wallets via React Native BLE",
   "author": "OneKey",
   "license": "MIT",
@@ -46,9 +46,9 @@
     "connector"
   ],
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.5",
     "buffer": "^6.0.3",
     "react-native-ble-plx": "^3.5.1"
   },

--- a/packages/hwk-trezor-connector-rn-ble/package.json
+++ b/packages/hwk-trezor-connector-rn-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector-rn-ble",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "description": "IConnector implementation for Trezor hardware wallets via React Native BLE",
   "author": "OneKey",
   "license": "MIT",
@@ -46,9 +46,9 @@
     "connector"
   ],
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.6",
     "buffer": "^6.0.3",
     "react-native-ble-plx": "^3.5.1"
   },

--- a/packages/hwk-trezor-connector-rn-ble/package.json
+++ b/packages/hwk-trezor-connector-rn-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector-rn-ble",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "description": "IConnector implementation for Trezor hardware wallets via React Native BLE",
   "author": "OneKey",
   "license": "MIT",
@@ -46,9 +46,9 @@
     "connector"
   ],
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.4",
     "buffer": "^6.0.3",
     "react-native-ble-plx": "^3.5.1"
   },

--- a/packages/hwk-trezor-connector-rn-ble/package.json
+++ b/packages/hwk-trezor-connector-rn-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector-rn-ble",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "description": "IConnector implementation for Trezor hardware wallets via React Native BLE",
   "author": "OneKey",
   "license": "MIT",
@@ -46,9 +46,9 @@
     "connector"
   ],
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.1",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.2",
     "buffer": "^6.0.3",
     "react-native-ble-plx": "^3.5.1"
   },

--- a/packages/hwk-trezor-connector-rn-ble/package.json
+++ b/packages/hwk-trezor-connector-rn-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector-rn-ble",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "description": "IConnector implementation for Trezor hardware wallets via React Native BLE",
   "author": "OneKey",
   "license": "MIT",
@@ -46,9 +46,9 @@
     "connector"
   ],
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-adapter": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.3",
     "buffer": "^6.0.3",
     "react-native-ble-plx": "^3.5.1"
   },

--- a/packages/hwk-trezor-connector-webusb/package.json
+++ b/packages/hwk-trezor-connector-webusb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector-webusb",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "description": "IConnector implementation for Trezor hardware wallets via WebUSB",
   "author": "OneKey",
   "license": "MIT",
@@ -55,8 +55,8 @@
     "connector"
   ],
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.5",
     "buffer": "^6.0.3"
   },
   "devDependencies": {

--- a/packages/hwk-trezor-connector-webusb/package.json
+++ b/packages/hwk-trezor-connector-webusb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector-webusb",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "description": "IConnector implementation for Trezor hardware wallets via WebUSB",
   "author": "OneKey",
   "license": "MIT",
@@ -55,8 +55,8 @@
     "connector"
   ],
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.6",
     "buffer": "^6.0.3"
   },
   "devDependencies": {

--- a/packages/hwk-trezor-connector-webusb/package.json
+++ b/packages/hwk-trezor-connector-webusb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector-webusb",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "description": "IConnector implementation for Trezor hardware wallets via WebUSB",
   "author": "OneKey",
   "license": "MIT",
@@ -55,8 +55,8 @@
     "connector"
   ],
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.1",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.2",
     "buffer": "^6.0.3"
   },
   "devDependencies": {

--- a/packages/hwk-trezor-connector-webusb/package.json
+++ b/packages/hwk-trezor-connector-webusb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector-webusb",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "description": "IConnector implementation for Trezor hardware wallets via WebUSB",
   "author": "OneKey",
   "license": "MIT",
@@ -55,8 +55,8 @@
     "connector"
   ],
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.4",
     "buffer": "^6.0.3"
   },
   "devDependencies": {

--- a/packages/hwk-trezor-connector-webusb/package.json
+++ b/packages/hwk-trezor-connector-webusb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector-webusb",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "description": "IConnector implementation for Trezor hardware wallets via WebUSB",
   "author": "OneKey",
   "license": "MIT",
@@ -55,8 +55,8 @@
     "connector"
   ],
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-connector": "1.2.2-alpha.3",
     "buffer": "^6.0.3"
   },
   "devDependencies": {

--- a/packages/hwk-trezor-connector/package.json
+++ b/packages/hwk-trezor-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "description": "Shared Trezor connector base for Hardware Wallet Kit",
   "author": "OneKey",
   "license": "MIT",
@@ -38,13 +38,13 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.5"
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.6"
   },
   "devDependencies": {
-    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.6",
     "rimraf": "^5.0.0",
     "tsup": "^8.0.0",
     "typescript": "5.1.6"

--- a/packages/hwk-trezor-connector/package.json
+++ b/packages/hwk-trezor-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "description": "Shared Trezor connector base for Hardware Wallet Kit",
   "author": "OneKey",
   "license": "MIT",
@@ -38,13 +38,13 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.4"
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.5"
   },
   "devDependencies": {
-    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.5",
     "rimraf": "^5.0.0",
     "tsup": "^8.0.0",
     "typescript": "5.1.6"

--- a/packages/hwk-trezor-connector/package.json
+++ b/packages/hwk-trezor-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "description": "Shared Trezor connector base for Hardware Wallet Kit",
   "author": "OneKey",
   "license": "MIT",
@@ -38,13 +38,13 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.2"
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.3"
   },
   "devDependencies": {
-    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.3",
     "rimraf": "^5.0.0",
     "tsup": "^8.0.0",
     "typescript": "5.1.6"

--- a/packages/hwk-trezor-connector/package.json
+++ b/packages/hwk-trezor-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "description": "Shared Trezor connector base for Hardware Wallet Kit",
   "author": "OneKey",
   "license": "MIT",
@@ -38,13 +38,13 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.1"
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.2"
   },
   "devDependencies": {
-    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.1",
+    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.2",
     "rimraf": "^5.0.0",
     "tsup": "^8.0.0",
     "typescript": "5.1.6"

--- a/packages/hwk-trezor-connector/package.json
+++ b/packages/hwk-trezor-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-connector",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "description": "Shared Trezor connector base for Hardware Wallet Kit",
   "author": "OneKey",
   "license": "MIT",
@@ -38,13 +38,13 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.3"
+    "@onekeyfe/hwk-adapter-core": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-core": "1.2.2-alpha.4"
   },
   "devDependencies": {
-    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.4",
     "rimraf": "^5.0.0",
     "tsup": "^8.0.0",
     "typescript": "5.1.6"

--- a/packages/hwk-trezor-core/package.json
+++ b/packages/hwk-trezor-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-core",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "description": "Minimal Trezor core call layer for Hardware Wallet Kit",
   "author": "OneKey",
   "license": "MIT",
@@ -41,10 +41,10 @@
   "devDependencies": {
     "@noble/ciphers": "^1.3.0",
     "@noble/hashes": "^1.8.0",
-    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.5",
     "buffer": "^6.0.3",
     "rimraf": "^5.0.0",
     "tsup": "^8.0.0",

--- a/packages/hwk-trezor-core/package.json
+++ b/packages/hwk-trezor-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-core",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "description": "Minimal Trezor core call layer for Hardware Wallet Kit",
   "author": "OneKey",
   "license": "MIT",
@@ -41,10 +41,10 @@
   "devDependencies": {
     "@noble/ciphers": "^1.3.0",
     "@noble/hashes": "^1.8.0",
-    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.6",
     "buffer": "^6.0.3",
     "rimraf": "^5.0.0",
     "tsup": "^8.0.0",

--- a/packages/hwk-trezor-core/package.json
+++ b/packages/hwk-trezor-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-core",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "description": "Minimal Trezor core call layer for Hardware Wallet Kit",
   "author": "OneKey",
   "license": "MIT",
@@ -41,10 +41,10 @@
   "devDependencies": {
     "@noble/ciphers": "^1.3.0",
     "@noble/hashes": "^1.8.0",
-    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.3",
     "buffer": "^6.0.3",
     "rimraf": "^5.0.0",
     "tsup": "^8.0.0",

--- a/packages/hwk-trezor-core/package.json
+++ b/packages/hwk-trezor-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-core",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "description": "Minimal Trezor core call layer for Hardware Wallet Kit",
   "author": "OneKey",
   "license": "MIT",
@@ -41,10 +41,10 @@
   "devDependencies": {
     "@noble/ciphers": "^1.3.0",
     "@noble/hashes": "^1.8.0",
-    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.4",
     "buffer": "^6.0.3",
     "rimraf": "^5.0.0",
     "tsup": "^8.0.0",

--- a/packages/hwk-trezor-core/package.json
+++ b/packages/hwk-trezor-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-core",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "description": "Minimal Trezor core call layer for Hardware Wallet Kit",
   "author": "OneKey",
   "license": "MIT",
@@ -41,10 +41,10 @@
   "devDependencies": {
     "@noble/ciphers": "^1.3.0",
     "@noble/hashes": "^1.8.0",
-    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.1",
+    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-transport": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.2",
     "buffer": "^6.0.3",
     "rimraf": "^5.0.0",
     "tsup": "^8.0.0",

--- a/packages/hwk-trezor-protobuf/package.json
+++ b/packages/hwk-trezor-protobuf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-protobuf",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "private": true,
   "description": "Trezor protobuf helpers vendored from Trezor Suite MIT sources",
   "author": "OneKey",
@@ -50,7 +50,7 @@
   "sideEffects": false,
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
-    "@onekeyfe/hwk-trezor-schema-utils": "1.2.2-alpha.5"
+    "@onekeyfe/hwk-trezor-schema-utils": "1.2.2-alpha.6"
   },
   "devDependencies": {
     "rimraf": "^5.0.0",

--- a/packages/hwk-trezor-protobuf/package.json
+++ b/packages/hwk-trezor-protobuf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-protobuf",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "private": true,
   "description": "Trezor protobuf helpers vendored from Trezor Suite MIT sources",
   "author": "OneKey",
@@ -50,7 +50,7 @@
   "sideEffects": false,
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
-    "@onekeyfe/hwk-trezor-schema-utils": "1.2.2-alpha.4"
+    "@onekeyfe/hwk-trezor-schema-utils": "1.2.2-alpha.5"
   },
   "devDependencies": {
     "rimraf": "^5.0.0",

--- a/packages/hwk-trezor-protobuf/package.json
+++ b/packages/hwk-trezor-protobuf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-protobuf",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "private": true,
   "description": "Trezor protobuf helpers vendored from Trezor Suite MIT sources",
   "author": "OneKey",
@@ -50,7 +50,7 @@
   "sideEffects": false,
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
-    "@onekeyfe/hwk-trezor-schema-utils": "1.2.2-alpha.2"
+    "@onekeyfe/hwk-trezor-schema-utils": "1.2.2-alpha.3"
   },
   "devDependencies": {
     "rimraf": "^5.0.0",

--- a/packages/hwk-trezor-protobuf/package.json
+++ b/packages/hwk-trezor-protobuf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-protobuf",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "private": true,
   "description": "Trezor protobuf helpers vendored from Trezor Suite MIT sources",
   "author": "OneKey",
@@ -50,7 +50,7 @@
   "sideEffects": false,
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
-    "@onekeyfe/hwk-trezor-schema-utils": "1.2.2-alpha.3"
+    "@onekeyfe/hwk-trezor-schema-utils": "1.2.2-alpha.4"
   },
   "devDependencies": {
     "rimraf": "^5.0.0",

--- a/packages/hwk-trezor-protobuf/package.json
+++ b/packages/hwk-trezor-protobuf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-protobuf",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "private": true,
   "description": "Trezor protobuf helpers vendored from Trezor Suite MIT sources",
   "author": "OneKey",
@@ -50,7 +50,7 @@
   "sideEffects": false,
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
-    "@onekeyfe/hwk-trezor-schema-utils": "1.2.2-alpha.1"
+    "@onekeyfe/hwk-trezor-schema-utils": "1.2.2-alpha.2"
   },
   "devDependencies": {
     "rimraf": "^5.0.0",

--- a/packages/hwk-trezor-protocol/package.json
+++ b/packages/hwk-trezor-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-protocol",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "private": true,
   "description": "Trezor transport protocol helpers vendored from Trezor Suite MIT sources",
   "author": "OneKey",

--- a/packages/hwk-trezor-protocol/package.json
+++ b/packages/hwk-trezor-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-protocol",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "private": true,
   "description": "Trezor transport protocol helpers vendored from Trezor Suite MIT sources",
   "author": "OneKey",

--- a/packages/hwk-trezor-protocol/package.json
+++ b/packages/hwk-trezor-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-protocol",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "private": true,
   "description": "Trezor transport protocol helpers vendored from Trezor Suite MIT sources",
   "author": "OneKey",

--- a/packages/hwk-trezor-protocol/package.json
+++ b/packages/hwk-trezor-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-protocol",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "private": true,
   "description": "Trezor transport protocol helpers vendored from Trezor Suite MIT sources",
   "author": "OneKey",

--- a/packages/hwk-trezor-protocol/package.json
+++ b/packages/hwk-trezor-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-protocol",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "private": true,
   "description": "Trezor transport protocol helpers vendored from Trezor Suite MIT sources",
   "author": "OneKey",

--- a/packages/hwk-trezor-schema-utils/package.json
+++ b/packages/hwk-trezor-schema-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-schema-utils",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "private": true,
   "description": "Schema helpers vendored from Trezor Suite MIT sources for HWK Trezor support",
   "author": "OneKey",
@@ -44,8 +44,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.5",
     "@sinclair/typebox": "^0.34.49",
     "ts-mixer": "^6.0.4"
   },

--- a/packages/hwk-trezor-schema-utils/package.json
+++ b/packages/hwk-trezor-schema-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-schema-utils",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "private": true,
   "description": "Schema helpers vendored from Trezor Suite MIT sources for HWK Trezor support",
   "author": "OneKey",
@@ -44,8 +44,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.6",
     "@sinclair/typebox": "^0.34.49",
     "ts-mixer": "^6.0.4"
   },

--- a/packages/hwk-trezor-schema-utils/package.json
+++ b/packages/hwk-trezor-schema-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-schema-utils",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "private": true,
   "description": "Schema helpers vendored from Trezor Suite MIT sources for HWK Trezor support",
   "author": "OneKey",
@@ -44,8 +44,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.1",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.2",
     "@sinclair/typebox": "^0.34.49",
     "ts-mixer": "^6.0.4"
   },

--- a/packages/hwk-trezor-schema-utils/package.json
+++ b/packages/hwk-trezor-schema-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-schema-utils",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "private": true,
   "description": "Schema helpers vendored from Trezor Suite MIT sources for HWK Trezor support",
   "author": "OneKey",
@@ -44,8 +44,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.3",
     "@sinclair/typebox": "^0.34.49",
     "ts-mixer": "^6.0.4"
   },

--- a/packages/hwk-trezor-schema-utils/package.json
+++ b/packages/hwk-trezor-schema-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-schema-utils",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "private": true,
   "description": "Schema helpers vendored from Trezor Suite MIT sources for HWK Trezor support",
   "author": "OneKey",
@@ -44,8 +44,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.4",
     "@sinclair/typebox": "^0.34.49",
     "ts-mixer": "^6.0.4"
   },

--- a/packages/hwk-trezor-transport-common/package.json
+++ b/packages/hwk-trezor-transport-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-transport-common",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "private": true,
   "description": "Environment-agnostic Trezor transport abstractions vendored from Trezor Suite MIT sources: types, errors, abstract base classes, structural USB interface, sessions backend, THP, utils",
   "author": "OneKey",
@@ -39,10 +39,10 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.5"
+    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.6"
   },
   "devDependencies": {
     "rimraf": "^5.0.0",

--- a/packages/hwk-trezor-transport-common/package.json
+++ b/packages/hwk-trezor-transport-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-transport-common",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "private": true,
   "description": "Environment-agnostic Trezor transport abstractions vendored from Trezor Suite MIT sources: types, errors, abstract base classes, structural USB interface, sessions backend, THP, utils",
   "author": "OneKey",
@@ -39,10 +39,10 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.4"
+    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.5"
   },
   "devDependencies": {
     "rimraf": "^5.0.0",

--- a/packages/hwk-trezor-transport-common/package.json
+++ b/packages/hwk-trezor-transport-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-transport-common",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "private": true,
   "description": "Environment-agnostic Trezor transport abstractions vendored from Trezor Suite MIT sources: types, errors, abstract base classes, structural USB interface, sessions backend, THP, utils",
   "author": "OneKey",
@@ -39,10 +39,10 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.3"
+    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.4"
   },
   "devDependencies": {
     "rimraf": "^5.0.0",

--- a/packages/hwk-trezor-transport-common/package.json
+++ b/packages/hwk-trezor-transport-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-transport-common",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "private": true,
   "description": "Environment-agnostic Trezor transport abstractions vendored from Trezor Suite MIT sources: types, errors, abstract base classes, structural USB interface, sessions backend, THP, utils",
   "author": "OneKey",
@@ -39,10 +39,10 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.2"
+    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.3"
   },
   "devDependencies": {
     "rimraf": "^5.0.0",

--- a/packages/hwk-trezor-transport-common/package.json
+++ b/packages/hwk-trezor-transport-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-transport-common",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "private": true,
   "description": "Environment-agnostic Trezor transport abstractions vendored from Trezor Suite MIT sources: types, errors, abstract base classes, structural USB interface, sessions backend, THP, utils",
   "author": "OneKey",
@@ -39,10 +39,10 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.1"
+    "@onekeyfe/hwk-trezor-protobuf": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.2"
   },
   "devDependencies": {
     "rimraf": "^5.0.0",

--- a/packages/hwk-trezor-transport-web/package.json
+++ b/packages/hwk-trezor-transport-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-transport-web",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "private": true,
   "description": "Browser-only Trezor transports vendored from Trezor Suite MIT sources: WebUSB and SharedWorker-backed sessions backend",
   "author": "OneKey",
@@ -39,7 +39,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.4"
+    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.5"
   },
   "devDependencies": {
     "@types/sharedworker": "^0.0.223",

--- a/packages/hwk-trezor-transport-web/package.json
+++ b/packages/hwk-trezor-transport-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-transport-web",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "private": true,
   "description": "Browser-only Trezor transports vendored from Trezor Suite MIT sources: WebUSB and SharedWorker-backed sessions backend",
   "author": "OneKey",
@@ -39,7 +39,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.5"
+    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.6"
   },
   "devDependencies": {
     "@types/sharedworker": "^0.0.223",

--- a/packages/hwk-trezor-transport-web/package.json
+++ b/packages/hwk-trezor-transport-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-transport-web",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "private": true,
   "description": "Browser-only Trezor transports vendored from Trezor Suite MIT sources: WebUSB and SharedWorker-backed sessions backend",
   "author": "OneKey",
@@ -39,7 +39,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.3"
+    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.4"
   },
   "devDependencies": {
     "@types/sharedworker": "^0.0.223",

--- a/packages/hwk-trezor-transport-web/package.json
+++ b/packages/hwk-trezor-transport-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-transport-web",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "private": true,
   "description": "Browser-only Trezor transports vendored from Trezor Suite MIT sources: WebUSB and SharedWorker-backed sessions backend",
   "author": "OneKey",
@@ -39,7 +39,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.2"
+    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.3"
   },
   "devDependencies": {
     "@types/sharedworker": "^0.0.223",

--- a/packages/hwk-trezor-transport-web/package.json
+++ b/packages/hwk-trezor-transport-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-transport-web",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "private": true,
   "description": "Browser-only Trezor transports vendored from Trezor Suite MIT sources: WebUSB and SharedWorker-backed sessions backend",
   "author": "OneKey",
@@ -39,7 +39,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.1"
+    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.2"
   },
   "devDependencies": {
     "@types/sharedworker": "^0.0.223",

--- a/packages/hwk-trezor-transport/package.json
+++ b/packages/hwk-trezor-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-transport",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "private": true,
   "description": "Low-level Trezor transport helpers vendored from Trezor Suite MIT sources",
   "author": "OneKey",
@@ -49,10 +49,10 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.4",
-    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.5",
     "cross-fetch": "^4.1.0",
     "usb": "^2.17.0"
   },

--- a/packages/hwk-trezor-transport/package.json
+++ b/packages/hwk-trezor-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-transport",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "private": true,
   "description": "Low-level Trezor transport helpers vendored from Trezor Suite MIT sources",
   "author": "OneKey",
@@ -49,10 +49,10 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.5",
-    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.6",
+    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.6",
     "cross-fetch": "^4.1.0",
     "usb": "^2.17.0"
   },

--- a/packages/hwk-trezor-transport/package.json
+++ b/packages/hwk-trezor-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-transport",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "private": true,
   "description": "Low-level Trezor transport helpers vendored from Trezor Suite MIT sources",
   "author": "OneKey",
@@ -49,10 +49,10 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.2",
-    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.3",
     "cross-fetch": "^4.1.0",
     "usb": "^2.17.0"
   },

--- a/packages/hwk-trezor-transport/package.json
+++ b/packages/hwk-trezor-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-transport",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "private": true,
   "description": "Low-level Trezor transport helpers vendored from Trezor Suite MIT sources",
   "author": "OneKey",
@@ -49,10 +49,10 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.3",
-    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.4",
     "cross-fetch": "^4.1.0",
     "usb": "^2.17.0"
   },

--- a/packages/hwk-trezor-transport/package.json
+++ b/packages/hwk-trezor-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-transport",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "private": true,
   "description": "Low-level Trezor transport helpers vendored from Trezor Suite MIT sources",
   "author": "OneKey",
@@ -49,10 +49,10 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.1",
-    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.1",
+    "@onekeyfe/hwk-trezor-protocol": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-transport-common": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-utils": "1.2.2-alpha.2",
     "cross-fetch": "^4.1.0",
     "usb": "^2.17.0"
   },

--- a/packages/hwk-trezor-type-utils/package.json
+++ b/packages/hwk-trezor-type-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-type-utils",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "private": true,
   "description": "Type helpers vendored from Trezor Suite MIT sources for HWK Trezor support",
   "author": "OneKey",

--- a/packages/hwk-trezor-type-utils/package.json
+++ b/packages/hwk-trezor-type-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-type-utils",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "private": true,
   "description": "Type helpers vendored from Trezor Suite MIT sources for HWK Trezor support",
   "author": "OneKey",

--- a/packages/hwk-trezor-type-utils/package.json
+++ b/packages/hwk-trezor-type-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-type-utils",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "private": true,
   "description": "Type helpers vendored from Trezor Suite MIT sources for HWK Trezor support",
   "author": "OneKey",

--- a/packages/hwk-trezor-type-utils/package.json
+++ b/packages/hwk-trezor-type-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-type-utils",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "private": true,
   "description": "Type helpers vendored from Trezor Suite MIT sources for HWK Trezor support",
   "author": "OneKey",

--- a/packages/hwk-trezor-type-utils/package.json
+++ b/packages/hwk-trezor-type-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-type-utils",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "private": true,
   "description": "Type helpers vendored from Trezor Suite MIT sources for HWK Trezor support",
   "author": "OneKey",

--- a/packages/hwk-trezor-utils/package.json
+++ b/packages/hwk-trezor-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-utils",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "private": true,
   "description": "Utility helpers vendored from Trezor Suite MIT sources for HWK Trezor support",
   "author": "OneKey",
@@ -39,7 +39,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.5",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.6",
     "bignumber.js": "^11.1.2",
     "events": "^3.3.0"
   },

--- a/packages/hwk-trezor-utils/package.json
+++ b/packages/hwk-trezor-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-utils",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "private": true,
   "description": "Utility helpers vendored from Trezor Suite MIT sources for HWK Trezor support",
   "author": "OneKey",
@@ -39,7 +39,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.4",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.5",
     "bignumber.js": "^11.1.2",
     "events": "^3.3.0"
   },

--- a/packages/hwk-trezor-utils/package.json
+++ b/packages/hwk-trezor-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-utils",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "private": true,
   "description": "Utility helpers vendored from Trezor Suite MIT sources for HWK Trezor support",
   "author": "OneKey",
@@ -39,7 +39,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.1",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.2",
     "bignumber.js": "^11.1.2",
     "events": "^3.3.0"
   },

--- a/packages/hwk-trezor-utils/package.json
+++ b/packages/hwk-trezor-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-utils",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "private": true,
   "description": "Utility helpers vendored from Trezor Suite MIT sources for HWK Trezor support",
   "author": "OneKey",
@@ -39,7 +39,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.2",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.3",
     "bignumber.js": "^11.1.2",
     "events": "^3.3.0"
   },

--- a/packages/hwk-trezor-utils/package.json
+++ b/packages/hwk-trezor-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hwk-trezor-utils",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "private": true,
   "description": "Utility helpers vendored from Trezor Suite MIT sources for HWK Trezor support",
   "author": "OneKey",
@@ -39,7 +39,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.3",
+    "@onekeyfe/hwk-trezor-type-utils": "1.2.2-alpha.4",
     "bignumber.js": "^11.1.2",
     "events": "^3.3.0"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.2.2-alpha.5",
+  "version": "1.2.2-alpha.6",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.2.2-alpha.4",
+  "version": "1.2.2-alpha.5",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.2.2-alpha.2",
+  "version": "1.2.2-alpha.3",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.2.2-alpha.3",
+  "version": "1.2.2-alpha.4",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/hd-shared",
-  "version": "1.2.2-alpha.1",
+  "version": "1.2.2-alpha.2",
   "description": "Hardware SDK's shared tool library",
   "keywords": [
     "Hardware-SDK",


### PR DESCRIPTION
## Summary

Protocol V2 wallet sessions follow firmware `origin/dev` (`f83f38bb6`). `DeviceSessionAskPassphrase.seed_domains` owns derivation. `DeviceSessionGet` is read/resume only and must not send field 3.

This also restores Pro1 Attach PIN product behavior: `select-hidden` while Attach PIN is unlocked reuses the current session. It does not lock and does not open the passphrase picker.

## Intent and context

origin/dev rejects unknown `DeviceSessionGet` field 3. Cardano must be requested on AskPassphrase. Attach PIN has no host passphrase, so Cardano uses an empty host Ask on the current SE session.

`+ Hidden wallet` while Attach PIN is unlocked is not a PIN mismatch. Pro1 returns the current Attach PIN wallet. The App shows the green "Wallet exists" toast only when that wallet is already in local DB.

## Root cause

- Sending `Get.seed_domains` fails on origin/dev.
- A real passphrase Ask on an Attach PIN session starts `SESSION_NEW` / can fail on SE.
- Treating `select-hidden` + Attach PIN as `DeviceCheckUnlockTypeError` mapped to "The entered PIN does not correspond to the current wallet." That copy is wrong for this path.

## Design decisions

- **AskPassphrase** sends `[Standard]` on wallet open; Cardano sends `[Standard, Cardano]`. Never send `[]`.
- **Get** carries only `session_id` / `btc_test_address`.
- **Attach PIN Cardano**: empty host `AskPassphrase({ passphrase: '', on_device: false, seed_domains: [Standard, Cardano] })` then `Get()`. Empty host Ask does not open the passphrase UI. Firmware must GEN Cardano in place and keep `unlocked_by_attach_to_pin`.
- **Passphrase hidden + Cardano**: extra Cardano still needs a **real** passphrase Ask, even if the device is still unlocked. origin/dev memzeros the secret after GEN, so Get cannot add Icarus later. This is expected, not a lock-state bug.
- **Passphrase off**: firmware Get auto-requests Cardano; SDK may send a second `Get()` if the first response is Standard-only. Do not AskPassphrase (firmware returns PassphraseDisabled).
- **`select-hidden` + Attach PIN unlocked**: `readCurrentAttachPinSession`. Reuse the current wallet. Do not `lockDevice`. Do not show the passphrase picker.
- **`standard` / `useEmptyPassphrase` while Attach PIN unlocked**: still `lockDevice` + `DeviceCheckUnlockTypeError` (wrong PIN type).
- **`forceWalletSelection` while Attach PIN unlocked**: still lock before the passphrase picker (cannot Ask a new passphrase on the Attach PIN session).
- `openWalletSession` does not thread `CommonParams.deriveCardano`.

## Compatibility and risk

- Targets `origin/dev` firmware. No old-firmware compatibility. No Get.seed_domains.
- Submodule: `submodules/firmware-pro2` @ `f83f38bb6`.
- Attach PIN empty-Ask Cardano also needs the matching firmware change (empty Ask on Attach PIN → current session GEN_CARDANO, do not `SESSION_NEW`, do not clear attach-pin). That firmware change is a separate PR on `wabicai/firmware-pro2`.

## Hardware coverage

- Live origin/dev Pro2: empty AskPassphrase after Attach PIN returned Cardano without UI (with local firmware).
- `select-hidden` reuse of Attach PIN covered by `packages/core` tests.

## Test plan

- [x] `packages/core` wallet-session / protocol-v2 tests (`open-wallet-session.test.ts`, 74 passed)
- [x] `select-hidden` reuses current Attach PIN session
- [x] empty AskPassphrase adds Cardano on Attach PIN without passphrase UI
- [x] standard / forceWalletSelection from Attach PIN still locks
- [ ] Desktop currently binds npm `@onekeyfe/hd-core@1.2.2-alpha.5`; unpublished SDK is not what the running App loads until that is updated
