### PR TITLE
docs: update package README links and deprecate keepSession

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ architecture boundary.
 
 ## Documentation
 
-- [Developer documentation](https://developer.onekey.so/connect-to-hardware/hardware-sdk):
+- [Developer documentation](https://developer.onekey.so/en/hardware-sdk/getting-started):
   integration and public API guidance.
 - [Internal documentation index](./docs/README.md): architecture, protocol, device, SDK, business,
   design, testing, and maintenance facts.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -26,7 +26,7 @@ import Core from '@onekeyfe/hd-core';
 
 ## Docs
 
-Documentation is available [hardware-js-sdk](https://developer.onekey.so/connect-to-hardware/hardware-sdk/start)
+Documentation is available [Hardware SDK Getting Started](https://developer.onekey.so/en/hardware-sdk/getting-started)
 
 ## Examples
 // TODO: add example url

--- a/packages/core/src/types/params.ts
+++ b/packages/core/src/types/params.ts
@@ -1,6 +1,10 @@
 import type { HardwareConnectProtocol } from '@onekeyfe/hd-shared';
 
 export interface CommonParams {
+  /**
+   * @deprecated Use `useEmptyPassphrase` for the standard wallet, or
+   * `openWalletSession` plus `passphraseState` for a hidden wallet.
+   */
   keepSession?: boolean;
   /**
    * polling connect max retry count

--- a/packages/hd-ble-sdk/README.md
+++ b/packages/hd-ble-sdk/README.md
@@ -30,7 +30,7 @@ function init() {
 
 ## Docs
 
-Documentation is available [hardware-js-sdk](https://developer.onekey.so/connect-to-hardware/hardware-sdk/start)
+Documentation is available [Hardware SDK Getting Started](https://developer.onekey.so/en/hardware-sdk/getting-started)
 
 ## Examples
 // TODO: add example url

--- a/packages/hd-common-connect-sdk/README.md
+++ b/packages/hd-common-connect-sdk/README.md
@@ -30,7 +30,7 @@ function init() {
 
 ## Docs
 
-Documentation is available [hardware-js-sdk](https://developer.onekey.so/connect-to-hardware/hardware-sdk/start)
+Documentation is available [Hardware SDK Getting Started](https://developer.onekey.so/en/hardware-sdk/getting-started)
 
 ## Examples
 // TODO: add example url

--- a/packages/hd-transport-http/README.md
+++ b/packages/hd-transport-http/README.md
@@ -26,4 +26,4 @@ yar update:protobuf to generate new ./messages.json and ./src/types/messages.ts
 
 ## Docs
 
-Documentation is available [hardware-js-sdk](https://developer.onekey.so/connect-to-hardware/hardware-sdk/start)
+Documentation is available [Hardware SDK Getting Started](https://developer.onekey.so/en/hardware-sdk/getting-started)

--- a/packages/hd-transport-lowlevel/README.md
+++ b/packages/hd-transport-lowlevel/README.md
@@ -26,4 +26,4 @@ yarn update:protobuf to generate new ./messages.json and ./src/types/messages.ts
 
 ## Docs
 
-Documentation is available [hardware-js-sdk](https://developer.onekey.so/connect-to-hardware/hardware-sdk/start)
+Documentation is available [Hardware SDK Getting Started](https://developer.onekey.so/en/hardware-sdk/getting-started)

--- a/packages/hd-transport-react-native/README.md
+++ b/packages/hd-transport-react-native/README.md
@@ -26,4 +26,4 @@ yar update:protobuf to generate new ./messages.json and ./src/types/messages.ts
 
 ## Docs
 
-Documentation is available [hardware-js-sdk](https://developer.onekey.so/connect-to-hardware/hardware-sdk/start)
+Documentation is available [Hardware SDK Getting Started](https://developer.onekey.so/en/hardware-sdk/getting-started)

--- a/packages/hd-transport-web-device/README.md
+++ b/packages/hd-transport-web-device/README.md
@@ -26,4 +26,4 @@ yar update:protobuf to generate new ./messages.json and ./src/types/messages.ts
 
 ## Docs
 
-Documentation is available [hardware-js-sdk](https://developer.onekey.so/connect-to-hardware/hardware-sdk/start)
+Documentation is available [Hardware SDK Getting Started](https://developer.onekey.so/en/hardware-sdk/getting-started)

--- a/packages/hd-transport/README.md
+++ b/packages/hd-transport/README.md
@@ -24,4 +24,4 @@ The same task can be run from the repository root with `yarn update-protobuf`. T
 
 ## Docs
 
-Documentation is available [hardware-js-sdk](https://developer.onekey.so/connect-to-hardware/hardware-sdk/start)
+Documentation is available [Hardware SDK Getting Started](https://developer.onekey.so/en/hardware-sdk/getting-started)

--- a/packages/hd-web-sdk/README.md
+++ b/packages/hd-web-sdk/README.md
@@ -24,11 +24,11 @@ import { HardwareSDK } from '@onekeyfe/hd-web-sdk';
 function init() {
   HardwareSDK.init({
     debug: false,
-    connectSrc: 'https://jssdk.onekey.so/'
+    // omit connectSrc — SDK fills https://jssdk.onekey.so/<installed-version>/
   });
 }
 ```
 
 ## Docs
 
-Documentation is available [hardware-js-sdk](https://developer.onekey.so/connect-to-hardware/hardware-sdk/start)
+Documentation is available [Hardware SDK Getting Started](https://developer.onekey.so/en/hardware-sdk/getting-started)


### PR DESCRIPTION
## Summary

Point published package READMEs at the 1.2.x Getting Started path, omit the stale iframe `connectSrc` sample, and mark public `keepSession` as deprecated.

## Intent and context

The developer portal 1.2.0 docs (see #920) tell integrators to:

- Start at `/en/hardware-sdk/getting-started`
- Omit `connectSrc` so `@onekeyfe/hd-web-sdk` fills `https://jssdk.onekey.so/<installed-version>/`
- Use `useEmptyPassphrase` / `openWalletSession` + `passphraseState` instead of `keepSession`

npm READMEs and `CommonParams` still taught the old contract.

## Root cause

Package-surface docs were not updated when Hardware SDK 1.2.0 shipped Protocol V2 wallet sessions.

## Design decisions

- README links go to `https://developer.onekey.so/en/hardware-sdk/getting-started`.
- `hd-web-sdk` init sample omits `connectSrc`; the SDK default is already `DEFAULT_DOMAIN` from `getSDKVersion()`.
- `@deprecated` is on public `CommonParams.keepSession` only. Transport `release(..., keepSession)` stays internal.
- `getPassphraseState` stays compatibility, not deprecated.

## Compatibility and risk

No runtime change. Existing `keepSession: true` calls still work. TypeScript consumers see a deprecation warning.

## Hardware coverage

Not applicable.

## Test plan

- [x] `yarn agent:check --profile commit` lint/whitespace/agent-context passed
- [ ] `@onekeyfe/hd-core` test: 1 unrelated failure in `evmSignTypedData.test.ts` (`BigNumber` parse of `0x89`). This PR only touches README + a JSDoc block on `keepSession`.
- [x] Staged files reviewed: 10 READMEs + `packages/core/src/types/params.ts`
