### PR TITLE
fix: retry Protocol V2 wallet session busy responses

### DIFF
--- a/packages/core/__tests__/DeviceCommands.test.ts
+++ b/packages/core/__tests__/DeviceCommands.test.ts
@@ -1,6 +1,9 @@
 import { ERRORS, HardwareErrorCode } from '@onekeyfe/hd-shared';
 import { DeviceSessionErrorCode } from '@onekeyfe/hd-transport';
 
+import { DataManager } from '../src/data-manager';
+import TransportManager from '../src/data-manager/TransportManager';
+import { Device } from '../src/device/Device';
 import { DeviceCommands } from '../src/device/DeviceCommands';
 import { DEVICE } from '../src/events';
 import { LoggerNames, getLogger } from '../src/utils';
@@ -958,6 +961,75 @@ describe('DeviceCommands Protocol V2 session busy retry', () => {
     await flushCalls();
     await expect(result).resolves.toBe(error);
     expect(call).toHaveBeenCalledTimes(2);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('stops a superseded retry when a React Native run reuses the commands', async () => {
+    jest.spyOn(DataManager, 'getSettings').mockReturnValue('react-native' as never);
+    const call = jest.fn().mockResolvedValueOnce(busy).mockResolvedValueOnce(busy);
+    call.mockResolvedValue(success);
+    const cancel = jest.fn();
+    jest.spyOn(TransportManager, 'getTransport').mockReturnValue({
+      call,
+      cancel,
+    } as DeviceCommands['transport']);
+    const device = Device.fromDescriptor({
+      id: 'ble-device',
+      path: 'ble-device',
+      name: 'OneKey Test',
+      debug: false,
+      commType: 'ble',
+      protocolType: 'V2',
+    });
+    const commands = new DeviceCommands(device, 'ble-device');
+    device.commands = commands;
+    const release = jest.spyOn(device, 'release');
+    const continued = jest.fn();
+    let staleCallResult: Promise<unknown> | undefined;
+    const staleRun = device
+      .run(
+        async () => {
+          const operation = commands.typedCall('DeviceSessionAskPassphrase', 'Success', {
+            on_device: true,
+          });
+          staleCallResult = operation.catch(error => error);
+          await operation;
+          continued();
+        },
+        { keepSession: true }
+      )
+      .catch(error => error);
+    await flushCalls();
+
+    const nextRun = device.run(
+      async () => {
+        await commands.typedCall('DeviceSessionAskPin', 'Success');
+      },
+      { keepSession: true }
+    );
+    await flushCalls();
+    expect(device.commands).toBe(commands);
+    expect(commands.disposed).toBe(false);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(call).toHaveBeenCalledTimes(2);
+
+    jest.advanceTimersByTime(100);
+    await flushCalls();
+
+    await expect(staleRun).resolves.toMatchObject({
+      errorCode: HardwareErrorCode.DeviceInterruptedFromOutside,
+    });
+    await expect(staleCallResult).resolves.toMatchObject({
+      errorCode: HardwareErrorCode.RuntimeError,
+    });
+    await expect(nextRun).resolves.toBeUndefined();
+    expect(call.mock.calls.map(([, request]) => request)).toEqual([
+      'DeviceSessionAskPassphrase',
+      'DeviceSessionAskPin',
+      'DeviceSessionAskPin',
+    ]);
+    expect(continued).not.toHaveBeenCalled();
+    expect(release).not.toHaveBeenCalled();
     expect(jest.getTimerCount()).toBe(0);
   });
 

--- a/packages/core/__tests__/DeviceCommands.test.ts
+++ b/packages/core/__tests__/DeviceCommands.test.ts
@@ -1,4 +1,5 @@
-import { HardwareErrorCode } from '@onekeyfe/hd-shared';
+import { ERRORS, HardwareErrorCode } from '@onekeyfe/hd-shared';
+import { DeviceSessionErrorCode } from '@onekeyfe/hd-transport';
 
 import { DeviceCommands } from '../src/device/DeviceCommands';
 import { DEVICE } from '../src/events';
@@ -805,6 +806,186 @@ describe('DeviceCommands Protocol V2 interactive response compatibility', () => 
       errorCode: HardwareErrorCode.RuntimeError,
     });
   });
