### PR TITLE
fix: sync Pro2 main protobuf and Solana signer fields

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "submodules/firmware-pro2"]
 	path = submodules/firmware-pro2
 	url = https://github.com/OneKeyHQ/firmware-pro2.git
-	branch = dev
+	branch = main

--- a/docs/business/chains-overview.md
+++ b/docs/business/chains-overview.md
@@ -154,6 +154,14 @@ OneKey 硬件钱包通过一组可复用的密码学原语和链专属协议支�
 - 特殊路径: 多账户支持 m/44'/501'/0'/0', m/44'/501'/1'/0', ...
 - 特性: 程序派生地址(PDA), 关联代币账户(ATA), 租金豁免
 
+For Pro2, regenerate the protocol schema from the `firmware-pro2` submodule's `main`
+branch with `yarn update-protobuf`. `SolanaSignOffChainMessage.required_signers` uses
+protobuf field 6; the former field 7 layout and `source_fingerprint` have been
+removed. The SDK accepts `requiredSigners` as sorted, unique 32-byte hex public keys
+and no longer exposes `sourceFingerprint`. App callers already using
+`requiredSigners` only need the updated SDK schema. Signer-count limits remain
+firmware-owned; the SDK does not impose a host-side limit.
+
 **Cardano 生态：**
 
 - **ADA (Cardano):** SLIP-44: 1815, 标准: CIP-1852

--- a/packages/core/__tests__/sol-sign-offchain-message.test.ts
+++ b/packages/core/__tests__/sol-sign-offchain-message.test.ts
@@ -25,15 +25,17 @@ const createMethod = (overrides: Record<string, unknown> = {}) =>
       messageVersion: SolanaOffChainMessageVersion.MESSAGE_VERSION_1,
       messageFormat: SolanaOffChainMessageFormat.V0_LIMITED_UTF8,
       applicationDomainHex: `0x${'aa'.repeat(32)}`,
-      sourceFingerprint: 0x12345678,
       requiredSigners,
       ...overrides,
     },
   });
 
 describe('SolSignOffchainMessage', () => {
-  test('maps V1 parameters without imposing a host-side signer count limit', async () => {
-    const method = createMethod();
+  test.each([
+    { description: 'without a host-side signer count limit', requiredSigners },
+    { description: 'with omitted optional signers', requiredSigners: undefined },
+  ])('maps V1 parameters $description', async ({ requiredSigners }) => {
+    const method = createMethod({ requiredSigners });
     method.init();
 
     const typedCall = jest.fn().mockResolvedValue({
@@ -48,8 +50,7 @@ describe('SolSignOffchainMessage', () => {
       message_version: SolanaOffChainMessageVersion.MESSAGE_VERSION_1,
       message_format: SolanaOffChainMessageFormat.V0_LIMITED_UTF8,
       application_domain: 'aa'.repeat(32),
-      source_fingerprint: 0x12345678,
-      required_signers: requiredSigners,
+      required_signers: requiredSigners ?? [],
     });
   });
 
@@ -60,11 +61,4 @@ describe('SolSignOffchainMessage', () => {
   ])('rejects invalid required signers: $error', ({ requiredSigners, error }) => {
     expect(() => createMethod({ requiredSigners }).init()).toThrow(error);
   });
-
-  test.each([-1, 0x100000000, 1.5])(
-    'rejects an invalid source fingerprint: %s',
-    sourceFingerprint => {
-      expect(() => createMethod({ sourceFingerprint }).init()).toThrow('uint32');
-    }
-  );
 });

--- a/packages/core/src/api/solana/SolSignOffchainMessage.ts
+++ b/packages/core/src/api/solana/SolSignOffchainMessage.ts
@@ -9,9 +9,7 @@ import type { SolanaSignOffChainMessage as HardwareSolSignOffChainMessage } from
 const SOLANA_PUBLIC_KEY_LENGTH = 32;
 const SOLANA_APPLICATION_DOMAIN_LENGTH = 32;
 
-const normalizeRequiredSigners = (requiredSigners?: unknown[]): string[] | undefined => {
-  if (!requiredSigners) return undefined;
-
+const normalizeRequiredSigners = (requiredSigners: unknown[] = []): string[] => {
   const normalized = requiredSigners.map((signer, index) => {
     if (
       typeof signer !== 'string' ||
@@ -50,7 +48,6 @@ export default class SolSignOffchainMessage extends BaseMethod<HardwareSolSignOf
       { name: 'messageVersion', type: 'number', required: false },
       { name: 'messageFormat', type: 'number', required: false },
       { name: 'applicationDomainHex', type: 'hexString', required: false },
-      { name: 'sourceFingerprint', type: 'number', required: false },
       { name: 'requiredSigners', type: 'array', required: false, allowEmpty: true },
     ]);
 
@@ -60,18 +57,9 @@ export default class SolSignOffchainMessage extends BaseMethod<HardwareSolSignOf
       messageVersion,
       messageFormat,
       applicationDomainHex,
-      sourceFingerprint,
       requiredSigners,
     } = this.payload;
     const addressN = validatePath(path, 3);
-    if (
-      sourceFingerprint !== undefined &&
-      (!Number.isInteger(sourceFingerprint) ||
-        sourceFingerprint < 0 ||
-        sourceFingerprint > 0xffffffff)
-    ) {
-      throw invalidParameter('Parameter [sourceFingerprint] must be a uint32 number.');
-    }
     if (
       applicationDomainHex !== undefined &&
       !isHexString(addHexPrefix(applicationDomainHex), SOLANA_APPLICATION_DOMAIN_LENGTH)
@@ -86,7 +74,6 @@ export default class SolSignOffchainMessage extends BaseMethod<HardwareSolSignOf
       message_version: messageVersion ?? undefined,
       message_format: messageFormat ?? undefined,
       application_domain: applicationDomainHex ? stripHexPrefix(applicationDomainHex) : undefined,
-      source_fingerprint: sourceFingerprint ?? undefined,
       required_signers: normalizeRequiredSigners(requiredSigners),
     };
   }

--- a/packages/core/src/data/messages/messages-protocol-v2.json
+++ b/packages/core/src/data/messages/messages-protocol-v2.json
@@ -4463,10 +4463,6 @@
         "request_id": {
           "type": "bytes",
           "id": 5
-        },
-        "source_fingerprint": {
-          "type": "uint32",
-          "id": 6
         }
       }
     },
@@ -4722,10 +4718,6 @@
         "expected_address": {
           "type": "bytes",
           "id": 12
-        },
-        "source_fingerprint": {
-          "type": "uint32",
-          "id": 13
         }
       }
     },
@@ -4810,10 +4802,6 @@
         "expected_address": {
           "type": "bytes",
           "id": 12
-        },
-        "source_fingerprint": {
-          "type": "uint32",
-          "id": 13
         }
       }
     },
