### PR TITLE
refactor: restore 1.1.32-style CALL_API logging

### DIFF
--- a/packages/core/__tests__/logBlockEvent.test.ts
+++ b/packages/core/__tests__/logBlockEvent.test.ts
@@ -130,7 +130,7 @@ describe('getLogBlockLabel', () => {
   );
 
   it.each(['evmSignMessage', 'btcSignMessage', 'evmSignTransaction'])(
-    'blocks request and response payload logging for signing method %s',
+    'identifies signing method %s for safe logging',
     method => {
       expect(getLogBlockLabel({ method, message: 'sensitive signing payload' })).toBe(method);
       expect(
@@ -141,6 +141,241 @@ describe('getLogBlockLabel', () => {
       ).toBe(method);
     }
   );
+
+  it('reveals signing request fields in debug logs while redacting red-line secrets', () => {
+    const request = {
+      event: 'iframe-call',
+      type: 'iframe-call',
+      payload: {
+        method: 'btcSignMessage',
+        path: "m/44'/0'/0'/0/0",
+        messageHex: '68656c6c6f',
+        noScriptType: true,
+        coin: 'Bitcoin',
+        passphraseState: 'wallet-identifier-for-qa',
+        useEmptyPassphrase: false,
+        keepSession: true,
+        initSession: false,
+        passphrase: 'hidden-wallet-secret',
+        private_key: 'private-key-secret',
+        privateKeyHex: 'private-key-hex-secret',
+        mnemonic: 'mnemonic-secret',
+        nested: {
+          apiKey: 'api-key-secret',
+          sessionId: 'session-secret',
+        },
+        accounts: [
+          {
+            seed: 'seed-secret',
+            xprv: 'xprv-secret',
+            entropy: 'entropy-secret',
+            password: 'password-secret',
+            token: 'token-secret',
+            credential: 'credential-secret',
+            pin: 'pin-secret',
+            accessToken: 'access-token-secret',
+            auth_token: 'auth-token-secret',
+            bearerToken: 'bearer-token-secret',
+            'refresh-token': 'refresh-token-secret',
+            secret: 'generic-secret',
+            words: 'recovery-words',
+          },
+        ],
+      },
+    };
+
+    expect(getSafeLogPayload(request, 'btcSignMessage', { revealSigningPayload: true })).toEqual({
+      event: 'iframe-call',
+      type: 'iframe-call',
+      payload: {
+        method: 'btcSignMessage',
+        path: "m/44'/0'/0'/0/0",
+        messageHex: '68656c6c6f',
+        noScriptType: true,
+        coin: 'Bitcoin',
+        passphraseState: 'wallet-identifier-for-qa',
+        useEmptyPassphrase: false,
+        keepSession: true,
+        initSession: false,
+        passphrase: '[REDACTED]',
+        private_key: '[REDACTED]',
+        privateKeyHex: '[REDACTED]',
+        mnemonic: '[REDACTED]',
+        nested: {
+          apiKey: '[REDACTED]',
+          sessionId: '[REDACTED]',
+        },
+        accounts: [
+          {
+            seed: '[REDACTED]',
+            xprv: '[REDACTED]',
+            entropy: '[REDACTED]',
+            password: '[REDACTED]',
+            token: '[REDACTED]',
+            credential: '[REDACTED]',
+            pin: '[REDACTED]',
+            accessToken: '[REDACTED]',
+            auth_token: '[REDACTED]',
+            bearerToken: '[REDACTED]',
+            'refresh-token': '[REDACTED]',
+            secret: '[REDACTED]',
+            words: '[REDACTED]',
+          },
+        ],
+      },
+    });
+  });
+
+  it('keeps signing request payloads blocked when debug reveal is not requested', () => {
+    expect(
+      getSafeLogPayload({ method: 'btcSignMessage', messageHex: '68656c6c6f' }, 'btcSignMessage')
+    ).toEqual({
+      method: 'btcSignMessage',
+      payload: '[REDACTED]',
+    });
+  });
+
+  it('handles circular arrays in debug signing payloads', () => {
+    const accounts: unknown[] = [{ secret: 'generic-secret' }];
+    accounts.push(accounts);
+
+    expect(
+      getSafeLogPayload({ method: 'btcSignMessage', accounts }, 'btcSignMessage', {
+        revealSigningPayload: true,
+      })
+    ).toEqual({
+      method: 'btcSignMessage',
+      accounts: [{ secret: '[REDACTED]' }, '[CIRCULAR]'],
+    });
+  });
+
+  it('keeps safe signing request metadata visible without debug reveal', () => {
+    expect(
+      getSafeLogPayload(
+        {
+          event: 'iframe-call',
+          payload: {
+            method: 'evmSignTransaction',
+            path: "m/44'/60'/0'/0/0",
+            transaction: {
+              chainId: 1,
+              txType: 2,
+              to: '0xrecipient',
+              data: '0xcontract-call-data',
+            },
+          },
+        },
+        'evmSignTransaction'
+      )
+    ).toEqual({
+      method: 'evmSignTransaction',
+      chainId: 1,
+      transactionType: 2,
+    });
+
+    expect(
+      getSafeLogPayload(
+        {
+          method: 'btcSignTransaction',
+          coin: 'Bitcoin',
+          inputs: [{ prev_hash: 'input-1' }, { prev_hash: 'input-2' }],
+          outputs: [{ address: 'recipient' }],
+          refTxs: [{ hash: 'previous-transaction' }],
+        },
+        'btcSignTransaction'
+      )
+    ).toEqual({
+      method: 'btcSignTransaction',
+      coin: 'Bitcoin',
+      inputCount: 2,
+      outputCount: 1,
+    });
+  });
+
+  it('keeps signing success responses minimal', () => {
+    expect(
+      getSafeLogPayload(
+        {
+          success: true,
+          payload: {
+            signature: 'signature-secret',
+            address: 'address-for-wallet-correlation',
+          },
+        },
+        'btcSignMessage',
+        { revealSigningPayload: true }
+      )
+    ).toEqual({
+      method: 'btcSignMessage',
+      success: true,
+    });
+  });
+
+  it('keeps the original SDK signing error while omitting error params', () => {
+    expect(
+      getSafeLogPayload(
+        {
+          success: false,
+          payload: {
+            code: 'DeviceBusy',
+            error: 'Original SDK device error',
+            params: {
+              connectId: 'connect-id',
+              deviceId: 'device-id',
+              passphrase: 'hidden-wallet-secret',
+            },
+          },
+        },
+        'btcSignMessage',
+        { revealSigningPayload: true }
+      )
+    ).toEqual({
+      method: 'btcSignMessage',
+      success: false,
+      code: 'DeviceBusy',
+      error: 'Original SDK device error',
+    });
+  });
+
+  it('does not serialize non-string signing error values', () => {
+    expect(
+      getSafeLogPayload(
+        {
+          success: false,
+          payload: {
+            code: 500,
+            error: { passphrase: 'hidden-wallet-secret' },
+          },
+        },
+        'btcSignMessage'
+      )
+    ).toEqual({
+      method: 'btcSignMessage',
+      success: false,
+      code: 500,
+    });
+  });
+
+  it('never reveals sensitive UI or resource upload payloads through debug logging', () => {
+    expect(
+      getSafeLogPayload(
+        { type: UI_RESPONSE.RECEIVE_PIN, payload: '1234' },
+        UI_RESPONSE.RECEIVE_PIN,
+        { revealSigningPayload: true }
+      )
+    ).toEqual({
+      method: UI_RESPONSE.RECEIVE_PIN,
+      payload: '[REDACTED]',
+    });
+    expect(
+      getSafeLogPayload({ method: 'deviceUploadNft', data: 'large-base64' }, 'deviceUploadNft', {
+        revealSigningPayload: true,
+      })
+    ).toEqual({
+      method: 'deviceUploadNft',
+      payload: '[REDACTED]',
+    });
+  });
 
   it('keeps ordinary API requests and responses visible', () => {
     const request = { method: 'getDeviceState', connectId: 'connect-id', scope: 'runtime' };

--- a/packages/core/__tests__/logBlockEvent.test.ts
+++ b/packages/core/__tests__/logBlockEvent.test.ts
@@ -6,6 +6,8 @@ import {
   getSafeLogPayload,
 } from '../src/events';
 
+const debugSigning = { revealSigningPayload: true };
+
 describe('getLogBlockLabel', () => {
   it('blocks evmSignTypedData params before logging large typed data', () => {
     expect(
@@ -142,51 +144,67 @@ describe('getLogBlockLabel', () => {
     }
   );
 
-  it('reveals signing request fields in debug logs while redacting red-line secrets', () => {
-    const request = {
-      event: 'iframe-call',
-      type: 'iframe-call',
-      payload: {
-        method: 'btcSignMessage',
-        path: "m/44'/0'/0'/0/0",
-        messageHex: '68656c6c6f',
-        noScriptType: true,
-        coin: 'Bitcoin',
-        passphraseState: 'wallet-identifier-for-qa',
-        useEmptyPassphrase: false,
-        keepSession: true,
-        initSession: false,
-        passphrase: 'hidden-wallet-secret',
-        private_key: 'private-key-secret',
-        privateKeyHex: 'private-key-hex-secret',
-        mnemonic: 'mnemonic-secret',
-        nested: {
-          apiKey: 'api-key-secret',
-          session: 'session-secret',
-          sessionId: 'session-id',
-          walletSessionId: 'wallet-session-id',
-        },
-        accounts: [
-          {
-            seed: 'seed-secret',
-            xprv: 'xprv-secret',
-            entropy: 'entropy-secret',
-            password: 'password-secret',
-            token: 'token-secret',
-            credential: 'credential-secret',
-            pin: 'pin-secret',
-            accessToken: 'access-token-secret',
-            auth_token: 'auth-token-secret',
-            bearerToken: 'bearer-token-secret',
-            'refresh-token': 'refresh-token-secret',
-            secret: 'generic-secret',
-            words: 'recovery-words',
-          },
-        ],
-      },
-    };
+  it('keeps ordinary API requests and responses visible', () => {
+    const request = { method: 'getDeviceState', connectId: 'connect-id', scope: 'runtime' };
+    const response = { success: true, payload: { protocol: 'V2', initialized: true } };
 
-    expect(getSafeLogPayload(request, 'btcSignMessage', { revealSigningPayload: true })).toEqual({
+    expect(getLogBlockLabel(request)).toBeUndefined();
+    expect(getSafeLogPayload(request)).toEqual(request);
+    expect(getSafeLogPayload(response)).toEqual(response);
+  });
+
+  it('redacts sensitive keys even for ordinary API payloads', () => {
+    expect(
+      getSafeLogPayload({
+        method: 'ordinaryMethod',
+        payload: { session_id: 'session-secret', nested: { pin: '1234' } },
+      })
+    ).toEqual({
+      method: 'ordinaryMethod',
+      payload: { session_id: '[REDACTED]', nested: { pin: '[REDACTED]' } },
+    });
+  });
+
+  it('puts sensitive API method names in the log label', () => {
+    expect(formatLogMethodLabel('response:', 'openWalletSession')).toBe(
+      'response: [openWalletSession]'
+    );
+    expect(formatLogMethodLabel('response:')).toBe('response:');
+  });
+
+  it('does not classify events without an API method as method calls', () => {
+    expect(getLogBlockLabel({ event: 'DEVICE_EVENT', type: 'device-connect' })).toBeUndefined();
+  });
+});
+
+describe('signing log payloads', () => {
+  it('reveals signing request fields in debug logs', () => {
+    expect(
+      getSafeLogPayload(
+        {
+          event: 'iframe-call',
+          type: 'iframe-call',
+          payload: {
+            method: 'btcSignMessage',
+            path: "m/44'/0'/0'/0/0",
+            messageHex: '68656c6c6f',
+            noScriptType: true,
+            coin: 'Bitcoin',
+            passphraseState: 'wallet-identifier-for-qa',
+            useEmptyPassphrase: false,
+            keepSession: true,
+            initSession: false,
+            nested: {
+              session: 'session-secret',
+              sessionId: 'session-id',
+              walletSessionId: 'wallet-session-id',
+            },
+          },
+        },
+        'btcSignMessage',
+        debugSigning
+      )
+    ).toEqual({
       event: 'iframe-call',
       type: 'iframe-call',
       payload: {
@@ -199,34 +217,45 @@ describe('getLogBlockLabel', () => {
         useEmptyPassphrase: false,
         keepSession: true,
         initSession: false,
-        passphrase: '[REDACTED]',
-        private_key: '[REDACTED]',
-        privateKeyHex: '[REDACTED]',
-        mnemonic: '[REDACTED]',
         nested: {
-          apiKey: '[REDACTED]',
           session: '[REDACTED]',
           sessionId: 'session-id',
           walletSessionId: 'wallet-session-id',
         },
-        accounts: [
-          {
-            seed: '[REDACTED]',
-            xprv: '[REDACTED]',
-            entropy: '[REDACTED]',
-            password: '[REDACTED]',
-            token: '[REDACTED]',
-            credential: '[REDACTED]',
-            pin: '[REDACTED]',
-            accessToken: '[REDACTED]',
-            auth_token: '[REDACTED]',
-            bearerToken: '[REDACTED]',
-            'refresh-token': '[REDACTED]',
-            secret: '[REDACTED]',
-            words: '[REDACTED]',
-          },
-        ],
       },
+    });
+  });
+
+  it.each([
+    'accessToken',
+    'apiKey',
+    'auth_token',
+    'bearerToken',
+    'credential',
+    'entropy',
+    'mnemonic',
+    'passphrase',
+    'password',
+    'pin',
+    'privateKeyHex',
+    'private_key',
+    'refresh-token',
+    'secret',
+    'seed',
+    'session',
+    'token',
+    'words',
+    'xprv',
+  ])('redacts %s in debug signing logs', key => {
+    expect(
+      getSafeLogPayload(
+        { method: 'btcSignMessage', [key]: 'secret-value' },
+        'btcSignMessage',
+        debugSigning
+      )
+    ).toEqual({
+      method: 'btcSignMessage',
+      [key]: '[REDACTED]',
     });
   });
 
@@ -244,9 +273,7 @@ describe('getLogBlockLabel', () => {
     accounts.push(accounts);
 
     expect(
-      getSafeLogPayload({ method: 'btcSignMessage', accounts }, 'btcSignMessage', {
-        revealSigningPayload: true,
-      })
+      getSafeLogPayload({ method: 'btcSignMessage', accounts }, 'btcSignMessage', debugSigning)
     ).toEqual({
       method: 'btcSignMessage',
       accounts: [{ secret: '[REDACTED]' }, '[CIRCULAR]'],
@@ -307,7 +334,7 @@ describe('getLogBlockLabel', () => {
           },
         },
         'btcSignMessage',
-        { revealSigningPayload: true }
+        debugSigning
       )
     ).toEqual({
       method: 'btcSignMessage',
@@ -331,7 +358,7 @@ describe('getLogBlockLabel', () => {
           },
         },
         'btcSignMessage',
-        { revealSigningPayload: true }
+        debugSigning
       )
     ).toEqual({
       method: 'btcSignMessage',
@@ -365,51 +392,21 @@ describe('getLogBlockLabel', () => {
       getSafeLogPayload(
         { type: UI_RESPONSE.RECEIVE_PIN, payload: '1234' },
         UI_RESPONSE.RECEIVE_PIN,
-        { revealSigningPayload: true }
+        debugSigning
       )
     ).toEqual({
       method: UI_RESPONSE.RECEIVE_PIN,
       payload: '[REDACTED]',
     });
     expect(
-      getSafeLogPayload({ method: 'deviceUploadNft', data: 'large-base64' }, 'deviceUploadNft', {
-        revealSigningPayload: true,
-      })
+      getSafeLogPayload(
+        { method: 'deviceUploadNft', data: 'large-base64' },
+        'deviceUploadNft',
+        debugSigning
+      )
     ).toEqual({
       method: 'deviceUploadNft',
       payload: '[REDACTED]',
     });
-  });
-
-  it('keeps ordinary API requests and responses visible', () => {
-    const request = { method: 'getDeviceState', connectId: 'connect-id', scope: 'runtime' };
-    const response = { success: true, payload: { protocol: 'V2', initialized: true } };
-
-    expect(getLogBlockLabel(request)).toBeUndefined();
-    expect(getSafeLogPayload(request)).toEqual(request);
-    expect(getSafeLogPayload(response)).toEqual(response);
-  });
-
-  it('redacts sensitive keys even for ordinary API payloads', () => {
-    expect(
-      getSafeLogPayload({
-        method: 'ordinaryMethod',
-        payload: { session_id: 'session-secret', nested: { pin: '1234' } },
-      })
-    ).toEqual({
-      method: 'ordinaryMethod',
-      payload: { session_id: '[REDACTED]', nested: { pin: '[REDACTED]' } },
-    });
-  });
-
-  it('puts sensitive API method names in the log label', () => {
-    expect(formatLogMethodLabel('response:', 'openWalletSession')).toBe(
-      'response: [openWalletSession]'
-    );
-    expect(formatLogMethodLabel('response:')).toBe('response:');
-  });
-
-  it('does not classify events without an API method as method calls', () => {
-    expect(getLogBlockLabel({ event: 'DEVICE_EVENT', type: 'device-connect' })).toBeUndefined();
   });
 });

--- a/packages/core/__tests__/logBlockEvent.test.ts
+++ b/packages/core/__tests__/logBlockEvent.test.ts
@@ -6,39 +6,7 @@ import {
   getSafeLogPayload,
 } from '../src/events';
 
-const debugSigning = { revealSigningPayload: true };
-
 describe('getLogBlockLabel', () => {
-  it('blocks evmSignTypedData params before logging large typed data', () => {
-    expect(
-      getLogBlockLabel({
-        method: 'evmSignTypedData',
-        data: {
-          message: {
-            data: `0x${'ab'.repeat(4096)}`,
-          },
-        },
-      })
-    ).toBe('evmSignTypedData');
-  });
-
-  it('blocks evmSignTypedData iframe call payload before bridge logging', () => {
-    expect(
-      getLogBlockLabel({
-        event: 'iframe-call',
-        type: 'iframe-call',
-        payload: {
-          method: 'evmSignTypedData',
-          data: {
-            message: {
-              data: `0x${'ab'.repeat(4096)}`,
-            },
-          },
-        },
-      })
-    ).toBe('evmSignTypedData');
-  });
-
   it('keeps existing sensitive UI response blocking', () => {
     expect(getLogBlockLabel({ type: UI_RESPONSE.RECEIVE_PIN })).toBe(UI_RESPONSE.RECEIVE_PIN);
   });
@@ -55,61 +23,27 @@ describe('getLogBlockLabel', () => {
           },
         })
       ).toBe(type);
+      expect(
+        getSafeLogPayload(
+          {
+            type,
+            payload: {
+              passphraseState: 'wallet-identifier',
+            },
+          },
+          type
+        )
+      ).toEqual({
+        method: type,
+        payload: '[REDACTED]',
+      });
     }
   );
 
-  it('blocks openWalletSession wallet identifiers in direct and iframe call logging', () => {
-    const payload = {
-      method: 'openWalletSession',
-      mode: 'resume-hidden',
-      deviceId: 'device-id',
-      passphraseState: 'wallet-identifier',
-    };
-
-    expect(getLogBlockLabel(payload)).toBe('openWalletSession');
-    expect(
-      getLogBlockLabel({
-        event: 'iframe-call',
-        type: 'iframe-call',
-        payload,
-      })
-    ).toBe('openWalletSession');
-  });
-
-  it('keeps openWalletSession metadata while redacting wallet session identifiers', () => {
-    const safeResponse = getSafeLogPayload(
-      {
-        success: true,
-        payload: {
-          protocol: 'V2',
-          walletType: 'hidden',
-          deviceId: 'device-id',
-          passphraseState: 'wallet-identifier',
-          sessionId: 'wallet-session-id',
-          resumed: false,
-        },
-      },
-      'openWalletSession'
-    );
-
-    expect(safeResponse).toEqual({
-      method: 'openWalletSession',
-      success: true,
-      payload: {
-        protocol: 'V2',
-        walletType: 'hidden',
-        deviceId: 'device-id',
-        passphraseState: '[REDACTED]',
-        sessionId: '[REDACTED]',
-        resumed: false,
-      },
-    });
-  });
-
-  it.each(['deviceUploadNft', 'deviceUploadWallpaper', 'uploadPortfolio'])(
-    'skips large Base64 resource payload logging for %s',
+  it.each(['deviceUploadNft', 'deviceUploadWallpaper', 'uploadPortfolio', 'fileWrite', 'fileRead'])(
+    'skips large resource or binary payload logging for %s',
     method => {
-      const request = { method, path: 'resource.bin', data: 'A'.repeat(1024 * 1024) };
+      const request = { method, path: 'resource.bin', data: 'A'.repeat(1024) };
       expect(getLogBlockLabel(request)).toBe(method);
       expect(getSafeLogPayload(request, method)).toEqual({
         method,
@@ -118,295 +52,48 @@ describe('getLogBlockLabel', () => {
     }
   );
 
-  it.each(['fileWrite', 'fileRead'])(
-    'keeps metadata and replaces binary payloads with their size for %s',
-    method => {
-      const request = { method, path: 'resource.bin', data: new Uint8Array(1024) };
-      expect(getLogBlockLabel(request)).toBe(method);
-      expect(getSafeLogPayload(request, method)).toEqual({
-        method,
-        path: 'resource.bin',
-        data: '[BINARY:1024]',
-      });
-    }
-  );
+  it('logs signing requests and responses as-is', () => {
+    const request = {
+      method: 'btcSignMessage',
+      path: "m/44'/0'/0'/0/0",
+      messageHex: '68656c6c6f',
+      coin: 'Bitcoin',
+    };
+    const iframeRequest = {
+      event: 'iframe-call',
+      payload: request,
+    };
+    const response = {
+      success: true,
+      payload: {
+        signature: 'signature-bytes',
+        address: 'bc1qexample',
+      },
+    };
 
-  it.each(['evmSignMessage', 'btcSignMessage', 'evmSignTransaction'])(
-    'identifies signing method %s for safe logging',
-    method => {
-      expect(getLogBlockLabel({ method, message: 'sensitive signing payload' })).toBe(method);
-      expect(
-        getLogBlockLabel({
-          event: 'iframe-call',
-          payload: { method, message: 'sensitive signing payload' },
-        })
-      ).toBe(method);
-    }
-  );
+    expect(getLogBlockLabel(request)).toBeUndefined();
+    expect(getLogBlockLabel(iframeRequest)).toBeUndefined();
+    expect(getSafeLogPayload(request)).toBe(request);
+    expect(getSafeLogPayload(response)).toBe(response);
+  });
 
   it('keeps ordinary API requests and responses visible', () => {
     const request = { method: 'getDeviceState', connectId: 'connect-id', scope: 'runtime' };
     const response = { success: true, payload: { protocol: 'V2', initialized: true } };
 
     expect(getLogBlockLabel(request)).toBeUndefined();
-    expect(getSafeLogPayload(request)).toEqual(request);
-    expect(getSafeLogPayload(response)).toEqual(response);
+    expect(getSafeLogPayload(request)).toBe(request);
+    expect(getSafeLogPayload(response)).toBe(response);
   });
 
-  it('redacts sensitive keys even for ordinary API payloads', () => {
-    expect(
-      getSafeLogPayload({
-        method: 'ordinaryMethod',
-        payload: { session_id: 'session-secret', nested: { pin: '1234' } },
-      })
-    ).toEqual({
-      method: 'ordinaryMethod',
-      payload: { session_id: '[REDACTED]', nested: { pin: '[REDACTED]' } },
-    });
-  });
-
-  it('puts sensitive API method names in the log label', () => {
-    expect(formatLogMethodLabel('response:', 'openWalletSession')).toBe(
-      'response: [openWalletSession]'
+  it('puts blocked method names in the log label', () => {
+    expect(formatLogMethodLabel('response:', 'deviceUploadNft')).toBe(
+      'response: [deviceUploadNft]'
     );
     expect(formatLogMethodLabel('response:')).toBe('response:');
   });
 
   it('does not classify events without an API method as method calls', () => {
     expect(getLogBlockLabel({ event: 'DEVICE_EVENT', type: 'device-connect' })).toBeUndefined();
-  });
-});
-
-describe('signing log payloads', () => {
-  it('reveals signing request fields in debug logs', () => {
-    expect(
-      getSafeLogPayload(
-        {
-          event: 'iframe-call',
-          type: 'iframe-call',
-          payload: {
-            method: 'btcSignMessage',
-            path: "m/44'/0'/0'/0/0",
-            messageHex: '68656c6c6f',
-            noScriptType: true,
-            coin: 'Bitcoin',
-            passphraseState: 'wallet-identifier-for-qa',
-            useEmptyPassphrase: false,
-            keepSession: true,
-            initSession: false,
-            nested: {
-              session: 'session-secret',
-              sessionId: 'session-id',
-              walletSessionId: 'wallet-session-id',
-            },
-          },
-        },
-        'btcSignMessage',
-        debugSigning
-      )
-    ).toEqual({
-      event: 'iframe-call',
-      type: 'iframe-call',
-      payload: {
-        method: 'btcSignMessage',
-        path: "m/44'/0'/0'/0/0",
-        messageHex: '68656c6c6f',
-        noScriptType: true,
-        coin: 'Bitcoin',
-        passphraseState: 'wallet-identifier-for-qa',
-        useEmptyPassphrase: false,
-        keepSession: true,
-        initSession: false,
-        nested: {
-          session: '[REDACTED]',
-          sessionId: 'session-id',
-          walletSessionId: 'wallet-session-id',
-        },
-      },
-    });
-  });
-
-  it.each([
-    'accessToken',
-    'apiKey',
-    'auth_token',
-    'bearerToken',
-    'credential',
-    'entropy',
-    'mnemonic',
-    'passphrase',
-    'password',
-    'pin',
-    'privateKeyHex',
-    'private_key',
-    'refresh-token',
-    'secret',
-    'seed',
-    'session',
-    'token',
-    'words',
-    'xprv',
-  ])('redacts %s in debug signing logs', key => {
-    expect(
-      getSafeLogPayload(
-        { method: 'btcSignMessage', [key]: 'secret-value' },
-        'btcSignMessage',
-        debugSigning
-      )
-    ).toEqual({
-      method: 'btcSignMessage',
-      [key]: '[REDACTED]',
-    });
-  });
-
-  it('keeps signing request payloads blocked when debug reveal is not requested', () => {
-    expect(
-      getSafeLogPayload({ method: 'btcSignMessage', messageHex: '68656c6c6f' }, 'btcSignMessage')
-    ).toEqual({
-      method: 'btcSignMessage',
-      payload: '[REDACTED]',
-    });
-  });
-
-  it('handles circular arrays in debug signing payloads', () => {
-    const accounts: unknown[] = [{ secret: 'generic-secret' }];
-    accounts.push(accounts);
-
-    expect(
-      getSafeLogPayload({ method: 'btcSignMessage', accounts }, 'btcSignMessage', debugSigning)
-    ).toEqual({
-      method: 'btcSignMessage',
-      accounts: [{ secret: '[REDACTED]' }, '[CIRCULAR]'],
-    });
-  });
-
-  it('keeps safe signing request metadata visible without debug reveal', () => {
-    expect(
-      getSafeLogPayload(
-        {
-          event: 'iframe-call',
-          payload: {
-            method: 'evmSignTransaction',
-            path: "m/44'/60'/0'/0/0",
-            transaction: {
-              chainId: 1,
-              txType: 2,
-              to: '0xrecipient',
-              data: '0xcontract-call-data',
-            },
-          },
-        },
-        'evmSignTransaction'
-      )
-    ).toEqual({
-      method: 'evmSignTransaction',
-      chainId: 1,
-      transactionType: 2,
-    });
-
-    expect(
-      getSafeLogPayload(
-        {
-          method: 'btcSignTransaction',
-          coin: 'Bitcoin',
-          inputs: [{ prev_hash: 'input-1' }, { prev_hash: 'input-2' }],
-          outputs: [{ address: 'recipient' }],
-          refTxs: [{ hash: 'previous-transaction' }],
-        },
-        'btcSignTransaction'
-      )
-    ).toEqual({
-      method: 'btcSignTransaction',
-      coin: 'Bitcoin',
-      inputCount: 2,
-      outputCount: 1,
-    });
-  });
-
-  it('keeps signing success responses minimal', () => {
-    expect(
-      getSafeLogPayload(
-        {
-          success: true,
-          payload: {
-            signature: 'signature-secret',
-            address: 'address-for-wallet-correlation',
-          },
-        },
-        'btcSignMessage',
-        debugSigning
-      )
-    ).toEqual({
-      method: 'btcSignMessage',
-      success: true,
-    });
-  });
-
-  it('keeps the original SDK signing error while omitting error params', () => {
-    expect(
-      getSafeLogPayload(
-        {
-          success: false,
-          payload: {
-            code: 'DeviceBusy',
-            error: 'Original SDK device error',
-            params: {
-              connectId: 'connect-id',
-              deviceId: 'device-id',
-              passphrase: 'hidden-wallet-secret',
-            },
-          },
-        },
-        'btcSignMessage',
-        debugSigning
-      )
-    ).toEqual({
-      method: 'btcSignMessage',
-      success: false,
-      code: 'DeviceBusy',
-      error: 'Original SDK device error',
-    });
-  });
-
-  it('does not serialize non-string signing error values', () => {
-    expect(
-      getSafeLogPayload(
-        {
-          success: false,
-          payload: {
-            code: 500,
-            error: { passphrase: 'hidden-wallet-secret' },
-          },
-        },
-        'btcSignMessage'
-      )
-    ).toEqual({
-      method: 'btcSignMessage',
-      success: false,
-      code: 500,
-    });
-  });
-
-  it('never reveals sensitive UI or resource upload payloads through debug logging', () => {
-    expect(
-      getSafeLogPayload(
-        { type: UI_RESPONSE.RECEIVE_PIN, payload: '1234' },
-        UI_RESPONSE.RECEIVE_PIN,
-        debugSigning
-      )
-    ).toEqual({
-      method: UI_RESPONSE.RECEIVE_PIN,
-      payload: '[REDACTED]',
-    });
-    expect(
-      getSafeLogPayload(
-        { method: 'deviceUploadNft', data: 'large-base64' },
-        'deviceUploadNft',
-        debugSigning
-      )
-    ).toEqual({
-      method: 'deviceUploadNft',
-      payload: '[REDACTED]',
-    });
   });
 });

--- a/packages/core/__tests__/logBlockEvent.test.ts
+++ b/packages/core/__tests__/logBlockEvent.test.ts
@@ -162,7 +162,9 @@ describe('getLogBlockLabel', () => {
         mnemonic: 'mnemonic-secret',
         nested: {
           apiKey: 'api-key-secret',
-          sessionId: 'session-secret',
+          session: 'session-secret',
+          sessionId: 'session-id',
+          walletSessionId: 'wallet-session-id',
         },
         accounts: [
           {
@@ -203,7 +205,9 @@ describe('getLogBlockLabel', () => {
         mnemonic: '[REDACTED]',
         nested: {
           apiKey: '[REDACTED]',
-          sessionId: '[REDACTED]',
+          session: '[REDACTED]',
+          sessionId: 'session-id',
+          walletSessionId: 'wallet-session-id',
         },
         accounts: [
           {

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -1811,9 +1811,7 @@ export default class Core extends EventEmitter {
         const logBlockLabel = getLogBlockLabel(message);
         Log.log(
           formatLogMethodLabel(`[${Date.now()}][CALL_API]`, logBlockLabel),
-          getSafeLogPayload(message, logBlockLabel, {
-            revealSigningPayload: DataManager.getSettings('debug') === true,
-          })
+          getSafeLogPayload(message, logBlockLabel)
         );
         const response = await callAPI(this.getCoreContext(), message);
         const { success, payload } = response;

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -1811,7 +1811,9 @@ export default class Core extends EventEmitter {
         const logBlockLabel = getLogBlockLabel(message);
         Log.log(
           formatLogMethodLabel(`[${Date.now()}][CALL_API]`, logBlockLabel),
-          getSafeLogPayload(message, logBlockLabel)
+          getSafeLogPayload(message, logBlockLabel, {
+            revealSigningPayload: DataManager.getSettings('debug') === true,
+          })
         );
         const response = await callAPI(this.getCoreContext(), message);
         const { success, payload } = response;

--- a/packages/core/src/events/logBlockEvent.ts
+++ b/packages/core/src/events/logBlockEvent.ts
@@ -8,166 +8,14 @@ export const LogBlockEvent: Set<string> = new Set([
   UI_RESPONSE.RECEIVE_PASSPHRASE,
 ]);
 
-const LogLabelMethod: Set<string> = new Set([
-  'openWalletSession',
+// 1.1.32 没有这些资源/文件 API。整段跳过，避免日志层复制超大 Base64 或二进制。
+const LogPayloadBlockMethod: Set<string> = new Set([
   'deviceUploadNft',
   'deviceUploadWallpaper',
   'uploadPortfolio',
   'fileWrite',
   'fileRead',
 ]);
-
-// 资源上传参数可能包含很大的 Base64 字符串。这里按方法整段跳过，避免日志层
-// 递归复制和序列化这些数据；资源 API 与传输内容本身保持不变。
-const LogPayloadBlockMethod: Set<string> = new Set([
-  'deviceUploadNft',
-  'deviceUploadWallpaper',
-  'uploadPortfolio',
-]);
-
-const SensitiveLogKeys: Set<string> = new Set([
-  'devicestate',
-  'entropy',
-  'expectedpassphrasestate',
-  'mnemonic',
-  'passphrase',
-  'passphrasestate',
-  'password',
-  'pin',
-  'privatekey',
-  'seed',
-  'session',
-  'sessionid',
-  'walletsessionid',
-  'xprv',
-]);
-
-// Debug signing logs may show tx/message fields. These stems still stay redacted.
-// `session` is exact-only so `sessionId` remains visible for QA.
-const CriticalExactLogKeys: Set<string> = new Set(['session']);
-const CriticalSubstringLogKeys = [
-  'credential',
-  'entropy',
-  'mnemonic',
-  'password',
-  'privatekey',
-  'secret',
-  'seed',
-  'xprv',
-] as const;
-const CriticalSuffixLogKeys = ['apikey', 'passphrase', 'pin', 'token', 'word', 'words'] as const;
-
-// `useEmptyPassphrase` would otherwise match the passphrase suffix rule.
-const DebugVisibleLogKeys: Set<string> = new Set([
-  'expectedpassphrasestate',
-  'passphrasestate',
-  'useemptypassphrase',
-]);
-
-const normalizeLogKey = (key: string) => key.replace(/[_-]/g, '').toLowerCase();
-
-const isSigningMethod = (methodName: string) => /sign/i.test(methodName);
-
-const isSensitiveLogKey = (key: string) => SensitiveLogKeys.has(normalizeLogKey(key));
-
-const isCriticalSensitiveLogKey = (key: string) => {
-  const normalizedKey = normalizeLogKey(key);
-  if (DebugVisibleLogKeys.has(normalizedKey)) return false;
-  return (
-    CriticalExactLogKeys.has(normalizedKey) ||
-    CriticalSubstringLogKeys.some(stem => normalizedKey.includes(stem)) ||
-    CriticalSuffixLogKeys.some(stem => normalizedKey.endsWith(stem))
-  );
-};
-
-const asPlainObject = (value: unknown): Record<string, unknown> | undefined => {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
-  return value as Record<string, unknown>;
-};
-
-const isScalar = (value: unknown): value is string | number | boolean =>
-  typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
-
-const getSigningResponseLogSummary = (
-  value: unknown,
-  method: string
-): Record<string, unknown> | undefined => {
-  const response = asPlainObject(value);
-  if (typeof response?.success !== 'boolean') return undefined;
-
-  const summary: Record<string, unknown> = { method, success: response.success };
-  if (response.success) return summary;
-
-  const payload = asPlainObject(response.payload);
-  if (typeof payload?.code === 'string' || typeof payload?.code === 'number') {
-    summary.code = payload.code;
-  }
-  if (typeof payload?.error === 'string') {
-    summary.error = payload.error;
-  }
-  return summary;
-};
-
-const getSigningRequestLogSummary = (value: unknown, method: string): Record<string, unknown> => {
-  const blockedSummary = { method, payload: '[REDACTED]' };
-  const message = asPlainObject(value);
-  if (!message) return blockedSummary;
-
-  const nestedPayload = asPlainObject(message.payload);
-  const params = nestedPayload?.method === method ? nestedPayload : message;
-  const transaction = asPlainObject(params.transaction) ?? {};
-  const summary: Record<string, unknown> = { method };
-
-  const assign = (outputKey: string, ...candidates: unknown[]) => {
-    const valueToLog = candidates.find(isScalar);
-    if (valueToLog !== undefined) summary[outputKey] = valueToLog;
-  };
-
-  assign('chainId', params.chainId, transaction.chainId);
-  assign('transactionType', params.transactionType, params.txType, transaction.txType);
-  assign('coin', params.coin);
-  assign('coinType', params.coinType);
-  assign('network', params.network);
-  assign('networkId', params.networkId, params.network_id);
-  assign('noScriptType', params.noScriptType);
-  assign('dAppSignType', params.dAppSignType);
-
-  if (Array.isArray(params.inputs)) summary.inputCount = params.inputs.length;
-  if (Array.isArray(params.outputs)) summary.outputCount = params.outputs.length;
-
-  return Object.keys(summary).length > 1 ? summary : blockedSummary;
-};
-
-const redactLogValue = (
-  value: unknown,
-  seen: WeakSet<object>,
-  shouldRedactKey: (key: string) => boolean = isSensitiveLogKey
-): unknown => {
-  if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
-    return `[BINARY:${value.byteLength}]`;
-  }
-  if (Array.isArray(value)) {
-    if (seen.has(value)) return '[CIRCULAR]';
-    seen.add(value);
-    const redacted = value.map(item => redactLogValue(item, seen, shouldRedactKey));
-    seen.delete(value);
-    return redacted;
-  }
-  if (!value || typeof value !== 'object') return value;
-  if (seen.has(value)) return '[CIRCULAR]';
-
-  seen.add(value);
-  const redacted = Object.fromEntries(
-    Object.entries(value as Record<string, unknown>).map(([key, item]) => [
-      key,
-      shouldRedactKey(key) && item !== null && item !== undefined
-        ? '[REDACTED]'
-        : redactLogValue(item, seen, shouldRedactKey),
-    ])
-  );
-  seen.delete(value);
-  return redacted;
-};
 
 export function getLogBlockLabel(message: unknown): string | undefined {
   if (!message || typeof message !== 'object') return undefined;
@@ -183,37 +31,18 @@ export function getLogBlockLabel(message: unknown): string | undefined {
   }
 
   const methodName = method ?? payload?.method;
-  if (methodName && (LogLabelMethod.has(methodName) || isSigningMethod(methodName))) {
+  if (methodName && LogPayloadBlockMethod.has(methodName)) {
     return methodName;
   }
 
   return undefined;
 }
 
-export function getSafeLogPayload(
-  value: unknown,
-  blockLabel?: string,
-  options: { revealSigningPayload?: boolean } = {}
-): unknown {
-  if (blockLabel && isSigningMethod(blockLabel)) {
-    return (
-      getSigningResponseLogSummary(value, blockLabel) ??
-      (options.revealSigningPayload
-        ? redactLogValue(value, new WeakSet(), isCriticalSensitiveLogKey)
-        : getSigningRequestLogSummary(value, blockLabel))
-    );
-  }
-
-  if (blockLabel && (LogBlockEvent.has(blockLabel) || LogPayloadBlockMethod.has(blockLabel))) {
+export function getSafeLogPayload(value: unknown, blockLabel?: string): unknown {
+  if (blockLabel) {
     return { method: blockLabel, payload: '[REDACTED]' };
   }
-
-  const redactedValue = redactLogValue(value, new WeakSet());
-  const redactedObject = asPlainObject(redactedValue);
-  if (blockLabel && redactedObject) {
-    return { ...redactedObject, method: blockLabel };
-  }
-  return redactedValue;
+  return value;
 }
 
 export function formatLogMethodLabel(label: string, methodName?: string): string {

--- a/packages/core/src/events/logBlockEvent.ts
+++ b/packages/core/src/events/logBlockEvent.ts
@@ -42,36 +42,24 @@ const SensitiveLogKeys: Set<string> = new Set([
   'xprv',
 ]);
 
-// Debug signing logs intentionally expose transaction and message data for QA.
-// These red-line secrets remain blocked even when SDK debug logging is enabled.
-const CriticalSensitiveLogKeys: Set<string> = new Set([
-  'accesstoken',
-  'apikey',
-  'authtoken',
-  'bearertoken',
+// Debug signing logs may show tx/message fields. These stems still stay redacted.
+// `session` is exact-only so `sessionId` remains visible for QA.
+const CriticalExactLogKeys: Set<string> = new Set(['session']);
+const CriticalSubstringLogKeys = [
   'credential',
-  'credentials',
   'entropy',
   'mnemonic',
-  'mnemonics',
-  'passphrase',
   'password',
-  'pin',
   'privatekey',
-  'refreshtoken',
   'secret',
   'seed',
-  'session',
-  'token',
-  'word',
-  'words',
   'xprv',
-]);
+] as const;
+const CriticalSuffixLogKeys = ['apikey', 'passphrase', 'pin', 'token', 'word', 'words'] as const;
 
+// `useEmptyPassphrase` would otherwise match the passphrase suffix rule.
 const DebugVisibleLogKeys: Set<string> = new Set([
   'expectedpassphrasestate',
-  'initsession',
-  'keepsession',
   'passphrasestate',
   'useemptypassphrase',
 ]);
@@ -86,84 +74,63 @@ const isCriticalSensitiveLogKey = (key: string) => {
   const normalizedKey = normalizeLogKey(key);
   if (DebugVisibleLogKeys.has(normalizedKey)) return false;
   return (
-    CriticalSensitiveLogKeys.has(normalizedKey) ||
-    normalizedKey.includes('privatekey') ||
-    normalizedKey.includes('mnemonic') ||
-    normalizedKey.includes('password') ||
-    normalizedKey.includes('seed') ||
-    normalizedKey.includes('secret') ||
-    normalizedKey.includes('xprv') ||
-    normalizedKey.includes('entropy') ||
-    normalizedKey.includes('credential') ||
-    normalizedKey.endsWith('passphrase') ||
-    normalizedKey.endsWith('pin') ||
-    normalizedKey.endsWith('token') ||
-    normalizedKey.endsWith('apikey') ||
-    normalizedKey.endsWith('word') ||
-    normalizedKey.endsWith('words')
+    CriticalExactLogKeys.has(normalizedKey) ||
+    CriticalSubstringLogKeys.some(stem => normalizedKey.includes(stem)) ||
+    CriticalSuffixLogKeys.some(stem => normalizedKey.endsWith(stem))
   );
 };
+
+const asPlainObject = (value: unknown): Record<string, unknown> | undefined => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  return value as Record<string, unknown>;
+};
+
+const isScalar = (value: unknown): value is string | number | boolean =>
+  typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
 
 const getSigningResponseLogSummary = (
   value: unknown,
   method: string
 ): Record<string, unknown> | undefined => {
-  const response = value as {
-    success?: unknown;
-    payload?: { code?: unknown; error?: unknown } | null;
-  };
+  const response = asPlainObject(value);
   if (typeof response?.success !== 'boolean') return undefined;
 
-  const summary = { method, success: response.success };
+  const summary: Record<string, unknown> = { method, success: response.success };
   if (response.success) return summary;
 
-  const { code, error } = response.payload ?? {};
-  return {
-    ...summary,
-    ...(typeof code === 'string' || typeof code === 'number' ? { code } : {}),
-    ...(typeof error === 'string' ? { error } : {}),
-  };
+  const payload = asPlainObject(response.payload);
+  if (typeof payload?.code === 'string' || typeof payload?.code === 'number') {
+    summary.code = payload.code;
+  }
+  if (typeof payload?.error === 'string') {
+    summary.error = payload.error;
+  }
+  return summary;
 };
 
 const getSigningRequestLogSummary = (value: unknown, method: string): Record<string, unknown> => {
-  const blockedSummary: Record<string, unknown> = {
-    method,
-    payload: '[REDACTED]',
-  };
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return blockedSummary;
+  const blockedSummary = { method, payload: '[REDACTED]' };
+  const message = asPlainObject(value);
+  if (!message) return blockedSummary;
 
-  const message = value as Record<string, unknown>;
-  const nestedPayload =
-    message.payload && typeof message.payload === 'object' && !Array.isArray(message.payload)
-      ? (message.payload as Record<string, unknown>)
-      : undefined;
+  const nestedPayload = asPlainObject(message.payload);
   const params = nestedPayload?.method === method ? nestedPayload : message;
-  const transaction =
-    params.transaction &&
-    typeof params.transaction === 'object' &&
-    !Array.isArray(params.transaction)
-      ? (params.transaction as Record<string, unknown>)
-      : undefined;
-
+  const transaction = asPlainObject(params.transaction) ?? {};
   const summary: Record<string, unknown> = { method };
-  const copyScalar = (outputKey: string, ...candidates: unknown[]) => {
-    const valueToLog = candidates.find(
-      candidate =>
-        typeof candidate === 'string' ||
-        typeof candidate === 'number' ||
-        typeof candidate === 'boolean'
-    );
+
+  const assign = (outputKey: string, ...candidates: unknown[]) => {
+    const valueToLog = candidates.find(isScalar);
     if (valueToLog !== undefined) summary[outputKey] = valueToLog;
   };
 
-  copyScalar('chainId', params.chainId, transaction?.chainId);
-  copyScalar('transactionType', params.transactionType, params.txType, transaction?.txType);
-  copyScalar('coin', params.coin);
-  copyScalar('coinType', params.coinType);
-  copyScalar('network', params.network);
-  copyScalar('networkId', params.networkId, params.network_id);
-  copyScalar('noScriptType', params.noScriptType);
-  copyScalar('dAppSignType', params.dAppSignType);
+  assign('chainId', params.chainId, transaction.chainId);
+  assign('transactionType', params.transactionType, params.txType, transaction.txType);
+  assign('coin', params.coin);
+  assign('coinType', params.coinType);
+  assign('network', params.network);
+  assign('networkId', params.networkId, params.network_id);
+  assign('noScriptType', params.noScriptType);
+  assign('dAppSignType', params.dAppSignType);
 
   if (Array.isArray(params.inputs)) summary.inputCount = params.inputs.length;
   if (Array.isArray(params.outputs)) summary.outputCount = params.outputs.length;
@@ -176,10 +143,7 @@ const redactLogValue = (
   seen: WeakSet<object>,
   shouldRedactKey: (key: string) => boolean = isSensitiveLogKey
 ): unknown => {
-  if (ArrayBuffer.isView(value)) {
-    return `[BINARY:${value.byteLength}]`;
-  }
-  if (value instanceof ArrayBuffer) {
+  if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
     return `[BINARY:${value.byteLength}]`;
   }
   if (Array.isArray(value)) {
@@ -232,16 +196,12 @@ export function getSafeLogPayload(
   options: { revealSigningPayload?: boolean } = {}
 ): unknown {
   if (blockLabel && isSigningMethod(blockLabel)) {
-    const responseSummary = getSigningResponseLogSummary(value, blockLabel);
-    if (responseSummary) return responseSummary;
-  }
-
-  if (blockLabel && isSigningMethod(blockLabel) && options.revealSigningPayload) {
-    return redactLogValue(value, new WeakSet(), isCriticalSensitiveLogKey);
-  }
-
-  if (blockLabel && isSigningMethod(blockLabel)) {
-    return getSigningRequestLogSummary(value, blockLabel);
+    return (
+      getSigningResponseLogSummary(value, blockLabel) ??
+      (options.revealSigningPayload
+        ? redactLogValue(value, new WeakSet(), isCriticalSensitiveLogKey)
+        : getSigningRequestLogSummary(value, blockLabel))
+    );
   }
 
   if (blockLabel && (LogBlockEvent.has(blockLabel) || LogPayloadBlockMethod.has(blockLabel))) {
@@ -249,13 +209,9 @@ export function getSafeLogPayload(
   }
 
   const redactedValue = redactLogValue(value, new WeakSet());
-  if (
-    blockLabel &&
-    redactedValue &&
-    typeof redactedValue === 'object' &&
-    !Array.isArray(redactedValue)
-  ) {
-    return { ...redactedValue, method: blockLabel };
+  const redactedObject = asPlainObject(redactedValue);
+  if (blockLabel && redactedObject) {
+    return { ...redactedObject, method: blockLabel };
   }
   return redactedValue;
 }

--- a/packages/core/src/events/logBlockEvent.ts
+++ b/packages/core/src/events/logBlockEvent.ts
@@ -62,9 +62,7 @@ const CriticalSensitiveLogKeys: Set<string> = new Set([
   'secret',
   'seed',
   'session',
-  'sessionid',
   'token',
-  'walletsessionid',
   'word',
   'words',
   'xprv',
@@ -99,7 +97,6 @@ const isCriticalSensitiveLogKey = (key: string) => {
     normalizedKey.includes('credential') ||
     normalizedKey.endsWith('passphrase') ||
     normalizedKey.endsWith('pin') ||
-    normalizedKey.endsWith('sessionid') ||
     normalizedKey.endsWith('token') ||
     normalizedKey.endsWith('apikey') ||
     normalizedKey.endsWith('word') ||
@@ -111,30 +108,21 @@ const getSigningResponseLogSummary = (
   value: unknown,
   method: string
 ): Record<string, unknown> | undefined => {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
-
-  const { success, payload } = value as {
+  const response = value as {
     success?: unknown;
-    payload?: unknown;
+    payload?: { code?: unknown; error?: unknown } | null;
   };
-  if (typeof success !== 'boolean') return undefined;
+  if (typeof response?.success !== 'boolean') return undefined;
 
-  const summary: Record<string, unknown> = { method, success };
-  if (success || !payload || typeof payload !== 'object' || Array.isArray(payload)) {
-    return summary;
-  }
+  const summary = { method, success: response.success };
+  if (response.success) return summary;
 
-  const { code, error } = payload as {
-    code?: unknown;
-    error?: unknown;
+  const { code, error } = response.payload ?? {};
+  return {
+    ...summary,
+    ...(typeof code === 'string' || typeof code === 'number' ? { code } : {}),
+    ...(typeof error === 'string' ? { error } : {}),
   };
-  if (typeof code === 'string' || typeof code === 'number') {
-    summary.code = code;
-  }
-  if (typeof error === 'string') {
-    summary.error = error;
-  }
-  return summary;
 };
 
 const getSigningRequestLogSummary = (value: unknown, method: string): Record<string, unknown> => {

--- a/packages/core/src/events/logBlockEvent.ts
+++ b/packages/core/src/events/logBlockEvent.ts
@@ -42,11 +42,152 @@ const SensitiveLogKeys: Set<string> = new Set([
   'xprv',
 ]);
 
+// Debug signing logs intentionally expose transaction and message data for QA.
+// These red-line secrets remain blocked even when SDK debug logging is enabled.
+const CriticalSensitiveLogKeys: Set<string> = new Set([
+  'accesstoken',
+  'apikey',
+  'authtoken',
+  'bearertoken',
+  'credential',
+  'credentials',
+  'entropy',
+  'mnemonic',
+  'mnemonics',
+  'passphrase',
+  'password',
+  'pin',
+  'privatekey',
+  'refreshtoken',
+  'secret',
+  'seed',
+  'session',
+  'sessionid',
+  'token',
+  'walletsessionid',
+  'word',
+  'words',
+  'xprv',
+]);
+
+const DebugVisibleLogKeys: Set<string> = new Set([
+  'expectedpassphrasestate',
+  'initsession',
+  'keepsession',
+  'passphrasestate',
+  'useemptypassphrase',
+]);
+
 const normalizeLogKey = (key: string) => key.replace(/[_-]/g, '').toLowerCase();
 
 const isSigningMethod = (methodName: string) => /sign/i.test(methodName);
 
-const redactLogValue = (value: unknown, seen: WeakSet<object>): unknown => {
+const isSensitiveLogKey = (key: string) => SensitiveLogKeys.has(normalizeLogKey(key));
+
+const isCriticalSensitiveLogKey = (key: string) => {
+  const normalizedKey = normalizeLogKey(key);
+  if (DebugVisibleLogKeys.has(normalizedKey)) return false;
+  return (
+    CriticalSensitiveLogKeys.has(normalizedKey) ||
+    normalizedKey.includes('privatekey') ||
+    normalizedKey.includes('mnemonic') ||
+    normalizedKey.includes('password') ||
+    normalizedKey.includes('seed') ||
+    normalizedKey.includes('secret') ||
+    normalizedKey.includes('xprv') ||
+    normalizedKey.includes('entropy') ||
+    normalizedKey.includes('credential') ||
+    normalizedKey.endsWith('passphrase') ||
+    normalizedKey.endsWith('pin') ||
+    normalizedKey.endsWith('sessionid') ||
+    normalizedKey.endsWith('token') ||
+    normalizedKey.endsWith('apikey') ||
+    normalizedKey.endsWith('word') ||
+    normalizedKey.endsWith('words')
+  );
+};
+
+const getSigningResponseLogSummary = (
+  value: unknown,
+  method: string
+): Record<string, unknown> | undefined => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+
+  const { success, payload } = value as {
+    success?: unknown;
+    payload?: unknown;
+  };
+  if (typeof success !== 'boolean') return undefined;
+
+  const summary: Record<string, unknown> = { method, success };
+  if (success || !payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return summary;
+  }
+
+  const { code, error } = payload as {
+    code?: unknown;
+    error?: unknown;
+  };
+  if (typeof code === 'string' || typeof code === 'number') {
+    summary.code = code;
+  }
+  if (typeof error === 'string') {
+    summary.error = error;
+  }
+  return summary;
+};
+
+const getSigningRequestLogSummary = (value: unknown, method: string): Record<string, unknown> => {
+  const blockedSummary: Record<string, unknown> = {
+    method,
+    payload: '[REDACTED]',
+  };
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return blockedSummary;
+
+  const message = value as Record<string, unknown>;
+  const nestedPayload =
+    message.payload && typeof message.payload === 'object' && !Array.isArray(message.payload)
+      ? (message.payload as Record<string, unknown>)
+      : undefined;
+  const params = nestedPayload?.method === method ? nestedPayload : message;
+  const transaction =
+    params.transaction &&
+    typeof params.transaction === 'object' &&
+    !Array.isArray(params.transaction)
+      ? (params.transaction as Record<string, unknown>)
+      : undefined;
+
+  const summary: Record<string, unknown> = { method };
+  const copyScalar = (outputKey: string, ...candidates: unknown[]) => {
+    const valueToLog = candidates.find(
+      candidate =>
+        typeof candidate === 'string' ||
+        typeof candidate === 'number' ||
+        typeof candidate === 'boolean'
+    );
+    if (valueToLog !== undefined) summary[outputKey] = valueToLog;
+  };
+
+  copyScalar('chainId', params.chainId, transaction?.chainId);
+  copyScalar('transactionType', params.transactionType, params.txType, transaction?.txType);
+  copyScalar('coin', params.coin);
+  copyScalar('coinType', params.coinType);
+  copyScalar('network', params.network);
+  copyScalar('networkId', params.networkId, params.network_id);
+  copyScalar('noScriptType', params.noScriptType);
+  copyScalar('dAppSignType', params.dAppSignType);
+
+  if (Array.isArray(params.inputs)) summary.inputCount = params.inputs.length;
+  if (Array.isArray(params.outputs)) summary.outputCount = params.outputs.length;
+
+  return Object.keys(summary).length > 1 ? summary : blockedSummary;
+};
+
+const redactLogValue = (
+  value: unknown,
+  seen: WeakSet<object>,
+  shouldRedactKey: (key: string) => boolean = isSensitiveLogKey
+): unknown => {
   if (ArrayBuffer.isView(value)) {
     return `[BINARY:${value.byteLength}]`;
   }
@@ -54,7 +195,11 @@ const redactLogValue = (value: unknown, seen: WeakSet<object>): unknown => {
     return `[BINARY:${value.byteLength}]`;
   }
   if (Array.isArray(value)) {
-    return value.map(item => redactLogValue(item, seen));
+    if (seen.has(value)) return '[CIRCULAR]';
+    seen.add(value);
+    const redacted = value.map(item => redactLogValue(item, seen, shouldRedactKey));
+    seen.delete(value);
+    return redacted;
   }
   if (!value || typeof value !== 'object') return value;
   if (seen.has(value)) return '[CIRCULAR]';
@@ -63,9 +208,9 @@ const redactLogValue = (value: unknown, seen: WeakSet<object>): unknown => {
   const redacted = Object.fromEntries(
     Object.entries(value as Record<string, unknown>).map(([key, item]) => [
       key,
-      SensitiveLogKeys.has(normalizeLogKey(key)) && item !== null && item !== undefined
+      shouldRedactKey(key) && item !== null && item !== undefined
         ? '[REDACTED]'
-        : redactLogValue(item, seen),
+        : redactLogValue(item, seen, shouldRedactKey),
     ])
   );
   seen.delete(value);
@@ -93,13 +238,25 @@ export function getLogBlockLabel(message: unknown): string | undefined {
   return undefined;
 }
 
-export function getSafeLogPayload(value: unknown, blockLabel?: string): unknown {
-  if (
-    blockLabel &&
-    (LogBlockEvent.has(blockLabel) ||
-      LogPayloadBlockMethod.has(blockLabel) ||
-      isSigningMethod(blockLabel))
-  ) {
+export function getSafeLogPayload(
+  value: unknown,
+  blockLabel?: string,
+  options: { revealSigningPayload?: boolean } = {}
+): unknown {
+  if (blockLabel && isSigningMethod(blockLabel)) {
+    const responseSummary = getSigningResponseLogSummary(value, blockLabel);
+    if (responseSummary) return responseSummary;
+  }
+
+  if (blockLabel && isSigningMethod(blockLabel) && options.revealSigningPayload) {
+    return redactLogValue(value, new WeakSet(), isCriticalSensitiveLogKey);
+  }
+
+  if (blockLabel && isSigningMethod(blockLabel)) {
+    return getSigningRequestLogSummary(value, blockLabel);
+  }
+
+  if (blockLabel && (LogBlockEvent.has(blockLabel) || LogPayloadBlockMethod.has(blockLabel))) {
     return { method: blockLabel, payload: '[REDACTED]' };
   }
 

--- a/packages/core/src/events/logBlockEvent.ts
+++ b/packages/core/src/events/logBlockEvent.ts
@@ -8,7 +8,8 @@ export const LogBlockEvent: Set<string> = new Set([
   UI_RESPONSE.RECEIVE_PASSPHRASE,
 ]);
 
-// 1.1.32 没有这些资源/文件 API。整段跳过，避免日志层复制超大 Base64 或二进制。
+// These resource/file APIs did not exist in 1.1.32. Skip the payload so
+// the log layer does not copy huge Base64 or binary data.
 const LogPayloadBlockMethod: Set<string> = new Set([
   'deviceUploadNft',
   'deviceUploadWallpaper',


### PR DESCRIPTION
## Summary

- Restore 1.1.32-style CALL_API logging: log the original request/response without recursive cloning or key redaction.
- Signing payloads are visible again, same as 1.1.32.
- Keep PIN/passphrase UI events blocked.
- Keep resource/file upload payloads skipped so logs do not copy huge Base64 or binary data. These APIs did not exist in 1.1.32.

## Scope

- Core CALL_API / iframe block labels only.
- Transport protocol logs are unchanged.

## Test plan

- [x] `node_modules/.bin/jest packages/core/__tests__/logBlockEvent.test.ts --runInBand`