+});
+
+describe('DeviceCommands Protocol V2 session busy retry', () => {
+  const busy = {
+    type: 'Failure',
+    message: {
+      code: 'Failure_ProcessError',
+      subcode: DeviceSessionErrorCode.DeviceSessionError_Busy,
+      message: 'Another flow in progress',
+    },
+  } as const;
+  const success = { type: 'Success', message: {} } as const;
+  const flushCalls = () =>
+    new Promise<void>(resolve => {
+      setImmediate(resolve);
+    });
+
+  beforeEach(() => {
+    jest.useFakeTimers({ doNotFake: ['performance', 'setImmediate'] });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  const setup = () => {
+    const commands = createCommands();
+    commands.device.wasInterruptedByUser = jest.fn(() => false);
+    commands.mainId = 'main-id';
+    const call = jest.fn();
+    commands.transport = { call } as DeviceCommands['transport'];
+    return { commands, call };
+  };
+
+  it.each(['DeviceSessionGet', 'DeviceSessionAskPin', 'DeviceSessionAskPassphrase'] as const)(
+    'retries %s busy responses at 100 ms intervals without matching their message',
+    async request => {
+      const { commands, call } = setup();
+      const response =
+        request === 'DeviceSessionGet' ? { type: 'DeviceSession' as const, message: {} } : success;
+      call
+        .mockResolvedValueOnce(busy)
+        .mockResolvedValueOnce({
+          type: 'Failure',
+          message: { ...busy.message, message: 'Passphrase entry busy' },
+        })
+        .mockResolvedValueOnce({
+          type: 'Failure',
+          message: { ...busy.message, message: 'Passphrase confirm busy' },
+        })
+        .mockResolvedValue(response);
+      const payload = request === 'DeviceSessionAskPassphrase' ? { on_device: true } : {};
+      const result = commands.typedCall(request, response.type, payload).catch(error => error);
+      await flushCalls();
+
+      for (let attempt = 1; attempt <= 3; attempt += 1) {
+        jest.advanceTimersByTime(99);
+        await flushCalls();
+        expect(call).toHaveBeenCalledTimes(attempt);
+        jest.advanceTimersByTime(1);
+        await flushCalls();
+        expect(call).toHaveBeenCalledTimes(attempt + 1);
+      }
+
+      await expect(result).resolves.toEqual(response);
+      expect(call.mock.calls).toEqual(
+        Array.from({ length: 4 }, () => [
+          commands.mainId,
+          request,
+          payload,
+          { expectedTypes: [response.type] },
+        ])
+      );
+      expect(jest.getTimerCount()).toBe(0);
+    }
+  );
+
+  it('preserves the final busy error after three retries', async () => {
+    const { commands, call } = setup();
+    call.mockResolvedValue(busy);
+    const result = commands.typedCall('DeviceSessionGet', 'DeviceSession').catch(error => error);
+    await flushCalls();
+    for (let retry = 0; retry < 3; retry += 1) {
+      jest.advanceTimersByTime(100);
+      await flushCalls();
+    }
+
+    expect(call).toHaveBeenCalledTimes(4);
+    await expect(result).resolves.toMatchObject({
+      errorCode: HardwareErrorCode.DeviceBusy,
+      params: {
+        failureCode: 'Failure_ProcessError',
+        subcode: DeviceSessionErrorCode.DeviceSessionError_Busy,
+        firmwareMessage: 'Another flow in progress',
+      },
+    });
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('does not delay a successful session request', async () => {
+    const { commands, call } = setup();
+    call.mockResolvedValue(success);
+    await expect(commands.typedCall('DeviceSessionAskPin', 'Success')).resolves.toEqual(success);
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it.each([
+    ['DeviceSessionAskPin', 'Failure_ProcessError', 0],
+    [
+      'DeviceSessionGet',
+      'Failure_ProcessError',
+      DeviceSessionErrorCode.DeviceSessionError_InvalidSession,
+    ],
+    [
+      'DeviceSessionAskPassphrase',
+      'Failure_ProcessError',
+      DeviceSessionErrorCode.DeviceSessionError_UserCancelled,
+    ],
+    ['DeviceSessionGet', 'Failure_DataError', DeviceSessionErrorCode.DeviceSessionError_Busy],
+    ['DeviceSettingsSet', 'Failure_ProcessError', 5],
+    ['EthereumSignTx', 'Failure_ProcessError', 5],
+  ] as const)('does not retry %s with %s subcode %s', async (request, code, subcode) => {
+    const { commands, call } = setup();
+    call.mockResolvedValue({ type: 'Failure', message: { code, subcode, message: 'Busy' } });
+    await expect(commands.typedCall(request, 'Success')).rejects.toBeInstanceOf(Error);
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('does not retry Protocol V1 busy responses', async () => {
+    const { commands, call } = setup();
+    commands.device.isProtocolV2 = () => false;
+    call.mockResolvedValue(busy);
+    await expect(commands.typedCall('DeviceSessionGet', 'DeviceSession')).rejects.toMatchObject({
+      errorCode: HardwareErrorCode.DeviceBusy,
+    });
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('stops retrying when the next attempt fails at the transport layer', async () => {
+    const { commands, call } = setup();
+    const error = ERRORS.TypedError(HardwareErrorCode.BridgeDeviceDisconnected);
+    call.mockResolvedValueOnce(busy).mockRejectedValue(error);
+    const result = commands.typedCall('DeviceSessionGet', 'DeviceSession').catch(err => err);
+    await flushCalls();
+    jest.advanceTimersByTime(100);
+    await flushCalls();
+    await expect(result).resolves.toBe(error);
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it.each(['cancelled', 'disposed'] as const)(
+    'does not resend when %s during backoff',
+    async state => {
+      const { commands, call } = setup();
+      call.mockResolvedValueOnce(busy).mockResolvedValue(success);
+      const result = commands.typedCall('DeviceSessionAskPin', 'Success').catch(error => error);
+      await flushCalls();
+      if (state === 'cancelled') {
+        commands.device.wasInterruptedByUser = () => true;
+      } else {
+        commands.disposed = true;
+      }
+      jest.advanceTimersByTime(100);
+      await flushCalls();
+
+      await expect(result).resolves.toMatchObject({
+        errorCode:
+          state === 'cancelled'
+            ? HardwareErrorCode.DeviceInterruptedFromUser
+            : HardwareErrorCode.RuntimeError,
+      });
+      expect(call).toHaveBeenCalledTimes(1);
+      expect(jest.getTimerCount()).toBe(0);
+    }
+  );
 });
 
 describe('DeviceCommands cancellation', () => {

--- a/packages/core/src/device/DeviceCommands.ts
+++ b/packages/core/src/device/DeviceCommands.ts
@@ -11,7 +11,7 @@ import {
 } from '@onekeyfe/hd-transport';
 
 import TransportManager from '../data-manager/TransportManager';
-import { LoggerNames, getLogger, patchFeatures } from '../utils';
+import { LoggerNames, getLogger, patchFeatures, wait } from '../utils';
 import { DEVICE, type PassphraseRequestPayload } from '../events';
 import { DeviceModelToTypes } from '../types';
 import {
@@ -439,7 +439,26 @@ export class DeviceCommands {
     msg?: DefaultMessageResponse['message'],
     options?: TransportCallOptions
   ) {
-    const resp = await this.call(type, msg, options);
+    let resp = await this.call(type, msg, options);
+    // Session busy failures precede wallet derivation or reject an occupied flow.
+    // Three retries cover the 240 ms PIN dismissal animation on older V2 firmware.
+    for (
+      let retry = 0;
+      retry < 3 &&
+      this.device.isProtocolV2() &&
+      DEVICE_SESSION_CALLS.has(type) &&
+      resp.type === 'Failure' &&
+      (resp.message.code as string | FailureType) === 'Failure_ProcessError' &&
+      resp.message.subcode === DeviceSessionErrorCode.DeviceSessionError_Busy;
+      retry += 1
+    ) {
+      await wait(100);
+      if (this.device.wasInterruptedByUser()) {
+        throw ERRORS.TypedError(HardwareErrorCode.DeviceInterruptedFromUser);
+      }
+      this.checkDisposed();
+      resp = await this.call(type, msg, options);
+    }
     return this._filterCommonTypes(resp, type, options);
   }
 

--- a/packages/core/src/device/DeviceCommands.ts
+++ b/packages/core/src/device/DeviceCommands.ts
@@ -198,6 +198,8 @@ export class DeviceCommands {
 
   disposed: boolean;
 
+  private disposalToken?: object;
+
   callPromise?: Promise<DefaultMessageResponse>;
 
   constructor(device: Device, mainId: string) {
@@ -212,6 +214,7 @@ export class DeviceCommands {
 
   async dispose(_cancelRequest: boolean) {
     this.disposed = true;
+    this.disposalToken = {};
     await this.transport.cancel?.();
   }
 
@@ -439,6 +442,7 @@ export class DeviceCommands {
     msg?: DefaultMessageResponse['message'],
     options?: TransportCallOptions
   ) {
+    const { disposalToken } = this;
     let resp = await this.call(type, msg, options);
     // Session busy failures precede wallet derivation or reject an occupied flow.
     // Three retries cover the 240 ms PIN dismissal animation on older V2 firmware.
@@ -457,6 +461,10 @@ export class DeviceCommands {
         throw ERRORS.TypedError(HardwareErrorCode.DeviceInterruptedFromUser);
       }
       this.checkDisposed();
+      if (this.disposalToken !== disposalToken) {
+        // React Native can revive this instance. A stale retry must not release the new run.
+        throw ERRORS.TypedError(HardwareErrorCode.RuntimeError, 'DeviceCommands lifecycle changed');
+      }
       resp = await this.call(type, msg, options);
     }
     return this._filterCommonTypes(resp, type, options);


### PR DESCRIPTION
## Summary

Handle transient Protocol V2 wallet-session busy responses without failing the App flow immediately. This covers Pro2 firmware returning `DeviceSessionAskPin -> Success` while the PIN dismissal animation is still running.

Fixes [OK-62075](https://onekeyhq.atlassian.net/browse/OK-62075).

## Design decisions

- Retry `Failure_ProcessError` with `DeviceSessionError_Busy` in Core `DeviceCommands._commonCall`, independent of firmware message text.
- Limit retries to `DeviceSessionGet`, `DeviceSessionAskPin`, and `DeviceSessionAskPassphrase` on Protocol V2. Other command domains reuse subcode 5 for different failures.
- Wait 100 ms between attempts, with at most three retries after the initial request. Total backoff is at most 300 ms, plus device response time, covering the 240 ms animation in affected firmware. Successful first attempts have no added delay.
- Reuse the original request and response expectations. Check cancellation and disposal before resending, propagate transport errors immediately, and preserve the normal final error mapping when retries are exhausted.
- Bind retries to the Commands lifecycle. Disposal invalidates pending retries even when React Native reuses the same instance. A stale retry exits with a non-releasing lifecycle error, while the superseded public run keeps its existing interruption result.

## Compatibility and risk

Protocol V1, public APIs, and public error codes are unchanged. Signing and device-control commands are outside the retry scope. Firmware review confirmed that Session busy failures reject an occupied flow or occur before wallet derivation when opening the passphrase UI fails.

## Hardware coverage

The change is in the Core path shared by USB and BLE. Validation uses mocked firmware responses; physical Pro2 USB/BLE verification is still pending.

## Test plan

- [x] `yarn agent:check --profile commit`: passed, including changed-file lint, all 88 Core test suites (1,274 tests passed, 4 skipped), and Core build.
- [x] Added 16 focused regression cases covering the three Session commands, message-independent matching, 100 ms spacing, retry exhaustion, immediate success, V1 and unrelated error exclusion, transport failure, cancellation, disposal, and React Native takeover while a retry is waiting. The takeover test also verifies that the new run can retry successfully and the stale run does not release its connection.
- [x] `yarn agent:check --profile pr`: passed, including package versions, full-repository lint, tests, and build.
- [ ] Verify unlock followed by wallet opening/resume on a physical Pro2 over USB and BLE, including cancellation and persistent busy.


[OK-62075]: https://onekeyhq.atlassian.net/browse/OK-62075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