@@ -4961,7 +4949,14 @@
           "type": "EthereumAuthorizationSignature",
           "id": 10
         }
-      }
+      },
+      "reserved": [
+        [5, 5],
+        [6, 6],
+        [7, 7],
+        [8, 8],
+        [9, 9]
+      ]
     },
     "EthereumTxAckOneKey": {
       "fields": {
@@ -4990,10 +4985,6 @@
         "chain_id": {
           "type": "uint64",
           "id": 3
-        },
-        "source_fingerprint": {
-          "type": "uint32",
-          "id": 4
         }
       }
     },
@@ -9017,10 +9008,6 @@
           "rule": "required",
           "type": "bytes",
           "id": 2
-        },
-        "source_fingerprint": {
-          "type": "uint32",
-          "id": 3
         }
       }
     },
@@ -9063,14 +9050,10 @@
           "type": "bytes",
           "id": 5
         },
-        "source_fingerprint": {
-          "type": "uint32",
-          "id": 6
-        },
         "required_signers": {
           "rule": "repeated",
           "type": "bytes",
-          "id": 7
+          "id": 6
         }
       }
     },
@@ -9088,10 +9071,6 @@
           "rule": "required",
           "type": "bytes",
           "id": 2
-        },
-        "source_fingerprint": {
-          "type": "uint32",
-          "id": 3
         }
       }
     },
@@ -11888,6 +11867,10 @@
         "manufacture_time": {
           "type": "DeviceFactoryInfoManufactureTime",
           "id": 5
+        },
+        "data": {
+          "type": "bytes",
+          "id": 100
         }
       }
     },
@@ -11897,11 +11880,20 @@
           "rule": "required",
           "type": "DeviceFactoryInfo",
           "id": 1
+        },
+        "full_data": {
+          "type": "bool",
+          "id": 2
         }
       }
     },
     "DeviceFactoryInfoGet": {
-      "fields": {}
+      "fields": {
+        "full_data": {
+          "type": "bool",
+          "id": 1
+        }
+      }
     },
     "DeviceFactoryPermanentLock": {
       "fields": {

--- a/packages/core/src/types/api/solSignOffchainMessage.ts
+++ b/packages/core/src/types/api/solSignOffchainMessage.ts
@@ -15,7 +15,6 @@ export type SolSignOffchainMessageParams = {
   messageVersion?: SolanaOffChainMessageVersion;
   messageFormat?: SolanaOffChainMessageFormat;
   applicationDomainHex?: string;
-  sourceFingerprint?: number;
   /** 32-byte public keys encoded as hex, strictly sorted and unique. */
   requiredSigners?: string[];
 };

--- a/packages/hd-transport/__tests__/protocol-v2.test.js
+++ b/packages/hd-transport/__tests__/protocol-v2.test.js
@@ -300,7 +300,7 @@ describe('Protocol V2 framing and session', () => {
     });
   });
 
