### PR TITLE
fix: preserve BLE pairing errors during protocol detection (OK-62220)

### DIFF
--- a/packages/core/__tests__/core-error-output.test.ts
+++ b/packages/core/__tests__/core-error-output.test.ts
@@ -1,4 +1,8 @@
-import { initCore } from '../src/core';
+import { ERRORS, HardwareErrorCode } from '@onekeyfe/hd-shared';
+
+import { initConnector, initCore } from '../src/core';
+import { DataManager } from '../src/data-manager';
+import TransportManager from '../src/data-manager/TransportManager';
 import { IFRAME } from '../src/events';
 
 jest.mock('../src/data/config', () => ({
@@ -9,12 +13,62 @@ jest.mock('../src/data/config', () => ({
 jest.mock('../src/data-manager/TransportManager', () => ({
   __esModule: true,
   default: {
+    load: jest.fn(),
     configure: jest.fn().mockResolvedValue(undefined),
     getTransport: jest.fn(() => undefined),
   },
 }));
 
 describe('Core 错误输出边界', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test.each([
+    HardwareErrorCode.BleDeviceNotBonded,
+    HardwareErrorCode.BleDeviceBondedCanceled,
+    HardwareErrorCode.BleDeviceDisconnected,
+    HardwareErrorCode.PollingTimeout,
+  ])(
+    'preserves terminal BLE error %s in the public response without polling again',
+    async errorCode => {
+      jest.spyOn(DataManager, 'getSettings').mockReturnValue('react-native' as never);
+      const error = ERRORS.TypedError(errorCode);
+      const acquire = jest.fn().mockRejectedValue(error);
+      jest.spyOn(TransportManager, 'getTransport').mockReturnValue({
+        acquire,
+        release: jest.fn().mockResolvedValue(true),
+        stop: jest.fn().mockResolvedValue(undefined),
+      } as never);
+      const core = initCore();
+      initConnector();
+
+      try {
+        const response = await core.handleMessage({
+          id: 1,
+          event: IFRAME.CALL,
+          type: IFRAME.CALL,
+          payload: {
+            method: 'getDeviceState',
+            connectId: 'ble-pairing-test',
+            forceProtocolDetection: true,
+            retryCount: 1,
+            pollIntervalTime: 1,
+            timeout: 1000,
+          },
+        } as never);
+
+        expect(response).toMatchObject({
+          success: false,
+          payload: { code: errorCode, error: error.message },
+        });
+        expect(acquire).toHaveBeenCalledTimes(1);
+      } finally {
+        await core.dispose();
+      }
+    }
+  );
+
   test('连接失败只返回结构化错误，不直接写入 stdout', async () => {
     const stdout = jest.spyOn(console, 'log').mockImplementation(() => undefined);
     const core = initCore();

--- a/packages/core/__tests__/core-error-output.test.ts
+++ b/packages/core/__tests__/core-error-output.test.ts
@@ -69,6 +69,43 @@ describe('Core 错误输出边界', () => {
     }
   );
 
+  test('desktop BLE still polls after a transient disconnect instead of failing immediately', async () => {
+    jest.spyOn(DataManager, 'getSettings').mockReturnValue('desktop-web-ble' as never);
+    const error = ERRORS.TypedError(HardwareErrorCode.BleDeviceDisconnected);
+    const acquire = jest.fn().mockRejectedValue(error);
+    jest.spyOn(TransportManager, 'getTransport').mockReturnValue({
+      acquire,
+      release: jest.fn().mockResolvedValue(true),
+      stop: jest.fn().mockResolvedValue(undefined),
+    } as never);
+    const core = initCore();
+    initConnector();
+
+    try {
+      const response = await core.handleMessage({
+        id: 1,
+        event: IFRAME.CALL,
+        type: IFRAME.CALL,
+        payload: {
+          method: 'getDeviceState',
+          connectId: 'desktop-ble-disconnect-test',
+          forceProtocolDetection: true,
+          retryCount: 1,
+          pollIntervalTime: 1,
+          timeout: 1000,
+        },
+      } as never);
+
+      expect(response).toMatchObject({
+        success: false,
+        payload: { code: HardwareErrorCode.DeviceNotFound },
+      });
+      expect(acquire.mock.calls.length).toBeGreaterThan(1);
+    } finally {
+      await core.dispose();
+    }
+  });
+
   test('连接失败只返回结构化错误，不直接写入 stdout', async () => {
     const stdout = jest.spyOn(console, 'log').mockImplementation(() => undefined);
     const core = initCore();

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -1296,7 +1296,7 @@ const ensureConnected = async (
             HardwareErrorCode.DeviceInterruptedFromUser,
             HardwareErrorCode.CallQueueActionCancelled,
           ].includes(error.errorCode) ||
-          (DataManager.isBleConnect(env) &&
+          (env === 'react-native' &&
             [HardwareErrorCode.BleDeviceDisconnected, HardwareErrorCode.PollingTimeout].includes(
               error.errorCode
             )) ||

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -1296,6 +1296,10 @@ const ensureConnected = async (
             HardwareErrorCode.DeviceInterruptedFromUser,
             HardwareErrorCode.CallQueueActionCancelled,
           ].includes(error.errorCode) ||
+          (DataManager.isBleConnect(env) &&
+            [HardwareErrorCode.BleDeviceDisconnected, HardwareErrorCode.PollingTimeout].includes(
+              error.errorCode
+            )) ||
           isTerminalBleStaleBondError(error) ||
           isDeviceIdentityMismatchError(error)
         ) {

--- a/packages/hd-transport-react-native/src/__tests__/bleNativeDisconnect.test.ts
+++ b/packages/hd-transport-react-native/src/__tests__/bleNativeDisconnect.test.ts
@@ -1,0 +1,33 @@
+import { HardwareErrorCode } from '@onekeyfe/hd-shared';
+
+import { isNativeBleDisconnectError, toBleDisconnectHardwareError } from '../bleNativeDisconnect';
+
+describe('native BLE disconnect mapping', () => {
+  test.each([
+    [{ errorCode: 201, reason: 'The specified device has disconnected from us.' }],
+    [{ errorCode: 201, iosErrorCode: 7, reason: 'The specified device has disconnected from us.' }],
+    [{ iosErrorCode: 7, reason: 'Peripheral disconnected' }],
+  ])('recognizes %j as a native disconnect', nativeError => {
+    expect(isNativeBleDisconnectError(nativeError)).toBe(true);
+    expect(toBleDisconnectHardwareError(nativeError)).toMatchObject({
+      errorCode: HardwareErrorCode.BleDeviceDisconnected,
+    });
+  });
+
+  test('does not treat a stale-bond iOS code as a disconnect', () => {
+    expect(
+      isNativeBleDisconnectError({
+        iosErrorCode: 14,
+        reason: 'Peer removed pairing information',
+      })
+    ).toBe(false);
+  });
+
+  test('does not treat an already-canonical unpaired error as a native disconnect', () => {
+    expect(
+      isNativeBleDisconnectError({
+        errorCode: HardwareErrorCode.BleDeviceNotBonded,
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/hd-transport-react-native/src/__tests__/protocolV2Link.test.ts
+++ b/packages/hd-transport-react-native/src/__tests__/protocolV2Link.test.ts
@@ -4,7 +4,7 @@ import transportPackage, {
   ProtocolV2,
   TRANSPORT_EVENT,
 } from '@onekeyfe/hd-transport';
-import { HardwareErrorCode, createDeferred } from '@onekeyfe/hd-shared';
+import { ERRORS, HardwareErrorCode, createDeferred } from '@onekeyfe/hd-shared';
 
 import ReactNativeBleTransport, {
   BLE_NATIVE_TEARDOWN_TIMEOUT_MS,
@@ -28,7 +28,7 @@ jest.mock('react-native-ble-plx', () => ({
   BleError: class BleError extends Error {},
   BleErrorCode: {
     DeviceAlreadyConnected: 203,
-    DeviceDisconnected: 205,
+    DeviceDisconnected: 201,
     DeviceMTUChangeFailed: 206,
     OperationCancelled: 2,
     CharacteristicNotFound: 404,
@@ -828,6 +828,76 @@ describe('ReactNativeBleTransport Protocol V2 link lifecycle', () => {
       });
     },
     BLE_NATIVE_TEARDOWN_TIMEOUT_MS + 5_000
+  );
+
+  test('preserves the unpaired error when iOS disconnects during the first V1 probe', async () => {
+    const { transport, uuid, writeCharacteristic } = createHarness({ deviceName: 'Neo Test' });
+    writeCharacteristic.writeWithResponse.mockRejectedValueOnce({
+      errorCode: 201,
+      iosErrorCode: 7,
+      reason: 'The specified device has disconnected from us.',
+    });
+    const probeProtocolV2 = jest.spyOn(transport as any, 'probeProtocolV2');
+
+    await expect(transport.acquire({ uuid })).rejects.toMatchObject({
+      errorCode: HardwareErrorCode.BleDeviceNotBonded,
+    });
+
+    expect(probeProtocolV2).not.toHaveBeenCalled();
+    expect(writeCharacteristic.writeWithResponse).toHaveBeenCalledTimes(1);
+    expect(transport.getProtocolType(uuid)).toBeUndefined();
+  });
+
+  test.each(['V1', 'V2'] as const)(
+    'preserves terminal BLE failures from the %s probe without trying another protocol',
+    async protocol => {
+      for (const errorCode of [
+        HardwareErrorCode.BleDeviceNotBonded,
+        HardwareErrorCode.BleDeviceBondedCanceled,
+        HardwareErrorCode.BlePeerRemovedPairingInformation,
+        HardwareErrorCode.BleDeviceDisconnected,
+        HardwareErrorCode.BleCharacteristicNotifyError,
+        HardwareErrorCode.BleCharacteristicNotifyChangeFailure,
+        HardwareErrorCode.BleWriteCharacteristicError,
+      ]) {
+        const { transport, uuid } = createHarness();
+        const error = ERRORS.TypedError(errorCode);
+        const call = jest
+          .spyOn(transport as any, protocol === 'V1' ? 'callProtocolV1' : 'callProtocolV2')
+          .mockRejectedValue(error);
+        const otherProbe = jest.spyOn(
+          transport as any,
+          protocol === 'V1' ? 'probeProtocolV2' : 'probeProtocolV1'
+        );
+
+        await expect(transport.acquire({ uuid, protocolHint: protocol })).rejects.toBe(error);
+
+        expect(call).toHaveBeenCalledTimes(1);
+        expect(otherProbe).not.toHaveBeenCalled();
+        expect(transport.getProtocolType(uuid)).toBeUndefined();
+      }
+    }
+  );
+
+  test.each(['V1', 'V2'] as const)(
+    'still falls back after a silent %s probe timeout',
+    async protocol => {
+      const { transport, uuid } = createHarness();
+      jest
+        .spyOn(transport as any, protocol === 'V1' ? 'callProtocolV1' : 'callProtocolV2')
+        .mockRejectedValue(ERRORS.TypedError(HardwareErrorCode.BleTimeoutError));
+      const otherProbe = jest
+        .spyOn(transport as any, protocol === 'V1' ? 'probeProtocolV2' : 'probeProtocolV1')
+        .mockResolvedValue(true);
+
+      await expect(transport.acquire({ uuid, protocolHint: protocol })).resolves.toEqual({
+        uuid,
+        protocolType: protocol === 'V1' ? 'V2' : 'V1',
+      });
+
+      expect(otherProbe).toHaveBeenCalledTimes(1);
+      await transport.release(uuid, true);
+    }
   );
 
   test('falls back to the other active probe on iOS when protocol metadata is absent', async () => {

--- a/packages/hd-transport-react-native/src/__tests__/protocolV2Link.test.ts
+++ b/packages/hd-transport-react-native/src/__tests__/protocolV2Link.test.ts
@@ -848,6 +848,46 @@ describe('ReactNativeBleTransport Protocol V2 link lifecycle', () => {
     expect(transport.getProtocolType(uuid)).toBeUndefined();
   });
 
+  test('preserves a native iOS disconnect during an expected Protocol V2 probe', async () => {
+    const { transport, uuid, writeCharacteristic, bleManager } = createHarness({
+      deviceName: 'Neo Test',
+    });
+    const nativeDisconnect = {
+      errorCode: 201,
+      iosErrorCode: 7,
+      reason: 'The specified device has disconnected from us.',
+    };
+    writeCharacteristic.writeWithoutResponse.mockRejectedValueOnce(nativeDisconnect);
+    const probeProtocolV1 = jest.spyOn(transport as any, 'probeProtocolV1');
+
+    await expect(transport.acquire({ uuid, expectedProtocol: 'V2' })).rejects.toMatchObject({
+      errorCode: HardwareErrorCode.BleDeviceDisconnected,
+    });
+
+    expect(probeProtocolV1).not.toHaveBeenCalled();
+    expect(writeCharacteristic.writeWithoutResponse).toHaveBeenCalledTimes(1);
+    expect(bleManager.cancelDeviceConnection).toHaveBeenCalledWith(uuid);
+    expect(transport.getProtocolType(uuid)).toBeUndefined();
+  });
+
+  test('preserves a native iOS disconnect during a V2-first probe without falling back to V1', async () => {
+    const { transport, uuid, writeCharacteristic } = createHarness({ deviceName: 'Neo Test' });
+    writeCharacteristic.writeWithoutResponse.mockRejectedValueOnce({
+      errorCode: 201,
+      iosErrorCode: 7,
+      reason: 'The specified device has disconnected from us.',
+    });
+    const probeProtocolV1 = jest.spyOn(transport as any, 'probeProtocolV1');
+
+    await expect(transport.acquire({ uuid, protocolHint: 'V2' })).rejects.toMatchObject({
+      errorCode: HardwareErrorCode.BleDeviceDisconnected,
+    });
+
+    expect(probeProtocolV1).not.toHaveBeenCalled();
+    expect(writeCharacteristic.writeWithoutResponse).toHaveBeenCalledTimes(1);
+    expect(transport.getProtocolType(uuid)).toBeUndefined();
+  });
+
   test.each(['V1', 'V2'] as const)(
     'preserves terminal BLE failures from the %s probe without trying another protocol',
     async protocol => {

--- a/packages/hd-transport-react-native/src/bleNativeDisconnect.ts
+++ b/packages/hd-transport-react-native/src/bleNativeDisconnect.ts
@@ -1,0 +1,40 @@
+import { ERRORS, HardwareErrorCode } from '@onekeyfe/hd-shared';
+
+const BLE_PLX_DEVICE_DISCONNECTED = 201;
+const IOS_PERIPHERAL_DISCONNECTED = 7;
+
+type NativeBleErrorFields = {
+  errorCode?: unknown;
+  iosErrorCode?: unknown;
+  reason?: unknown;
+  message?: unknown;
+};
+
+const nativeErrorText = (error: NativeBleErrorFields) =>
+  [error.reason, error.message]
+    .filter((value): value is string => typeof value === 'string')
+    .join(' ');
+
+export const isNativeBleDisconnectError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const nativeError = error as NativeBleErrorFields;
+  return (
+    nativeError.errorCode === BLE_PLX_DEVICE_DISCONNECTED ||
+    nativeError.iosErrorCode === IOS_PERIPHERAL_DISCONNECTED
+  );
+};
+
+export const toBleDisconnectHardwareError = (error: unknown) => {
+  if ((error as { errorCode?: unknown })?.errorCode === HardwareErrorCode.BleDeviceDisconnected) {
+    return error as Error;
+  }
+
+  const nativeError = (error ?? {}) as NativeBleErrorFields;
+  return ERRORS.TypedError(
+    HardwareErrorCode.BleDeviceDisconnected,
+    nativeErrorText(nativeError) || undefined
+  );
+};

--- a/packages/hd-transport-react-native/src/index.ts
+++ b/packages/hd-transport-react-native/src/index.ts
@@ -168,6 +168,20 @@ const isWedgedWriteError = (error: unknown): boolean =>
   (error as { errorCode?: unknown })?.errorCode === HardwareErrorCode.BleWriteCharacteristicError &&
   typeof (error as { message?: unknown })?.message === 'string' &&
   (error as { message: string }).message.startsWith(WEDGED_WRITE_MESSAGE);
+const shouldRethrowProtocolProbeError = (error: unknown): boolean => {
+  const code = (error as { errorCode?: unknown })?.errorCode;
+  // Bonding and GATT failures are not evidence of a protocol mismatch. Preserve
+  // them instead of probing another protocol on an unusable connection.
+  return (
+    isBleStaleBondHardwareError(error) ||
+    code === HardwareErrorCode.BleDeviceNotBonded ||
+    code === HardwareErrorCode.BleDeviceBondedCanceled ||
+    code === HardwareErrorCode.BleDeviceDisconnected ||
+    code === HardwareErrorCode.BleCharacteristicNotifyError ||
+    code === HardwareErrorCode.BleCharacteristicNotifyChangeFailure ||
+    code === HardwareErrorCode.BleWriteCharacteristicError
+  );
+};
 /** Consecutive wedged writes on one device before the BLE manager itself is recreated. */
 export const BLE_WRITE_TIMEOUT_MANAGER_RESET_THRESHOLD = 2;
 const DEVICE_SCAN_TIMEOUT_MS = 3000;
@@ -2339,9 +2353,7 @@ export default class ReactNativeBleTransport {
     } catch (error) {
       this.clearProbeProtocol(uuid, 'V1');
       Log?.debug('[ReactNativeBleTransport] Protocol V1 GetFeatures probe failed:', error);
-      // A wedged write already dropped the link, so probing another protocol on it
-      // would only fail against a torn-down transport: surface the real cause.
-      if (isWedgedWriteError(error)) {
+      if (shouldRethrowProtocolProbeError(error)) {
         throw error;
       }
       return false;
@@ -2366,7 +2378,7 @@ export default class ReactNativeBleTransport {
         this.protocolV2Assemblers.get(uuid)?.reset();
         this.resetProtocolV2Frames(uuid);
       },
-      shouldRethrow: isBleStaleBondHardwareError,
+      shouldRethrow: shouldRethrowProtocolProbeError,
     });
     if (!detected) {
       this.clearProbeProtocol(uuid, 'V2');

--- a/packages/hd-transport-react-native/src/index.ts
+++ b/packages/hd-transport-react-native/src/index.ts
@@ -47,6 +47,7 @@ import {
   getInfosForServiceUuid,
   isSameBleUuid,
 } from './constants';
+import { isNativeBleDisconnectError, toBleDisconnectHardwareError } from './bleNativeDisconnect';
 import {
   isBleStaleBondHardwareError,
   isNativeBleStaleBondError,
@@ -172,8 +173,11 @@ const shouldRethrowProtocolProbeError = (error: unknown): boolean => {
   const code = (error as { errorCode?: unknown })?.errorCode;
   // Bonding and GATT failures are not evidence of a protocol mismatch. Preserve
   // them instead of probing another protocol on an unusable connection.
+  // Native PLX disconnects (errorCode 201 / iOS 7) must match before they are
+  // mapped: Protocol V2 writes rethrow them unchanged unless normalized first.
   return (
     isBleStaleBondHardwareError(error) ||
+    isNativeBleDisconnectError(error) ||
     code === HardwareErrorCode.BleDeviceNotBonded ||
     code === HardwareErrorCode.BleDeviceBondedCanceled ||
     code === HardwareErrorCode.BleDeviceDisconnected ||
@@ -1184,7 +1188,7 @@ export default class ReactNativeBleTransport {
       this.attachDisconnectSubscription(currentTransport, currentTransport.device, uuid);
       return { uuid, protocolType };
     } catch (error) {
-      if (isBleStaleBondHardwareError(error)) {
+      if (isBleStaleBondHardwareError(error) || shouldRethrowProtocolProbeError(error)) {
         await this.disconnectUnlocked(uuid);
       } else {
         await this.releaseUnlocked(uuid, true);
@@ -2524,6 +2528,9 @@ export default class ReactNativeBleTransport {
           const bondError = toBleStaleBondHardwareError(error);
           this.rememberStaleBondError(uuid, bondError);
           throw bondError;
+        }
+        if (isNativeBleDisconnectError(error)) {
+          throw toBleDisconnectHardwareError(error);
         }
         if (
           getFirmwareUploadWriteRetryType(error) !== 'congested' ||


### PR DESCRIPTION
## Summary

- Preserve terminal BLE bonding, notification, and write errors during Protocol V1/V2 detection instead of treating them as protocol mismatches.
- Preserve BLE disconnect and terminal polling errors in Core instead of retrying and replacing them with `DeviceNotFound`.
- Add regression coverage for the reported iOS disconnect-to-unpaired path, early termination, silent-probe timeout fallback, and public error responses.

## Jira

[OK-62220: Pro2 BLE pairing failure is shown as device not connected](https://onekeyhq.atlassian.net/browse/OK-62220)

## Scope

- React Native BLE protocol probing and Core BLE connection error propagation only.
- Keep existing error codes and normal V1/V2 fallback behavior. This does not classify an ordinary disconnect as an explicit user rejection: the reported iOS error confirms a disconnect, not a distinct pairing-rejected signal.
- No App or Settings-navigation changes, SDK version bump, or npm publication.

## Validation

- [x] `yarn agent:check --profile commit`: changed-file lint and both affected-package builds passed; Core: 1,291 passed / 4 skipped; RN BLE: 123 passed.
- [ ] Physical iOS regression: reject pairing on the device and confirm the App displays the preserved connection/pairing error without the extra probe/retry chain.
- [ ] Physical iOS regression: accept pairing and retry after a rejection; verify normal Pro2/Neo and Protocol V1 connections.

Keep this PR in draft until the updated SDK is integrated into the App and physical-device validation is complete.
