### PR TITLE
fix: avoid redundant Pro2 unlock prompts in example

### DIFF
--- a/packages/connect-examples/expo-example/src/utils/protocolAwareMethod.test.ts
+++ b/packages/connect-examples/expo-example/src/utils/protocolAwareMethod.test.ts
@@ -1,4 +1,5 @@
-import { getMethodSupportedProtocols } from '@onekeyfe/hd-core';
+import { getMethodSupportedProtocols, projectDeviceStateFeatures } from '@onekeyfe/hd-core';
+import { DeviceSessionPinType } from '@onekeyfe/hd-transport';
 
 import { executeProtocolAwareMethod, isMethodSupportedOnProtocol } from './protocolAwareMethod';
 import { getProtocolAwareFeatures } from './protocolAwareFeatures';
@@ -7,6 +8,7 @@ import type { CoreApi } from '@onekeyfe/hd-core';
 
 jest.mock('@onekeyfe/hd-core', () => ({
   getMethodSupportedProtocols: jest.fn(),
+  projectDeviceStateFeatures: jest.fn(),
 }));
 
 jest.mock('./protocolAwareFeatures', () => ({
@@ -18,6 +20,9 @@ const mockedGetMethodSupportedProtocols = getMethodSupportedProtocols as jest.Mo
 >;
 const mockedGetProtocolAwareFeatures = getProtocolAwareFeatures as jest.MockedFunction<
   typeof getProtocolAwareFeatures
+>;
+const mockedProjectDeviceStateFeatures = projectDeviceStateFeatures as jest.MockedFunction<
+  typeof projectDeviceStateFeatures
 >;
 
 describe('protocolAwareMethod', () => {
@@ -80,4 +85,75 @@ describe('protocolAwareMethod', () => {
     );
     expect(stellarGetAddress).not.toHaveBeenCalled();
   });
+
+  test.each([
+    [undefined, false],
+    [DeviceSessionPinType.Main, false],
+    [DeviceSessionPinType.AttachToPin, true],
+    [DeviceSessionPinType.Any, true],
+  ])(
+    'skips a redundant Protocol V2 unlock for pinType=%s in the matching PIN context',
+    async (pinType, unlockedAttachPin) => {
+      mockedGetMethodSupportedProtocols.mockReturnValue(['V1', 'V2']);
+      const state = {
+        status: { unlocked: true, unlockedAttachPin },
+      };
+      const projectedFeatures = { unlocked: true, unlockedAttachPin };
+      mockedProjectDeviceStateFeatures.mockReturnValue(projectedFeatures as never);
+      const getDeviceState = jest.fn().mockResolvedValue({ success: true, payload: state });
+      const deviceUnlock = jest.fn();
+      const sdk = { getDeviceState, deviceUnlock } as unknown as CoreApi;
+
+      await expect(
+        executeProtocolAwareMethod({
+          sdk,
+          method: 'deviceUnlock',
+          connectId: 'pro2',
+          deviceId: '',
+          params: pinType === undefined ? {} : { pinType },
+          protocol: 'V2',
+          mode: 'connection',
+        })
+      ).resolves.toEqual({ success: true, payload: projectedFeatures });
+
+      expect(getDeviceState).toHaveBeenCalledWith('pro2', { scope: 'runtime' });
+      expect(mockedProjectDeviceStateFeatures).toHaveBeenCalledWith(state);
+      expect(deviceUnlock).not.toHaveBeenCalled();
+    }
+  );
+
+  test.each([
+    ['locked', false, false, undefined],
+    ['Attach PIN context for a Main PIN request', true, true, DeviceSessionPinType.Main],
+    ['Main PIN context for an Attach PIN request', true, false, DeviceSessionPinType.AttachToPin],
+  ])(
+    'executes Protocol V2 unlock when the device is %s',
+    async (_case, unlocked, unlockedAttachPin, pinType) => {
+      mockedGetMethodSupportedProtocols.mockReturnValue(['V1', 'V2']);
+      const stateResponse = {
+        success: true,
+        payload: { status: { unlocked, unlockedAttachPin } },
+      };
+      const unlockResponse = { success: true, payload: { unlocked: true } };
+      const getDeviceState = jest.fn().mockResolvedValue(stateResponse);
+      const deviceUnlock = jest.fn().mockResolvedValue(unlockResponse);
+      const sdk = { getDeviceState, deviceUnlock } as unknown as CoreApi;
+      const params = pinType === undefined ? {} : { pinType };
+
+      await expect(
+        executeProtocolAwareMethod({
+          sdk,
+          method: 'deviceUnlock',
+          connectId: 'pro2',
+          deviceId: '',
+          params,
+          protocol: 'V2',
+          mode: 'connection',
+        })
+      ).resolves.toBe(unlockResponse);
+
+      expect(deviceUnlock).toHaveBeenCalledWith('pro2', params);
+      expect(mockedProjectDeviceStateFeatures).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/packages/connect-examples/expo-example/src/utils/protocolAwareMethod.ts
+++ b/packages/connect-examples/expo-example/src/utils/protocolAwareMethod.ts
@@ -1,9 +1,10 @@
-import { getMethodSupportedProtocols } from '@onekeyfe/hd-core';
+import { getMethodSupportedProtocols, projectDeviceStateFeatures } from '@onekeyfe/hd-core';
 import { HardwareErrorCode } from '@onekeyfe/hd-shared';
+import { DeviceSessionPinType } from '@onekeyfe/hd-transport';
 
 import { getProtocolAwareFeatures } from './protocolAwareFeatures';
 
-import type { CoreApi } from '@onekeyfe/hd-core';
+import type { CoreApi, DeviceState } from '@onekeyfe/hd-core';
 
 export type ConnectProtocol = 'V1' | 'V2';
 export type MethodCallMode = 'no-connection' | 'connection' | 'device';
@@ -19,6 +20,20 @@ type ProtocolAwareMethodOptions = {
 };
 
 const protocolV2FeatureAdapters = new Set(['getFeatures', 'getOnekeyFeatures']);
+
+function isProtocolV2UnlockSatisfied(state: DeviceState, pinType: unknown) {
+  if (state.status.unlocked !== true) return false;
+
+  if (pinType === DeviceSessionPinType.Any) return true;
+  if (pinType === DeviceSessionPinType.AttachToPin) {
+    return state.status.unlockedAttachPin === true;
+  }
+
+  return (
+    (pinType === undefined || pinType === DeviceSessionPinType.Main) &&
+    state.status.unlockedAttachPin === false
+  );
+}
 
 export function isMethodSupportedOnProtocol(
   method: string,
@@ -88,6 +103,18 @@ export async function executeProtocolAwareMethod({
 
   if (!isMethodSupportedOnProtocol(method, protocol, params)) {
     return createProtocolUnsupportedResponse(method, protocol);
+  }
+
+  if (protocol === 'V2' && mode === 'connection' && method === 'deviceUnlock') {
+    const stateResponse = await sdk.getDeviceState(connectId, { scope: 'runtime' });
+    if (!stateResponse.success) return stateResponse;
+
+    if (isProtocolV2UnlockSatisfied(stateResponse.payload, params.pinType)) {
+      return {
+        ...stateResponse,
+        payload: projectDeviceStateFeatures(stateResponse.payload),
+      };
+    }
   }
 
   if (mode === 'connection') {


### PR DESCRIPTION
## Summary

- Query the Protocol V2 runtime device state before the Expo example calls deviceUnlock.
- Skip a redundant unlock only when the device is already unlocked in the requested Main, AttachToPin, or Any context.
- Preserve PIN-context switching, Protocol V1 behavior, and Core REQUEST_PIN notifications.

## Why

The current onekey Core already checks DeviceStatusGet before automatic AskPin handling. The remaining repeated prompt came from the Expo example explicitly calling deviceUnlock every time. Protocol V2 REQUEST_PIN is still required as a device-side input notification and for automation, so this change stays in the example call boundary.

## Validation

- yarn jest packages/connect-examples/expo-example/src/utils/protocolAwareMethod.test.ts --runInBand
- yarn tsc --project packages/connect-examples/expo-example/tsconfig.json --noEmit
- yarn eslint src/utils/protocolAwareMethod.ts src/utils/protocolAwareMethod.test.ts
- EXPO_PUBLIC_COMMIT_SHA=local yarn expo export:web
- yarn agent:check --profile commit
- yarn agent:check --profile pr