-  test('round-trips Solana v1 off-chain required signers with the production schema', () => {
+  test('encodes Solana v1 off-chain required signers as firmware field 6', () => {
     const productionSchemas = {
       protocolV1: protocolV1Messages,
       protocolV2: productionProtocolV2Messages,
@@ -312,6 +312,16 @@ describe('Protocol V2 framing and session', () => {
       message_version: 1,
       required_signers: requiredSigners,
     });
+
+    // Check the wire tag independently of the SDK schema: field 6, wire type 2.
+    const expectedSignersPayload = Buffer.concat(
+      requiredSigners.map(signer =>
+        Buffer.concat([Buffer.from([0x32, 0x20]), Buffer.from(signer, 'hex')])
+      )
+    );
+    expect(
+      Buffer.from(protocolV2.decodeFrame(frame).pbPayload).subarray(-expectedSignersPayload.length)
+    ).toEqual(expectedSignersPayload);
 
     expect(ProtocolV2.decodeFrame(productionSchemas, frame)).toMatchObject({
       type: 'SolanaSignOffChainMessage',

--- a/packages/hd-transport/messages-protocol-v2.json
+++ b/packages/hd-transport/messages-protocol-v2.json
@@ -4463,10 +4463,6 @@
         "request_id": {
           "type": "bytes",
           "id": 5
-        },
-        "source_fingerprint": {
-          "type": "uint32",
-          "id": 6
         }
       }
     },
@@ -4722,10 +4718,6 @@
         "expected_address": {
           "type": "bytes",
           "id": 12
-        },
-        "source_fingerprint": {
-          "type": "uint32",
-          "id": 13
         }
       }
     },
@@ -4810,10 +4802,6 @@
         "expected_address": {
           "type": "bytes",
           "id": 12
-        },
-        "source_fingerprint": {
-          "type": "uint32",
-          "id": 13
         }
       }
     },
@@ -4961,7 +4949,14 @@
           "type": "EthereumAuthorizationSignature",
           "id": 10
         }
-      }
+      },
+      "reserved": [
+        [5, 5],
+        [6, 6],
+        [7, 7],
+        [8, 8],
+        [9, 9]
+      ]
     },
     "EthereumTxAckOneKey": {
       "fields": {
@@ -4990,10 +4985,6 @@
         "chain_id": {
           "type": "uint64",
           "id": 3
-        },
-        "source_fingerprint": {
-          "type": "uint32",
-          "id": 4
         }
       }
     },
@@ -9017,10 +9008,6 @@
           "rule": "required",
           "type": "bytes",
           "id": 2
-        },
-        "source_fingerprint": {
-          "type": "uint32",
-          "id": 3
         }
       }
     },
@@ -9063,14 +9050,10 @@
           "type": "bytes",
           "id": 5
         },
-        "source_fingerprint": {
-          "type": "uint32",
-          "id": 6
-        },
         "required_signers": {
           "rule": "repeated",
           "type": "bytes",
-          "id": 7
+          "id": 6
         }
       }
     },
@@ -9088,10 +9071,6 @@
           "rule": "required",
           "type": "bytes",
           "id": 2
-        },
-        "source_fingerprint": {
-          "type": "uint32",
-          "id": 3
         }
       }
     },
@@ -11888,6 +11867,10 @@
         "manufacture_time": {
           "type": "DeviceFactoryInfoManufactureTime",
           "id": 5
+        },
+        "data": {
+          "type": "bytes",
+          "id": 100
         }
       }
     },
@@ -11897,11 +11880,20 @@
           "rule": "required",
           "type": "DeviceFactoryInfo",
           "id": 1
+        },
+        "full_data": {
+          "type": "bool",
+          "id": 2
         }
       }
     },
     "DeviceFactoryInfoGet": {
-      "fields": {}
+      "fields": {
+        "full_data": {
+          "type": "bool",
+          "id": 1
+        }
+      }
     },
     "DeviceFactoryPermanentLock": {
       "fields": {

--- a/packages/hd-transport/src/types/messages.ts
+++ b/packages/hd-transport/src/types/messages.ts
@@ -1951,7 +1951,6 @@ export type EthereumSignTxOneKey = {
   chain_id: number;
   tx_type?: number;
   expected_address?: string;
-  source_fingerprint?: number;
 };
 
 // EthereumAccessListOneKey
@@ -1974,7 +1973,6 @@ export type EthereumSignTxEIP1559OneKey = {
   chain_id: number;
   access_list: EthereumAccessListOneKey[];
   expected_address?: string;
-  source_fingerprint?: number;
 };
 
 // EthereumAuthorizationSignature
@@ -2027,7 +2025,6 @@ export type EthereumSignMessageOneKey = {
   address_n: number[];
   message: string;
   chain_id?: number;
-  source_fingerprint?: number;
 };
 
 // EthereumMessageSignatureOneKey
@@ -3820,7 +3817,6 @@ export type SolanaSignTx = {
   address_n: number[];
   raw_tx: string;
   extra_info?: SolanaTxExtraInfo;
-  source_fingerprint?: number;
 };
 
 // SolanaSignedTx
@@ -3846,14 +3842,12 @@ export type SolanaSignOffChainMessage = {
   message_format?: SolanaOffChainMessageFormat;
   application_domain?: string;
   required_signers: string[];
-  source_fingerprint?: number;
 };
 
 // SolanaSignUnsafeMessage
 export type SolanaSignUnsafeMessage = {
   address_n: number[];
   message: string;
-  source_fingerprint?: number;
 };
 
 // SolanaMessageSignature
@@ -4598,7 +4592,6 @@ export type EthereumSignTypedDataQR = {
   chain_id?: number;
   metamask_v4_compat?: boolean;
   request_id?: string;
-  source_fingerprint?: number;
 };
 
 // SetBusy
@@ -4812,15 +4805,19 @@ export type DeviceFactoryInfo = {
   factory_test_completed?: boolean;
   factory_burn_in_completed?: boolean;
   manufacture_time?: DeviceFactoryInfoManufactureTime;
+  data?: string;
 };
 
 // DeviceFactoryInfoSet
 export type DeviceFactoryInfoSet = {
   info: DeviceFactoryInfo;
+  full_data?: boolean;
 };
 
 // DeviceFactoryInfoGet
-export type DeviceFactoryInfoGet = {};
+export type DeviceFactoryInfoGet = {
+  full_data?: boolean;
+};
 
 // DeviceFactoryPermanentLock
 export type DeviceFactoryPermanentLock = {


### PR DESCRIPTION
Pro2 firmware on `main` now uses protobuf field 6 for `SolanaSignOffChainMessage.required_signers`, while the SDK still encoded field 7. This change aligns the SDK with the current firmware wire format.

Switch `submodules/firmware-pro2` from tracking `dev` to `main`, pin it to `947182460`, and regenerate both Protocol V2 catalogs and transport types. Remove the obsolete Solana `sourceFingerprint` API parameter and mapping, normalize omitted signers to an empty protobuf list, and assert the actual field-6 wire tag independently of the SDK schema. Generated changes also include upstream EVM fingerprint removals and factory-info fields.

Legacy Pro compatibility: the Protocol V1 schema is unchanged. It never defined `source_fingerprint`, and `required_signers` remains field 7. Compared the base and PR Protocol V1 request bytes for off-chain message v0 without signers and v1 with signers, including the former source fingerprint input; both are identical. Removing the public `sourceFingerprint` property is nevertheless a TypeScript source-compatibility change for consumers that explicitly pass it. Pro2 off-chain v1 requests now target firmware using the field-6 layout, not older Pro2 builds using field 7.

App impact: checked `app-monorepo` current checkout and `origin/x` at `57d0cbe3fad`. Its Solana hardware handler already passes sorted hex `requiredSigners` and does not use `sourceFingerprint`, so no business-logic change is needed. After an SDK release containing this PR, update the app's aligned hardware SDK dependencies, `resolutions`, and `yarn.lock` from `1.2.2-alpha.101`.

Validation:
- `yarn agent:check --profile commit`: passed; Core 1,258 tests and transport 141 tests passed, along with changed-file lint and both package builds.
- `yarn agent:check --profile pr`: passed, including full lint, tests across 18 packages, full build, and package-version alignment.
- Core and transport TypeScript checks passed; all three Solana signing schemas match firmware `main` directly.
- App `KeyringHardware.test.ts`: 2 tests passed.
- Legacy Pro Protocol V1 byte-level compatibility checks passed for off-chain message v0 and v1.
- No physical-device signing test was performed.
